### PR TITLE
Fix rotated ArrowIcon width

### DIFF
--- a/src/app/icons/ArrowIcon.tsx
+++ b/src/app/icons/ArrowIcon.tsx
@@ -22,7 +22,7 @@ const ArrowIcon: FC<ArrowProps> = ({ arrowDirection = ArrowDirection.UP }) => {
   return (
     <ArrowSvgIcon
       arrowDirection={arrowDirection}
-      width="8"
+      width="13"
       height="13"
       viewBox="0 0 8 13"
       fill="none"


### PR DESCRIPTION
When ArrowDirection.RIGHT it still takes up 8x13 instead of 13x8. Let's just make it square?