### PR TITLE
Add wrappers around MUI components

### DIFF
--- a/src/app/components/AppBox/AppBox.tsx
+++ b/src/app/components/AppBox/AppBox.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react'
+import Box from '@mui/material/Box'
+import { BoxTypeMap } from '@mui/material/Box/Box'
+
+export const AppBox = <P extends {}, D extends React.ElementType = 'div'>(props: BoxTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Box {...props} />
+  )
+}

--- a/src/app/components/AppCard/AppCard.tsx
+++ b/src/app/components/AppCard/AppCard.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react'
+import Card from '@mui/material/Card'
+import { CardTypeMap } from '@mui/material/Card/Card'
+
+export const AppCard = <P extends {}, D extends React.ElementType = 'div'>(props: CardTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Card {...props} />
+  )
+}

--- a/src/app/components/AppCardContent/AppCardContent.tsx
+++ b/src/app/components/AppCardContent/AppCardContent.tsx
@@ -1,0 +1,10 @@
+import { ReactElement } from 'react'
+import CardContent from '@mui/material/CardContent'
+import * as React from 'react'
+import { CardContentTypeMap } from '@mui/material/CardContent/CardContent'
+
+export const AppCardContent = <P extends {}, D extends React.ElementType = 'div'>(props: CardContentTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <CardContent {...props} />
+  )
+}

--- a/src/app/components/AppCardHeader/AppCardHeader.tsx
+++ b/src/app/components/AppCardHeader/AppCardHeader.tsx
@@ -1,0 +1,12 @@
+import { ReactElement } from 'react'
+import CardHeader from '@mui/material/CardHeader'
+import { CardHeaderTypeMap } from '@mui/material/CardHeader/CardHeader'
+
+export const AppCardHeader = <Props extends {},
+  DefaultComponent extends React.ElementType = 'div',
+  TitleTypographyComponent extends React.ElementType = 'span',
+  SubheaderTypographyComponent extends React.ElementType = 'span'>(props: CardHeaderTypeMap<Props, DefaultComponent, TitleTypographyComponent, SubheaderTypographyComponent>['props']): ReactElement => {
+  return (
+    <CardHeader {...props} />
+  )
+}

--- a/src/app/components/AppDivider/AppDivider.tsx
+++ b/src/app/components/AppDivider/AppDivider.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react'
+import Divider from '@mui/material/Divider'
+import { DividerTypeMap } from '@mui/material/Divider/Divider'
+
+export const AppDivider = <P extends {}, D extends React.ElementType = 'hr'>(props: DividerTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Divider {...props} />
+  )
+}

--- a/src/app/components/AppGrid/AppGrid.tsx
+++ b/src/app/components/AppGrid/AppGrid.tsx
@@ -1,0 +1,9 @@
+import Grid from '@mui/material/Grid'
+import { GridTypeMap } from '@mui/material/Grid/Grid'
+import { ReactElement } from 'react'
+
+export const AppGrid = <P extends {}, D extends React.ElementType = 'div'>(props: GridTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Grid {...props} />
+  )
+}

--- a/src/app/components/AppGrid2/AppGrid2.tsx
+++ b/src/app/components/AppGrid2/AppGrid2.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react'
+import { Unstable_Grid2 } from '@mui/material'
+import { Grid2TypeMap } from '@mui/material/Unstable_Grid2/Grid2Props'
+
+export const AppGrid2 = <P extends {}, D extends React.ElementType = 'div'>(props: Grid2TypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Unstable_Grid2 {...props} />
+  )
+}

--- a/src/app/components/AppLink/AppLink.tsx
+++ b/src/app/components/AppLink/AppLink.tsx
@@ -1,0 +1,8 @@
+import Link, { LinkTypeMap } from '@mui/material/Link'
+import { ReactElement } from 'react'
+
+export const AppLink = <P extends {}, D extends React.ElementType = 'a'>(props: LinkTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Link {...props} />
+  )
+}

