### PR TITLE
Replace custom ArrowIcon with MUI icons

### DIFF
--- a/src/app/components/PercentageGain/index.tsx
+++ b/src/app/components/PercentageGain/index.tsx
@@ -1,8 +1,7 @@
 import { FC, memo } from 'react'
-import ArrowIcon from '../../icons/ArrowIcon'
-import { Gain, GainToArrowDirectionMap } from './types'
-import { getGainFromPercentage } from './percentage-gain-utils'
 import { Chip } from '@mui/material'
+import NorthIcon from '@mui/icons-material/North'
+import SouthIcon from '@mui/icons-material/South'
 
 interface PercentageGainProps {
   /**
@@ -13,13 +12,13 @@ interface PercentageGainProps {
 }
 
 const PercentageGainCmp: FC<PercentageGainProps> = ({ percentage }) => {
-  const gain = getGainFromPercentage(percentage)
+  const gain = percentage >= 0
 
   return (
     <Chip
       sx={{ p: 3 }}
-      color={gain === Gain.POSITIVE ? 'success' : 'error'}
-      icon={<ArrowIcon arrowDirection={GainToArrowDirectionMap[gain]} />}
+      color={gain ? 'success' : 'error'}
+      icon={gain ? <NorthIcon sx={{ fontSize: '14px' }} /> : <SouthIcon sx={{ fontSize: '14px' }} />}
       label={`${percentage}%`}
     />
   )

--- a/src/app/components/PercentageGain/percentage-gain-utils.ts
+++ b/src/app/components/PercentageGain/percentage-gain-utils.ts
@@ -1,5 +1,0 @@
-import { Gain } from './types'
-
-export const getGainFromPercentage = (percentage: number) => {
-  return percentage >= 0 ? Gain.POSITIVE : Gain.NEGATIVE
-}

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -4,14 +4,13 @@ import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Table, TableCellAlign } from '../../components/Table'
 import { TransactionStatusIcon } from '../../components/TransactionStatusIcon'
 import { RuntimeTransactionLabel } from '../../components/RuntimeTransactionLabel'
 import { TrimLinkLabel } from '../../components/TrimLinkLabel'
 import { RuntimeTransaction } from '../../../oasis-indexer/generated/api'
-import ArrowIcon from '../../icons/ArrowIcon'
 import { COLORS } from '../../../styles/theme/colors'
-import { ArrowDirection } from '../../icons/types'
 import { RouteUtils } from '../../utils/route-utils'
 import { ParaTime } from '../../../config'
 
@@ -97,7 +96,7 @@ export const Transactions: FC<TransactionProps> = ({ isLoading, limit, paginatio
               to={RouteUtils.getAccountRoute(transaction.sender_0!, ParaTime.Emerald)}
             />
             <StyledCircle>
-              <ArrowIcon arrowDirection={ArrowDirection.RIGHT} />
+              <ArrowForwardIcon fontSize="inherit" />
             </StyledCircle>
           </Box>
         ),

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -258,6 +258,10 @@ export const defaultTheme = createTheme({
         label: {
           padding: 0,
         },
+        icon: {
+          marginLeft: 0,
+          marginRight: 0,
+        },
       },
     },
     MuiDivider: {


### PR DESCRIPTION
- custom icons are licensed so we will use MUI icons in this project. mockups will be updated in the future.
- using north/south icons in badge instead of up/down because they look more similar to current designs

![Screenshot 2023-01-11 at 13 59 18](https://user-images.githubusercontent.com/891392/211812480-7a8b322c-a326-4647-a035-d8516168dc46.png)
