### PR TITLE
Transactions List Page

### DIFF
--- a/src/app/components/Pagination/index.tsx
+++ b/src/app/components/Pagination/index.tsx
@@ -1,0 +1,100 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import usePagination, { type UsePaginationProps } from '@mui/material/usePagination'
+import { styled } from '@mui/material/styles'
+import NavigateNextIcon from '@mui/icons-material/NavigateNext'
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore'
+import { COLORS } from '../../../styles/theme/colors'
+import { useSearchParams } from 'react-router-dom'
+
+const StyledList = styled('ul')(({ theme }) => ({
+  listStyle: 'none',
+  padding: `${theme.spacing(5)} 0 0`,
+  margin: 0,
+  display: 'flex',
+}))
+
+const StyledListElement = styled('li')({
+  padding: 0,
+  margin: 0,
+  display: 'inline-flex',
+})
+
+const StyledButton = styled('button')(({ theme }) => ({
+  display: 'inline-flex',
+  background: 'none',
+  boxShadow: 'none',
+  padding: `0 ${theme.spacing(1)}`,
+  margin: 0,
+  cursor: 'pointer',
+  border: 'none',
+  font: 'inherit',
+  color: COLORS.brandExtraDark,
+  '&:disabled': {
+    color: COLORS.disabledPagination,
+    cursor: 'default',
+  },
+}))
+
+const StyledFirstPageButton = styled(StyledButton)(({ theme }) => ({
+  padding: `0 ${theme.spacing(3)} 0 ${theme.spacing(2)}`,
+}))
+
+const StyledLastPageButton = styled(StyledButton)(({ theme }) => ({
+  padding: `0 ${theme.spacing(2)} 0 ${theme.spacing(3)}`,
+}))
+
+export const Pagination: FC<UsePaginationProps> = ({ count, onChange, page }) => {
+  const { t } = useTranslation()
+  const { items } = usePagination({
+    showFirstButton: true,
+    showLastButton: true,
+    count,
+    page,
+    onChange,
+  })
+  const previousItem = items.find(item => item.type === 'previous')
+  const nextItem = items.find(item => item.type === 'next')
+
+  return (
+    <nav>
+      <StyledList>
+        <StyledListElement>
+          <StyledButton type="button" disabled={previousItem?.disabled} onClick={previousItem?.onClick}>
+            <NavigateBeforeIcon />
+          </StyledButton>
+        </StyledListElement>
+        {items.map(({ page, type, selected, ...item }, index) => {
+          let children = null
+          const pageAfterEndEllipsis = index === items.length - 3
+          if (type === 'page' && !pageAfterEndEllipsis) {
+            children = (
+              <StyledButton type="button" {...item} disabled={selected || item.disabled}>
+                {page}
+              </StyledButton>
+            )
+          } else if (type === 'first') {
+            children = (
+              <StyledFirstPageButton type="button" {...item}>
+                {t('pagination.first')}
+              </StyledFirstPageButton>
+            )
+          } else if (type === 'last') {
+            children = (
+              <StyledLastPageButton type="button" {...item}>
+                {t('pagination.last')}
+              </StyledLastPageButton>
+            )
+          }
+
+          return <StyledListElement key={index}>{children}</StyledListElement>
+        })}
+        <StyledListElement>
+          <StyledButton type="button" disabled={nextItem?.disabled} onClick={nextItem?.onClick}>
+            <NavigateNextIcon />
+          </StyledButton>
+        </StyledListElement>
+      </StyledList>
+    </nav>
+  )
+}