--- a/src/app/components/AppPaper/AppPaper.tsx
+++ b/src/app/components/AppPaper/AppPaper.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react'
+import Paper from '@mui/material/Paper'
+import { PaperTypeMap } from '@mui/material/Paper/Paper'
+
+export const AppPaper = <P extends {}, D extends React.ElementType = 'div'>(props: PaperTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Paper {...props} />
+  )
+}

--- a/src/app/components/AppTypography/AppTypography.tsx
+++ b/src/app/components/AppTypography/AppTypography.tsx
@@ -1,0 +1,9 @@
+import Typography from '@mui/material/Typography'
+import { TypographyTypeMap } from '@mui/material/Typography/Typography'
+import { ReactElement } from 'react'
+
+export const AppTypography = <P extends {}, D extends React.ElementType = 'span'>(props: TypographyTypeMap<P, D>['props']): ReactElement => {
+  return (
+    <Typography {...props} />
+  )
+}

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -1,13 +1,13 @@
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
+import { AppTypography } from '../AppTypography/AppTypography'
+import { AppBox } from '../AppBox/AppBox'
 
 export function Footer() {
   return (
     <footer>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 6 }}>
-        <Typography variant="footer">Version: {process.env.REACT_APP_BUILD_SHA}</Typography>
-        <Typography variant="footer">Oasis Protocol Foundation | 2022</Typography>
-      </Box>
+      <AppBox sx={{ display: 'flex', justifyContent: 'space-between', p: 6 }}>
+        <AppTypography variant="footer">Version: {process.env.REACT_APP_BUILD_SHA}</AppTypography>
+        <AppTypography variant="footer">Oasis Protocol Foundation | 2022</AppTypography>
+      </AppBox>
     </footer>
   )
 }

--- a/src/app/components/PageLayout/Header.tsx
+++ b/src/app/components/PageLayout/Header.tsx
@@ -1,19 +1,19 @@
-import Grid from '@mui/material/Unstable_Grid2'
 import { Logotype } from './Logotype'
 import { NetworkHeader } from './NetworkHeader'
+import { AppGrid2 } from '../AppGrid2/AppGrid2'
 
 export function Header() {
   return (
     <header>
-      <Grid container sx={{ px: 6, pb: 5 }}>
-        <Grid xs={12} sx={{ pb: '50px' }}>
+      <AppGrid2 container sx={{ px: 6, pb: 5 }}>
+        <AppGrid2 xs={12} sx={{ pb: '50px' }}>
           <Logotype />
-        </Grid>
-        <Grid xs={4}>
+        </AppGrid2>
+        <AppGrid2 xs={4}>
           <NetworkHeader />
-        </Grid>
-        <Grid xs={8}>{/* Search Placeholder */}</Grid>
-      </Grid>
+        </AppGrid2>
+        <AppGrid2 xs={8}>{/* Search Placeholder */}</AppGrid2>
+      </AppGrid2>
     </header>
   )
 }

--- a/src/app/components/PageLayout/Logotype.tsx
+++ b/src/app/components/PageLayout/Logotype.tsx
@@ -1,11 +1,11 @@
-import Typography from '@mui/material/Typography'
-import Link from '@mui/material/Link'
 import { Link as RouterLink } from 'react-router-dom'
 import logotype from './images/logo.svg'
