### PR TITLE
Add basic Transaction Detail page

### DIFF
--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -64,8 +64,12 @@ export const Transactions: FC<TransactionProps> = ({ isLoading, limit, paginatio
         key: 'success',
       },
       {
-        content: <TrimLinkLabel label={transaction.hash!} to="transaction" />,
-
+        content: (
+          <TrimLinkLabel
+            label={transaction.hash!}
+            to={RouteUtils.getTransactionRoute(transaction.hash!, ParaTime.Emerald)}
+          />
+        ),
         key: 'hash',
       },
       {

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import Skeleton from '@mui/material/Skeleton'
+import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
+import { StyledDescriptionList } from '../../components/StyledDescriptionList'
+import { PageLayout } from '../../components/PageLayout'
+import { SubPageCard } from '../../components/SubPageCard'
+import { TransactionStatusIcon } from '../../components/TransactionStatusIcon'
+import { RuntimeTransactionLabel } from '../../components/RuntimeTransactionLabel'
+
+// TODO: replace with an appropriate API
+function useGetEmeraldTransactionsByHash(hash: string) {
+  // Returns array to simulate that hash may not be unique.
+  return useGetEmeraldTransactions({ limit: 2 })
+}
+
+export const TransactionDetailPage: FC = () => {
+  const { t } = useTranslation()
+  const hash = useParams().hash!
+  const { isLoading, data } = useGetEmeraldTransactionsByHash(hash)
+  const transactions = data?.data.transactions
+
+  return (
+    <PageLayout>
+      {isLoading && (
+        <SubPageCard title={t('transaction.header')}>
+          <Skeleton variant="text" height={30} sx={{ my: 4 }} />
+          <Skeleton variant="text" height={30} sx={{ my: 4 }} />
+          <Skeleton variant="text" height={30} sx={{ my: 4 }} />
+          <Skeleton variant="text" height={30} sx={{ my: 4 }} />
+          <Skeleton variant="text" height={30} sx={{ my: 4 }} />
+        </SubPageCard>
+      )}
+      {transactions?.map(transaction => (
+        <SubPageCard title={t('transaction.header')} key={`${transaction.round}_${transaction.index}`}>
+          <StyledDescriptionList titleWidth="200px">
+            <dt>{t('common.hash')}</dt>
+            <dd>{transaction.hash}</dd>
+
+            <dt>{t('common.status')}</dt>
+            <dd>
+              <TransactionStatusIcon success={transaction.success!} />
+            </dd>
+
+            <dt>{t('common.block')}</dt>
+            <dd>{transaction.round}</dd>
+
+            <dt>{t('common.type')}</dt>
+            <dd>
+              <RuntimeTransactionLabel method={transaction.method!} />
+            </dd>
+
+            <dt>{t('common.from')}</dt>
+            <dd>{transaction.sender_0}</dd>
+
+            <dt>{t('common.to')}</dt>
+            <dd>{transaction.to}</dd>
+
+            <dt>{t('common.txnFee')}</dt>
+            <dd>{t('common.valueInRose', { value: transaction.fee_amount })}</dd>
+
+            <dt>{t('common.value')}</dt>
+            <dd>{t('common.valueInRose', { value: transaction.amount })}</dd>
+          </StyledDescriptionList>
+        </SubPageCard>
+      ))}
+    </PageLayout>
+  )
+}

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -7,6 +7,10 @@ export abstract class RouteUtils {
     return `${paraTime ? `/${paraTime}` : ''}/blocks/${encodeURIComponent(blockHeight)}`
   }
 
+  static getTransactionRoute = (txHash: string, paraTime: ParaTime | null = null) => {
+    return `${paraTime ? `/${paraTime}` : ''}/transactions/${encodeURIComponent(txHash)}`
+  }
+
   static getAccountRoute = (sender: string, paraTime: ParaTime | null = null) => {
     return `${paraTime ? `/${paraTime}` : ''}/account/${encodeURIComponent(sender)}`
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -90,6 +90,9 @@
       }
     }
   },
+  "transaction": {
+    "header": "Transaction"
+  },
   "transactionStats": {
     "header": "Transactions Per Day",
     "tooltip": "{{value}} tx/day"

--- a/src/oasis-indexer/orval.config.js
+++ b/src/oasis-indexer/orval.config.js
@@ -14,4 +14,4 @@ module.exports = {
       mode: 'single',
     },
   },
-};
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom'
 import { HomePage } from './app/pages/HomePage'
 import { BlocksPage } from './app/pages/BlocksPage'
 import { TransactionsPage } from './app/pages/TransactionsPage'
+import { TransactionDetailPage } from './app/pages/TransactionDetailPage'
 import { DashboardPage } from './app/pages/DashboardPage'
 import { BlockDetailPage } from './app/pages/BlockDetailPage'
 import { AccountDetailsPage } from './app/pages/AccountDetailsPage'
@@ -33,6 +34,10 @@ export const routes: RouteObject[] = [
       {
         path: `/${paraTime}/transactions`,
         element: <TransactionsPage />,
+      },
+      {
+        path: `${paraTime}/transactions/:hash`,
+        element: <TransactionDetailPage />,
       },
     ])
     .flat(),


### PR DESCRIPTION
This is an unpolished version, just to unblock working on Transaction Detail page despite missing API

/emerald/transactions/:hash displays last two indexed transactions to simulate that tx hash may not be unique
![localhost_1234_emerald_transactions_959586fdef45f2916ba28651d71700436040777a47ef964d5bc4141a42027249](https://user-images.githubusercontent.com/3758846/211430493-5893e23c-4149-495b-be4c-aa2e96e4e18c.png)
