### PR TITLE
Mark new items in BlocksPage

### DIFF
--- a/src/app/components/Blocks/index.tsx
+++ b/src/app/components/Blocks/index.tsx
@@ -3,14 +3,22 @@ import { useTranslation } from 'react-i18next'
 import Link from '@mui/material/Link'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 
-import { RuntimeBlockList } from '../../../oasis-indexer/generated/api'
+import { RuntimeBlock } from '../../../oasis-indexer/generated/api'
 import { VerticalProgressBar } from '../../components/ProgressBar'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { TrimLinkLabel } from '../../components/TrimLinkLabel'
 import { intlDateFormat } from '../../utils/dateFormatter'
 import { emeraldRoute } from '../../../routes'
 
-type BlocksProps = RuntimeBlockList & {
+export type TableRuntimeBlock = RuntimeBlock & {
+  markAsNew?: boolean
+}
+
+export type TableRuntimeBlockList = {
+  blocks?: TableRuntimeBlock[]
+}
+
+type BlocksProps = TableRuntimeBlockList & {
   isLoading: boolean
   limit: number
   verbose?: boolean
@@ -111,6 +119,7 @@ export const Blocks = (props: BlocksProps) => {
           ]
         : []),
     ],
+    markAsNew: block.markAsNew,
   }))
 
   return (

--- a/src/app/pages/BlocksPage/index.tsx
+++ b/src/app/pages/BlocksPage/index.tsx
@@ -1,12 +1,14 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import { UseQueryResult } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
 import Divider from '@mui/material/Divider'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTheme } from '@mui/material/styles'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { useGetEmeraldBlocks } from '../../../oasis-indexer/api'
-import { Blocks } from '../../components/Blocks'
+import { Blocks, TableRuntimeBlockList } from '../../components/Blocks'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, REFETCH_INTERVAL } from '../../config'
 
 const PAGE_SIZE = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
@@ -15,11 +17,34 @@ export const BlocksPage: FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const { t } = useTranslation()
-  const blocksQuery = useGetEmeraldBlocks(
+  const blocksQuery: UseQueryResult<AxiosResponse<TableRuntimeBlockList>> = useGetEmeraldBlocks(
     {
       limit: PAGE_SIZE,
     },
-    { query: { refetchInterval: REFETCH_INTERVAL } },
+    {
+      query: {
+        refetchInterval: REFETCH_INTERVAL,
+        structuralSharing: (previousState, nextState) => {
+          if (!previousState) {
+            return nextState
+          }
+          const oldBlocks = previousState.data?.blocks || []
+          const oldBlockIds = new Set<number>()
+          oldBlocks.forEach(block => oldBlockIds.add(block.round!))
+          return {
+            ...nextState,
+            data: {
+              blocks: nextState.data?.blocks?.map(block => {
+                return {
+                  ...block,
+                  markAsNew: !oldBlockIds.has(block.round!),
+                }
+              }),
+            },
+          }
+        },
+      },
+    },
   )
 
   return (


### PR DESCRIPTION
This is pretty much the same thing we already have for transactions, implemented here: https://github.com/oasisprotocol/explorer/commit/82a05855392e657d3695378844d0cf687a1b3286

For some reason, currently it's impossible to test this, because for some reason,  we only get 9 month old emerald blocks from the backend, when we ask for the latest block.