### PR TITLE
Dashboard: update labels in latest transactions

### DIFF
--- a/src/app/components/RuntimeTransactionLabel/index.tsx
+++ b/src/app/components/RuntimeTransactionLabel/index.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { TFunction } from 'i18next'
+
+enum RuntimeTransactionMethod {
+  Call = 'evm.Call',
+  Create = 'evm.Create',
+  Deposit = 'consensusaccounts.Deposit',
+  Withdraw = 'consensusaccounts.Withdraw',
+}
+
+const getRuntimeTransactionLabel = (t: TFunction, method: string) => {
+  switch (method) {
+    case RuntimeTransactionMethod.Call:
+      return t('transactions.method.evm.call')
+    case RuntimeTransactionMethod.Create:
+      return t('transactions.method.evm.create')
+    case RuntimeTransactionMethod.Deposit:
+    case RuntimeTransactionMethod.Withdraw:
+      return t('transactions.method.consensusaccounts.transaction')
+    default:
+      return ''
+  }
+}
+
+type RuntimeTransactionLabelProps = {
+  method: string // RuntimeTransaction method type is not yet defined in API
+}
+
+export const RuntimeTransactionLabel: FC<RuntimeTransactionLabelProps> = ({ method }) => {
+  const { t } = useTranslation()
+
+  return <>{getRuntimeTransactionLabel(t, method)}</>
+}

--- a/src/app/pages/DashboardPage/LatestTransactions.tsx
+++ b/src/app/pages/DashboardPage/LatestTransactions.tsx
@@ -9,6 +9,7 @@ import { Table, TableCellAlign } from '../../components/Table'
 import { TransactionStatusIcon } from '../../components/TransactionStatusIcon'
 import { trimLongString } from '../../utils/trimLongString'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
+import { RuntimeTransactionLabel } from '../../components/RuntimeTransactionLabel'
 
 export const LatestTransactions: FC = () => {
   const { t } = useTranslation()
@@ -53,7 +54,7 @@ export const LatestTransactions: FC = () => {
         key: 'age',
       },
       {
-        content: transaction.method,
+        content: <RuntimeTransactionLabel method={transaction.method!} />,
         key: 'type',
       },
       {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -62,7 +62,16 @@
   },
   "transactions": {
     "header": "Transactions",
-    "latest": "Latest Transactions"
+    "latest": "Latest Transactions",
+    "method": {
+      "consensusaccounts": {
+        "transaction": "Transaction"
+      },
+      "evm": {
+        "call": "Contract Call",
+        "create": "Contract Creation"
+      }
+    }
   },
   "transactionStats": {
     "header": "Transactions Per Day",


### PR DESCRIPTION
RuntimeTransactionMethod will be replaced by auto generated types, but they are not defined on BE yet.
RuntimeTransactionLabel needs to be a component to access translation hooks (I will add i18next today)