--- a/src/app/components/RuntimeTransactionLabel/index.tsx
+++ b/src/app/components/RuntimeTransactionLabel/index.tsx
@@ -5,8 +5,8 @@ import { TFunction } from 'i18next'
 enum RuntimeTransactionMethod {
   Call = 'evm.Call',
   Create = 'evm.Create',
-  Deposit = 'consensusaccounts.Deposit',
-  Withdraw = 'consensusaccounts.Withdraw',
+  Deposit = 'consensus.Deposit',
+  Withdraw = 'consensus.Withdraw',
 }
 
 const getRuntimeTransactionLabel = (t: TFunction, method: string) => {

--- a/src/app/components/Table/TablePagination.tsx
+++ b/src/app/components/Table/TablePagination.tsx
@@ -10,8 +10,8 @@ type TablePaginationProps = {
 export const TablePagination: FC<TablePaginationProps> = ({ count, rowsNumber }) => {
   const [searchParams, setSearchParams] = useSearchParams()
   const offsetSearchQuery = searchParams.get('offset')
-  const offset = offsetSearchQuery ? parseInt(offsetSearchQuery, 10) : 0
-  const page = offset / rowsNumber + 1
+  const offset = (offsetSearchQuery && parseInt(offsetSearchQuery, 10)) || 0
+  const page = offset ? offset / rowsNumber + 1 : 1
 
   return (
     <Pagination

--- a/src/app/components/Table/TablePagination.tsx
+++ b/src/app/components/Table/TablePagination.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Pagination } from '../Pagination'
+
+type TablePaginationProps = {
+  count: number
+  rowsNumber: number
+}
+
+export const TablePagination: FC<TablePaginationProps> = ({ count, rowsNumber }) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const offsetSearchQuery = searchParams.get('offset')
+  const offset = offsetSearchQuery ? parseInt(offsetSearchQuery, 10) : 0
+  const page = offset / rowsNumber + 1
+
+  return (
+    <Pagination
+      count={count}
+      page={page}
+      onChange={(e, newPage) =>
+        setSearchParams({
+          offset: `${(newPage - 1) * rowsNumber}`,
+        })
+      }
+    />
+  )
+}

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -80,43 +80,47 @@ export const Table: FC<TableProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <TableContainer>
-      <MuiTable aria-label={name}>
-        <TableHead>
-          <TableRow>
-            {columns.map((column, index) => (
-              <TableCell
-                key={column.content}
-                align={column.align}
-                sx={stickyColumn && !index && isMobile ? stickyColumnStyles : undefined}
-              >
-                {column.content}
-              </TableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {!rows && isLoading && <SkeletonTableRows rowsNumber={rowsNumber} columnsNumber={columns.length} />}
-          {rows?.map(row => (
-            <TableRow key={row.key}>
-              {row.data.map((cell, index) => (
+    <>
+      <TableContainer>
+        <MuiTable aria-label={name}>
+          <TableHead>
+            <TableRow>
+              {columns.map((column, index) => (
                 <TableCell
-                  key={cell.key}
-                  align={cell.align}
+                  key={column.content}
+                  align={column.align}
                   sx={stickyColumn && !index && isMobile ? stickyColumnStyles : undefined}
                 >
-                  {cell.content}
+                  {column.content}
                 </TableCell>
               ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </MuiTable>
+          </TableHead>
+          <TableBody>
+            {!rows && isLoading && (
+              <SkeletonTableRows rowsNumber={rowsNumber} columnsNumber={columns.length} />
+            )}
+            {rows?.map(row => (
+              <TableRow key={row.key}>
+                {row.data.map((cell, index) => (
+                  <TableCell
+                    key={cell.key}
+                    align={cell.align}
+                    sx={stickyColumn && !index && isMobile ? stickyColumnStyles : undefined}
+                  >
+                    {cell.content}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </MuiTable>
+      </TableContainer>
       {!!pagination?.numberOfAllTransactions && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <TablePagination count={pagination.numberOfAllTransactions} rowsNumber={rowsNumber} />
         </Box>
       )}
-    </TableContainer>
+    </>
   )
 }

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -54,7 +54,7 @@ type TableProps = {
   name: string
   isLoading: boolean
   pagination?: {
-    numberOfItems: number
+    numberOfAllTransactions: number
   }
   rows?: TableRowProps[]
   rowsNumber?: number
@@ -114,7 +114,7 @@ export const Table: FC<TableProps> = ({
       </MuiTable>
       {pagination && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <TablePagination count={pagination.numberOfItems} rowsNumber={rowsNumber} />
+          <TablePagination count={pagination.numberOfAllTransactions} rowsNumber={rowsNumber} />
         </Box>
       )}
     </TableContainer>

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -1,4 +1,5 @@
 import { FC, ReactNode } from 'react'
+import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import TableContainer from '@mui/material/TableContainer'
 import MuiTable from '@mui/material/Table'
@@ -9,6 +10,7 @@ import TableCell from '@mui/material/TableCell'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTheme } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
+import { TablePagination } from './TablePagination'
 
 type SkeletonTableRowsProps = {
   rowsNumber: number
@@ -51,6 +53,9 @@ type TableProps = {
   columnsNumber?: number
   name: string
   isLoading: boolean
+  pagination?: {
+    numberOfItems: number
+  }
   rows?: TableRowProps[]
   rowsNumber?: number
   stickyColumn?: boolean
@@ -66,6 +71,7 @@ export const Table: FC<TableProps> = ({
   columns,
   isLoading,
   name,
+  pagination,
   rows,
   rowsNumber = 5,
   stickyColumn = false,
@@ -106,6 +112,11 @@ export const Table: FC<TableProps> = ({
           ))}
         </TableBody>
       </MuiTable>
+      {pagination && (
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+          <TablePagination count={pagination.numberOfItems} rowsNumber={rowsNumber} />
+        </Box>
+      )}
     </TableContainer>
   )
 }

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -53,9 +53,7 @@ type TableProps = {
   columnsNumber?: number
   name: string
   isLoading: boolean
-  pagination?: {
-    numberOfAllTransactions: number
-  }
+  pagination?: boolean
   rows?: TableRowProps[]
   rowsNumber?: number
   stickyColumn?: boolean
@@ -116,9 +114,12 @@ export const Table: FC<TableProps> = ({
           </TableBody>
         </MuiTable>
       </TableContainer>
-      {!!pagination?.numberOfAllTransactions && (
+      {pagination && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <TablePagination count={pagination.numberOfAllTransactions} rowsNumber={rowsNumber} />
+          <TablePagination
+            count={100} // hardcoded total number of pages
+            rowsNumber={rowsNumber}
+          />
         </Box>
       )}
     </>

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -112,7 +112,7 @@ export const Table: FC<TableProps> = ({
           ))}
         </TableBody>
       </MuiTable>
-      {pagination && (
+      {!!pagination?.numberOfAllTransactions && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <TablePagination count={pagination.numberOfAllTransactions} rowsNumber={rowsNumber} />
         </Box>

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -31,7 +31,7 @@ export const Transactions: FC<TransactionProps> = ({
     { content: t('common.table.from') },
     { content: t('common.table.to') },
     { content: t('common.table.txnFee') },
-    { content: t('common.table.value') },
+    { align: TableCellAlign.Right, content: t('common.table.value') },
   ]
   const tableRows = transactions?.map(transaction => ({
     key: transaction.hash!,

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -1,0 +1,110 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link as RouterLink } from 'react-router-dom'
+import Link from '@mui/material/Link'
+import { Table, TableCellAlign } from '../../components/Table'
+import { TransactionStatusIcon } from '../../components/TransactionStatusIcon'
+import { trimLongString } from '../../utils/trimLongString'
+import { RuntimeTransactionLabel } from '../../components/RuntimeTransactionLabel'
+import { RuntimeTransactionList } from '../../../oasis-indexer/generated/api'
+
+type TransactionProps = RuntimeTransactionList & {
+  isLoading: boolean
+  limit: number
+  numberOfAllTransactions?: number
+}
+
+export const Transactions: FC<TransactionProps> = ({
+  isLoading,
+  limit,
+  numberOfAllTransactions = 0,
+  transactions,
+}) => {
+  const { t } = useTranslation()
+
+  const tableColumns = [
+    { content: t('common.table.status') },
+    { content: t('common.table.hash') },
+    { content: t('common.table.block') },
+    { content: t('common.table.age') },
+    { content: t('common.table.type') },
+    { content: t('common.table.from') },
+    { content: t('common.table.to') },
+    { content: t('common.table.txnFee') },
+    { content: t('common.table.value') },
+  ]
+  const tableRows = transactions?.map(transaction => ({
+    key: transaction.hash!,
+    data: [
+      {
+        content: <TransactionStatusIcon success={transaction.success!} />,
+        key: 'success',
+      },
+      {
+        content: (
+          <Link component={RouterLink} to="transaction">
+            {trimLongString(transaction.hash!, 4, 4, '-')}
+          </Link>
+        ),
+
+        key: 'hash',
+      },
+      {
+        content: (
+          <Link component={RouterLink} to="block">
+            {transaction.round}
+          </Link>
+        ),
+        key: 'round',
+      },
+      {
+        content: '-',
+        key: 'age',
+      },
+      {
+        content: <RuntimeTransactionLabel method={transaction.method!} />,
+        key: 'type',
+      },
+      {
+        content: (
+          <Link component={RouterLink} to="account">
+            {trimLongString(transaction.sender_0!, 10, 0)}
+          </Link>
+        ),
+
+        key: 'from',
+      },
+      {
+        content: (
+          <Link component={RouterLink} to="account">
+            {trimLongString(transaction.to!, 10, 0)}
+          </Link>
+        ),
+        key: 'to',
+      },
+      {
+        align: TableCellAlign.Right,
+        content: t('common.table.valueInRose', { value: transaction.fee_amount }),
+        key: 'fee_amount',
+      },
+      {
+        align: TableCellAlign.Right,
+        content: t('common.table.valueInRose', { value: transaction.amount }),
+        key: 'value',
+      },
+    ],
+  }))
+
+  return (
+    <Table
+      columns={tableColumns}
+      rows={tableRows}
+      rowsNumber={limit}
+      name={t('transactions.latest')}
+      isLoading={isLoading}
+      pagination={{
+        numberOfAllTransactions,
+      }}
+    />
+  )
+}

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -11,15 +11,10 @@ import { RuntimeTransactionList } from '../../../oasis-indexer/generated/api'
 type TransactionProps = RuntimeTransactionList & {
   isLoading: boolean
   limit: number
-  numberOfAllTransactions?: number
+  pagination?: boolean
 }
 
-export const Transactions: FC<TransactionProps> = ({
-  isLoading,
-  limit,
-  numberOfAllTransactions = 0,
-  transactions,
-}) => {
+export const Transactions: FC<TransactionProps> = ({ isLoading, limit, pagination = true, transactions }) => {
   const { t } = useTranslation()
 
   const tableColumns = [
@@ -102,9 +97,7 @@ export const Transactions: FC<TransactionProps> = ({
       rowsNumber={limit}
       name={t('transactions.latest')}
       isLoading={isLoading}
-      pagination={{
-        numberOfAllTransactions,
-      }}
+      pagination={pagination}
     />
   )
 }

--- a/src/app/pages/DashboardPage/LatestTransactions.tsx
+++ b/src/app/pages/DashboardPage/LatestTransactions.tsx
@@ -35,6 +35,7 @@ export const LatestTransactions: FC = () => {
           transactions={transactionsQuery.data?.data.transactions}
           isLoading={transactionsQuery.isLoading}
           limit={limit}
+          pagination={false}
         />
       </CardContent>
     </Card>

--- a/src/app/pages/DashboardPage/LatestTransactions.tsx
+++ b/src/app/pages/DashboardPage/LatestTransactions.tsx
@@ -10,82 +10,13 @@ import { TransactionStatusIcon } from '../../components/TransactionStatusIcon'
 import { trimLongString } from '../../utils/trimLongString'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { RuntimeTransactionLabel } from '../../components/RuntimeTransactionLabel'
+import { Transactions } from '../../components/Transactions'
+
+const limit = 5
 
 export const LatestTransactions: FC = () => {
   const { t } = useTranslation()
-  const transactionsQuery = useGetEmeraldTransactions({ limit: 5 })
-  const tableColumns = [
-    { content: t('common.table.status') },
-    { content: t('common.table.hash') },
-    { content: t('common.table.block') },
-    { content: t('common.table.age') },
-    { content: t('common.table.type') },
-    { content: t('common.table.from') },
-    { content: t('common.table.to') },
-    { content: t('common.table.txnFee') },
-    { content: t('common.table.value') },
-  ]
-  const tableRows = transactionsQuery.data?.data.transactions?.map(transaction => ({
-    key: transaction.hash!,
-    data: [
-      {
-        content: <TransactionStatusIcon success={transaction.success!} />,
-        key: 'success',
-      },
-      {
-        content: (
-          <Link component={RouterLink} to="transaction">
-            {trimLongString(transaction.hash!, 4, 4, '-')}
-          </Link>
-        ),
-
-        key: 'hash',
-      },
-      {
-        content: (
-          <Link component={RouterLink} to="block">
-            {transaction.round}
-          </Link>
-        ),
-        key: 'round',
-      },
-      {
-        content: '-',
-        key: 'age',
-      },
-      {
-        content: <RuntimeTransactionLabel method={transaction.method!} />,
-        key: 'type',
-      },
-      {
-        content: (
-          <Link component={RouterLink} to="account">
-            {trimLongString(transaction.sender_0!, 10, 0)}
-          </Link>
-        ),
-
-        key: 'from',
-      },
-      {
-        content: (
-          <Link component={RouterLink} to="account">
-            {trimLongString(transaction.to!, 10, 0)}
-          </Link>
-        ),
-        key: 'to',
-      },
-      {
-        align: TableCellAlign.Right,
-        content: t('common.table.valueInRose', { value: transaction.fee_amount }),
-        key: 'fee_amount',
-      },
-      {
-        align: TableCellAlign.Right,
-        content: t('common.table.valueInRose', { value: transaction.amount }),
-        key: 'value',
-      },
-    ],
-  }))
+  const transactionsQuery = useGetEmeraldTransactions({ limit })
 
   return (
     <Card>
@@ -100,11 +31,10 @@ export const LatestTransactions: FC = () => {
         }
       />
       <CardContent>
-        <Table
-          columns={tableColumns}
-          rows={tableRows}
-          name={t('transactions.latest')}
+        <Transactions
+          transactions={transactionsQuery.data?.data.transactions}
           isLoading={transactionsQuery.isLoading}
+          limit={limit}
         />
       </CardContent>
     </Card>

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -1,4 +1,31 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
 import { PageLayout } from '../../components/PageLayout'
+import { Transactions } from '../../components/Transactions'
+import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 
-export const TransactionsPage: FC = () => <PageLayout></PageLayout>
+const limit = 10
+
+export const TransactionsPage: FC = () => {
+  const { t } = useTranslation()
+  const transactionsQuery = useGetEmeraldTransactions({ limit: limit })
+
+  return (
+    <PageLayout>
+      <Card>
+        <CardHeader disableTypography component="h3" title={t('transactions.latest')} />
+        <CardContent>
+          <Transactions
+            transactions={transactionsQuery.data?.data.transactions}
+            isLoading={transactionsQuery.isLoading}
+            limit={limit}
+            numberOfAllTransactions={100} // missing in API
+          />
+        </CardContent>
+      </Card>
+    </PageLayout>
+  )
+}

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -22,7 +22,6 @@ export const TransactionsPage: FC = () => {
             transactions={transactionsQuery.data?.data.transactions}
             isLoading={transactionsQuery.isLoading}
             limit={limit}
-            numberOfAllTransactions={100} // missing in API
           />
         </CardContent>
       </Card>

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -1,0 +1,4 @@
+import { FC } from 'react'
+import { PageLayout } from '../../components/PageLayout'
+
+export const TransactionsPage: FC = () => <PageLayout></PageLayout>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -51,6 +51,10 @@
     "status": "ParaTime Online",
     "emerald": "The official confidential EVM Compatible ParaTime providing a smart contract development environment."
   },
+  "pagination": {
+    "first": "First",
+    "last": "Last"
+  },
   "social": {
     "description": "Be part of the community and stay in the loop on everything Oasis",
     "discord": "Discord",

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -4,6 +4,7 @@ import { UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 import { paraTimesConfig } from '../config'
 import * as generated from './generated/api'
+import { useSearchParams } from 'react-router-dom'
 
 export * from './generated/api'
 
@@ -16,7 +17,11 @@ export const useGetEmeraldTransactions = (
   params?: generated.GetEmeraldTransactionsParams,
   options?: { query: UseQueryOptions<AxiosResponse<generated.RuntimeTransactionList>> },
 ) => {
-  const result = generated.useGetEmeraldTransactions(params, options)
+  const [searchParams] = useSearchParams()
+  const offsetSearchQuery = searchParams.get('offset')
+  const offset = offsetSearchQuery ? parseInt(offsetSearchQuery, 10) : 0
+
+  const result = generated.useGetEmeraldTransactions({ ...params, offset }, options)
   if (result.data) {
     return {
       ...result,

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -19,7 +19,7 @@ export const useGetEmeraldTransactions = (
 ) => {
   const [searchParams] = useSearchParams()
   const offsetSearchQuery = searchParams.get('offset')
-  const offset = offsetSearchQuery ? parseInt(offsetSearchQuery, 10) : 0
+  const offset = (offsetSearchQuery && parseInt(offsetSearchQuery, 10)) || 0
 
   const result = generated.useGetEmeraldTransactions({ ...params, offset }, options)
   if (result.data) {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom'
 import { HomePage } from './app/pages/HomePage'
 
 import { BlocksPage } from './app/pages/BlocksPage'
+import { TransactionsPage } from './app/pages/TransactionsPage'
 import { DashboardPage } from './app/pages/DashboardPage'
 
 export const emeraldRoute = '/emerald'
@@ -18,5 +19,9 @@ export const routes: RouteObject[] = [
   {
     path: `${emeraldRoute}/blocks`,
     element: <BlocksPage />,
+  },
+  {
+    path: `${emeraldRoute}/transactions`,
+    element: <TransactionsPage />,
   },
 ]

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -29,5 +29,6 @@ export const COLORS = {
   vistaBlue: '#8988dd',
   white: '#ffffff',
   spaceCadet: '#0f0f5f',
-  denimBlue: '#3138bc'
+  denimBlue: '#3138bc',
+  disabledPagination: '#7575a7',
 }


### PR DESCRIPTION
PR adds transactions list page with offset pagination.
Transaction list is extracted from Dashboard Latest Transaction
For pagination I had to use [headless pagination component](https://mui.com/material-ui/react-pagination/#UsePagination.tsx), because it was impossible to swap next/first/prev/last etc.


what's not in this PR
- polling / marking new items with diff background color 

<img width="1019" alt="Screenshot 2022-12-22 at 12 59 59" src="https://user-images.githubusercontent.com/891392/209130075-78cb52dd-ae5a-4658-bccb-a071fed218ed.png">