+import { AppTypography } from '../AppTypography/AppTypography'
+import { AppLink } from '../AppLink/AppLink'
 
 export function Logotype() {
   return (
-    <Link
+    <AppLink
       to="/"
       component={RouterLink}
       sx={{
@@ -16,7 +16,7 @@ export function Logotype() {
       }}
     >
       <img src={logotype} alt="logo" height={40} width={40} />
-      <Typography variant="h1">Oasis Blockchain Explorer</Typography>
-    </Link>
+      <AppTypography variant="h1">Oasis Blockchain Explorer</AppTypography>
+    </AppLink>
   )
 }

--- a/src/app/components/PageLayout/NetworkHeader.tsx
+++ b/src/app/components/PageLayout/NetworkHeader.tsx
@@ -1,12 +1,12 @@
 import { useLocation } from 'react-router-dom'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import blockchainImage from './images/blockchain.svg'
 import { emeraldRoute } from '../../../routes'
+import { AppTypography } from '../AppTypography/AppTypography'
+import { AppBox } from '../AppBox/AppBox'
 
-const StyledCircle = styled(Box)(({ theme }) => ({
+const StyledCircle = styled(AppBox)(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
@@ -29,38 +29,38 @@ export function NetworkHeader() {
   const label = getLabel(pathname)
 
   return (
-    <Box sx={{ display: 'flex' }}>
+    <AppBox sx={{ display: 'flex' }}>
       <StyledCircle>
         <img src={blockchainImage} alt={label} />
       </StyledCircle>
-      <Box>
-        <Box
+      <AppBox>
+        <AppBox
           sx={{
             display: 'flex',
             alignItems: 'center',
           }}
         >
-          <Typography variant="h2" sx={{ pr: 4 }}>
+          <AppTypography variant="h2" sx={{ pr: 4 }}>
             {label}
-          </Typography>
+          </AppTypography>
 
-          <Box
+          <AppBox
             sx={{
               display: 'flex',
               alignItems: 'center',
             }}
           >
-            <Typography sx={{ fontSize: 10, color: '#8f8cdf', mr: 3 }} component="span">
+            <AppTypography sx={{ fontSize: 10, color: '#8f8cdf', mr: 3 }} component="span">
               ParaTime Online
-            </Typography>
+            </AppTypography>
             <CheckCircleIcon color="success" sx={{ fontSize: 16 }} />
-          </Box>
-        </Box>
-        <Typography sx={{ fontSize: 11, color: '#fff' }}>
+          </AppBox>
+        </AppBox>
+        <AppTypography sx={{ fontSize: 11, color: '#fff' }}>
           The official confidential EVM Compatible ParaTime providing a smart contract development
           environment.
-        </Typography>
-      </Box>
-    </Box>
+        </AppTypography>
+      </AppBox>
+    </AppBox>
   )
 }

--- a/src/app/components/PageLayout/index.tsx
+++ b/src/app/components/PageLayout/index.tsx
@@ -1,14 +1,14 @@
 import { ReactNode } from 'react'
 import { Header } from './Header'
 import { Footer } from './Footer'
-import Box from '@mui/material/Box'
+import { AppBox } from '../AppBox/AppBox'
 
 export function PageLayout({ children }: { children: ReactNode }) {
   return (
-    <Box sx={{ pt: 5, px: '5%' }}>
+    <AppBox sx={{ pt: 5, px: '5%' }}>
       <Header />
       <main>{children}</main>
       <Footer />
-    </Box>
+    </AppBox>
   )
 }

--- a/src/app/pages/DashboardPage/AverageTransactionSize.tsx
+++ b/src/app/pages/DashboardPage/AverageTransactionSize.tsx
@@ -1,12 +1,12 @@
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
-import CardContent from '@mui/material/CardContent'
+import { AppCard } from '../../components/AppCard/AppCard'
+import { AppCardHeader } from '../../components/AppCardHeader/AppCardHeader'
+import { AppCardContent } from '../../components/AppCardContent/AppCardContent'
 
 export function AverageTransactionSize() {
   return (
-    <Card>
-      <CardHeader disableTypography component="h3" title="Average Transaction Size" />
-      <CardContent></CardContent>
-    </Card>
+    <AppCard>
+      <AppCardHeader disableTypography component="h3" title="Average Transaction Size" />
+      <AppCardContent></AppCardContent>
+    </AppCard>
   )
 }

--- a/src/app/pages/DashboardPage/LatestBlocks.tsx
+++ b/src/app/pages/DashboardPage/LatestBlocks.tsx
@@ -1,12 +1,12 @@
 import { Link as RouterLink } from 'react-router-dom'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
-import CardContent from '@mui/material/CardContent'
-import Link from '@mui/material/Link'
 import { Table, TableCellAlign } from '../../components/Table'
 import { VerticalProgressBar } from '../../components/ProgressBar'
 import { useGetEmeraldBlocks } from '../../../oasis-indexer/api'
+import { AppCard } from '../../components/AppCard/AppCard'
+import { AppCardHeader } from '../../components/AppCardHeader/AppCardHeader'
+import { AppLink } from '../../components/AppLink/AppLink'
+import { AppCardContent } from '../../components/AppCardContent/AppCardContent'
 
 const gasLimit = 1000000 // temporary value
 
@@ -22,9 +22,9 @@ export function LatestBlocks() {
       {
         align: TableCellAlign.Right,
         content: (
-          <Link component={RouterLink} to="blocks">
+          <AppLink component={RouterLink} to="blocks">
             {block.round}
-          </Link>
+          </AppLink>
         ),
         key: 'block',
       },
@@ -49,18 +49,18 @@ export function LatestBlocks() {
   }))
 
   return (
-    <Card>
-      <CardHeader
+    <AppCard>
+      <AppCardHeader
         disableTypography
         component="h3"
         title="Latest Blocks"
         action={
-          <Link component={RouterLink} to="blocks">
+          <AppLink component={RouterLink} to="blocks">
             View all
-          </Link>
+          </AppLink>
         }
       />
-      <CardContent>
+      <AppCardContent>
         <Table
           columns={[
             { content: 'Fill' },
@@ -73,7 +73,7 @@ export function LatestBlocks() {
           name="Latest Blocks"
           isLoading={blocksQuery.isLoading}
         />
-      </CardContent>
-    </Card>
+      </AppCardContent>
+    </AppCard>
   )
 }

--- a/src/app/pages/DashboardPage/LatestTransactions.tsx
+++ b/src/app/pages/DashboardPage/LatestTransactions.tsx
@@ -1,12 +1,12 @@
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
-import CardContent from '@mui/material/CardContent'
+import { AppCard } from '../../components/AppCard/AppCard'
+import { AppCardHeader } from '../../components/AppCardHeader/AppCardHeader'
+import { AppCardContent } from '../../components/AppCardContent/AppCardContent'
 
 export function LatestTransactions() {
   return (
-    <Card>
-      <CardHeader disableTypography component="h3" title="Latest Transactions" />
-      <CardContent></CardContent>
-    </Card>
+    <AppCard>
+      <AppCardHeader disableTypography component="h3" title="Latest Transactions" />
+      <AppCardContent></AppCardContent>
+    </AppCard>
   )
 }

--- a/src/app/pages/DashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/DashboardPage/LearningMaterials.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react'
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
-import CardContent from '@mui/material/CardContent'
-import Grid from '@mui/material/Unstable_Grid2'
-import Link from '@mui/material/Link'
-import Paper, { type PaperProps } from '@mui/material/Paper'
+import { type PaperProps } from '@mui/material/Paper'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
+import { AppLink } from '../../components/AppLink/AppLink'
+import { AppTypography } from '../../components/AppTypography/AppTypography'
+import { AppCard } from '../../components/AppCard/AppCard'
+import { AppCardHeader } from '../../components/AppCardHeader/AppCardHeader'
+import { AppCardContent } from '../../components/AppCardContent/AppCardContent'
+import { AppPaper } from '../../components/AppPaper/AppPaper'
+import { AppGrid2 } from '../../components/AppGrid2/AppGrid2'
 
 const docsUrl = 'https://docs.oasis.io/'
 const docsPages = {
@@ -16,7 +17,7 @@ const docsPages = {
   transfer: 'general/manage-tokens/how-to-transfer-rose-into-paratime',
 }
 const getDocsLink = (document: keyof typeof docsPages) => `${docsUrl}${docsPages[document]}`
-const StyledLink = styled(Link)(() => ({
+const StyledLink = styled(AppLink)(() => ({
   width: '44px',
   height: '44px',
   borderRadius: '50%',
@@ -40,59 +41,59 @@ type LearningSectionProps = PaperProps & {
 
 const LearningSection: FC<LearningSectionProps> = ({ description, title, url, ...props }) => {
   return (
-    <Paper variant="content" {...props}>
-      <Typography variant="h4">{title}</Typography>
-      <Typography variant="body2">{description}</Typography>
+    <AppPaper variant="content" {...props}>
+      <AppTypography variant="h4">{title}</AppTypography>
+      <AppTypography variant="body2">{description}</AppTypography>
       <StyledLink href={url} rel="noopener noreferrer" target="_blank">
         <ArrowForwardIcon />
       </StyledLink>
-    </Paper>
+    </AppPaper>
   )
 }
 
 export function LearningMaterials() {
   return (
-    <Card>
-      <CardHeader
+    <AppCard>
+      <AppCardHeader
         disableTypography
         component="h3"
         title="Learning materials"
         action={
-          <Link href={docsUrl} rel="noopener noreferrer" target="_blank">
+          <AppLink href={docsUrl} rel="noopener noreferrer" target="_blank">
             Access Learning Center
-          </Link>
+          </AppLink>
         }
       />
-      <CardContent>
-        <Grid container spacing={3}>
-          <Grid xs={12} md={6}>
+      <AppCardContent>
+        <AppGrid2 container spacing={3}>
+          <AppGrid2 xs={12} md={6}>
             <LearningSection
               description="The Emerald ParaTime is our official EVM Compatible ParaTime providing smart contract environment with full EVM compatibility."
               title="What is the Emerald network?"
               url={getDocsLink('emerald')}
               sx={{ height: '100%' }}
             />
-          </Grid>
-          <Grid xs={12} md={6}>
-            <Grid container spacing={3}>
-              <Grid>
+          </AppGrid2>
+          <AppGrid2 xs={12} md={6}>
+            <AppGrid2 container spacing={3}>
+              <AppGrid2>
                 <LearningSection
                   description="Rose is the currency powering the Emerald network."
                   title="What is the ROSE token?"
                   url={getDocsLink('token')}
                 />
-              </Grid>
-              <Grid>
+              </AppGrid2>
+              <AppGrid2>
                 <LearningSection
                   description="Rose is the currency powering the Emerald network."
                   title="How to Transfer ROSE into a ParaTime"
                   url={getDocsLink('transfer')}
                 />
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
+              </AppGrid2>
+            </AppGrid2>
+          </AppGrid2>
+        </AppGrid2>
+      </AppCardContent>
+    </AppCard>
   )
 }

--- a/src/app/pages/DashboardPage/Social.tsx
+++ b/src/app/pages/DashboardPage/Social.tsx
@@ -1,14 +1,14 @@
 import { FC } from 'react'
-import Box from '@mui/material/Box'
-import Grid from '@mui/material/Unstable_Grid2'
-import Link from '@mui/material/Link'
-import Typography from '@mui/material/Typography'
 import social from './images/social.png'
 import telegram from './images/telegram.svg'
 import twitter from './images/twitter.svg'
 import discord from './images/discord.svg'
 import youtube from './images/youtube.svg'
 import reddit from './images/reddit.svg'
+import { AppLink } from '../../components/AppLink/AppLink'
+import { AppBox } from '../../components/AppBox/AppBox'
+import { AppTypography } from '../../components/AppTypography/AppTypography'
+import { AppGrid2 } from '../../components/AppGrid2/AppGrid2'
 
 type SocialLinkProps = {
   label: string
@@ -18,7 +18,7 @@ type SocialLinkProps = {
 
 const SocialLink: FC<SocialLinkProps> = ({ label, href, img }) => {
   return (
-    <Link
+    <AppLink
       href={href}
       color="#fff"
       underline="none"
@@ -28,13 +28,13 @@ const SocialLink: FC<SocialLinkProps> = ({ label, href, img }) => {
     >
       <img src={img} alt={label} height={40} />
       {label}
-    </Link>
+    </AppLink>
   )
 }
 
 export function Social() {
   return (
-    <Grid
+    <AppGrid2
       container
       sx={{
         px: 6,
@@ -45,16 +45,16 @@ export function Social() {
         backgroundSize: 'cover',
       }}
     >
-      <Grid xs={12} md={4}>
-        <Typography sx={{ fontSize: 18, fontWeight: 600, mb: 3 }} color="#fff">
+      <AppGrid2 xs={12} md={4}>
+        <AppTypography sx={{ fontSize: 18, fontWeight: 600, mb: 3 }} color="#fff">
           Join us
-        </Typography>
-        <Typography color="#fff" sx={{ maxWidth: 230 }}>
+        </AppTypography>
+        <AppTypography color="#fff" sx={{ maxWidth: 230 }}>
           Be part of the community and stay in the loop on everything Oasis
-        </Typography>
-      </Grid>
-      <Grid xs={12} md={8}>
-        <Box
+        </AppTypography>
+      </AppGrid2>
+      <AppGrid2 xs={12} md={8}>
+        <AppBox
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -72,8 +72,8 @@ export function Social() {
             img={youtube}
           />
           <SocialLink label="Reddit" href="https://www.reddit.com/r/oasisnetwork/" img={reddit} />
-        </Box>
-      </Grid>
-    </Grid>
+        </AppBox>
+      </AppGrid2>
+    </AppGrid2>
   )
 }

--- a/src/app/pages/DashboardPage/TransactionsPerSecond.tsx
+++ b/src/app/pages/DashboardPage/TransactionsPerSecond.tsx
@@ -1,12 +1,12 @@
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
-import CardContent from '@mui/material/CardContent'
+import { AppCard } from '../../components/AppCard/AppCard'
+import { AppCardHeader } from '../../components/AppCardHeader/AppCardHeader'
+import { AppCardContent } from '../../components/AppCardContent/AppCardContent'
 
 export function TransactionsPerSecond() {
   return (
-    <Card>
-      <CardHeader disableTypography component="h3" title="Transactions Per Second" />
-      <CardContent></CardContent>
-    </Card>
+    <AppCard>
+      <AppCardHeader disableTypography component="h3" title="Transactions Per Second" />
+      <AppCardContent></AppCardContent>
+    </AppCard>
   )
 }

--- a/src/app/pages/DashboardPage/index.tsx
+++ b/src/app/pages/DashboardPage/index.tsx
@@ -1,5 +1,3 @@
-import Divider from '@mui/material/Divider'
-import Grid from '@mui/material/Grid'
 import { Social } from './Social'
 import { LearningMaterials } from './LearningMaterials'
 import { LatestBlocks } from './LatestBlocks'
@@ -7,20 +5,22 @@ import { LatestTransactions } from './LatestTransactions'
 import { TransactionsPerSecond } from './TransactionsPerSecond'
 import { AverageTransactionSize } from './AverageTransactionSize'
 import { PageLayout } from '../../components/PageLayout'
+import { AppDivider } from '../../components/AppDivider/AppDivider'
+import { AppGrid } from '../../components/AppGrid/AppGrid'
 
 export function DashboardPage() {
   return (
     <PageLayout>
-      <Divider variant="layout" />
+      <AppDivider variant="layout" />
       <LatestTransactions />
-      <Grid container spacing={4}>
-        <Grid item xs={12} md={6}>
+      <AppGrid container spacing={4}>
+        <AppGrid item xs={12} md={6}>
           <LearningMaterials />
-        </Grid>
-        <Grid item xs={12} md={6}>
+        </AppGrid>
+        <AppGrid item xs={12} md={6}>
           <LatestBlocks />
-        </Grid>
-      </Grid>
+        </AppGrid>
+      </AppGrid>
       <TransactionsPerSecond />
       <AverageTransactionSize />
       <Social />


### PR DESCRIPTION
Idea around wrapping the MUI components is to generalize usage. More consistency for components that are essentially the same. Easier to change core components, if we need some styling changes applied globally, that is not possible to do via `createTheme`.

Banned imports can be added later.