### PR TITLE
Fix TertiaryButton type again

### DIFF
--- a/src/app/components/Select/index.tsx
+++ b/src/app/components/Select/index.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react'
-import SelectUnstyled, { SelectUnstyledProps, selectUnstyledClasses } from '@mui/base/SelectUnstyled'
+import SelectUnstyled, {
+  SelectUnstyledProps,
+  selectUnstyledClasses,
+  SelectUnstyledComponentsPropsOverrides,
+  SelectUnstyledOwnerState,
+} from '@mui/base/SelectUnstyled'
 import OptionUnstyled, { optionUnstyledClasses } from '@mui/base/OptionUnstyled'
 import PopperUnstyled from '@mui/base/PopperUnstyled'
 import { styled } from '@mui/material/styles'
 import Box from '@mui/material/Box'
-import { ForwardedRef, forwardRef, memo, ReactElement, useCallback, useId } from 'react'
+import { ForwardedRef, forwardRef, memo, PropsWithChildren, ReactElement, useCallback, useId } from 'react'
 import Typography from '@mui/material/Typography'
-import Button, { ButtonProps } from '@mui/material/Button'
+import Button from '@mui/material/Button'
+import { SlotComponentProps } from '@mui/base/utils'
 import { COLORS } from '../../../styles/theme/colors'
 import chevronUp from '../../icons/chevron-up.svg'
 import chevronDown from '../../icons/chevron-down.svg'
@@ -82,12 +88,15 @@ const TertiaryButton = forwardRef(
     {
       children,
       ...restProps
-    }: ButtonProps,
+    }: PropsWithChildren<
+      SlotComponentProps<'button', SelectUnstyledComponentsPropsOverrides, SelectUnstyledOwnerState<{}>>
+    >,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     const { t } = useTranslation()
 
     return (
+      // @ts-expect-error TS2322
       <StyledButton ref={ref} color={'tertiary'} {...restProps}>
         <Typography variant="select">{children ? children : t('select.placeholder')}</Typography>
       </StyledButton>

--- a/src/app/components/Select/index.tsx
+++ b/src/app/components/Select/index.tsx
@@ -2,17 +2,15 @@ import * as React from 'react'
 import SelectUnstyled, {
   SelectUnstyledProps,
   selectUnstyledClasses,
-  SelectUnstyledComponentsPropsOverrides,
-  SelectUnstyledOwnerState,
+  SelectUnstyledRootSlotProps,
 } from '@mui/base/SelectUnstyled'
 import OptionUnstyled, { optionUnstyledClasses } from '@mui/base/OptionUnstyled'
 import PopperUnstyled from '@mui/base/PopperUnstyled'
 import { styled } from '@mui/material/styles'
 import Box from '@mui/material/Box'
-import { ForwardedRef, forwardRef, memo, PropsWithChildren, ReactElement, useCallback, useId } from 'react'
+import { ForwardedRef, forwardRef, memo, ReactElement, useCallback, useId } from 'react'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
-import { SlotComponentProps } from '@mui/base/utils'
 import { COLORS } from '../../../styles/theme/colors'
 import chevronUp from '../../icons/chevron-up.svg'
 import chevronDown from '../../icons/chevron-down.svg'
@@ -84,20 +82,11 @@ const StyledPopper = styled(PopperUnstyled)`
 `
 
 const TertiaryButton = forwardRef(
-  (
-    {
-      children,
-      ...restProps
-    }: PropsWithChildren<
-      SlotComponentProps<'button', SelectUnstyledComponentsPropsOverrides, SelectUnstyledOwnerState<{}>>
-    >,
-    ref: ForwardedRef<HTMLButtonElement>,
-  ) => {
+  ({ children, ...restProps }: SelectUnstyledRootSlotProps<{}>, ref: ForwardedRef<HTMLButtonElement>) => {
     const { t } = useTranslation()
 
     return (
-      // @ts-expect-error TS2322
-      <StyledButton ref={ref} color={'tertiary'} {...restProps}>
+      <StyledButton {...restProps} ref={ref} color={'tertiary'}>
         <Typography variant="select">{children ? children : t('select.placeholder')}</Typography>
       </StyledButton>
     )


### PR DESCRIPTION
Previous change https://github.com/oasisprotocol/explorer/pull/53/files#r1069961535 was inaccurate

This now correctly exposes e.g. `restProps.ownerState.open` that we could use for switching icons, instead of using css