### PR TITLE
Init Tokens sub pages

### DIFF
--- a/src/app/components/RouterTabs/index.tsx
+++ b/src/app/components/RouterTabs/index.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react'
+import { useLocation, matchPath, Link as RouterLink, Outlet } from 'react-router-dom'
+import Tabs from '@mui/material/Tabs'
+import Tab from '@mui/material/Tab'
+
+type RouterTabsProps = {
+  tabs: {
+    label: string
+    to: string
+  }[]
+}
+
+function useRouteMatch(patterns: string[]) {
+  const { pathname } = useLocation()
+
+  for (let i = 0; i < patterns.length; i += 1) {
+    const pattern = patterns[i]
+    const possibleMatch = matchPath(pattern, pathname)
+    if (possibleMatch !== null) {
+      return possibleMatch
+    }
+  }
+
+  return null
+}
+
+export const RouterTabs: FC<RouterTabsProps> = ({ tabs }) => {
+  const tabsPaths = tabs.flatMap(num => num.to)
+  const routeMatch = useRouteMatch(tabsPaths)
+  const currentTab = routeMatch?.pattern?.path
+
+  return (
+    <>
+      <Tabs value={currentTab}>
+        {tabs.map(tab => (
+          <Tab key={tab.to} component={RouterLink} value={tab.to} label={tab.label} to={tab.to} />
+        ))}
+      </Tabs>
+      <Outlet />
+    </>
+  )
+}

--- a/src/app/pages/AccountDetailsPage/TokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TokensCard.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+
+type TokensCardProps = {
+  type: 'erc-20' | 'erc-721'
+}
+
+export const TokensCard: FC<TokensCardProps> = ({ type }) => {
+  const { t } = useTranslation()
+  const tokenLabel = t(`account.${type}`)
+
+  return (
+    <Card>
+      <CardHeader
+        disableTypography
+        component="h3"
+        title={t('account.tokensListTitle', { token: tokenLabel })}
+      />
+      <CardContent></CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import { Transactions } from '../../components/Transactions'
+import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+
+export const TransactionsCard: FC = () => {
+  const { t } = useTranslation()
+  const { address } = useParams()
+  const txsPagination = useSearchParamsPagination('page')
+  const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+  const transactionsQuery = useGetEmeraldTransactions({
+    limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+    offset: txsOffset,
+    rel: address,
+  })
+
+  return (
+    <Card>
+      <CardHeader disableTypography component="h3" title={t('account.transactionsListTitle')} />
+      <CardContent>
+        <Transactions
+          transactions={transactionsQuery.data?.data.transactions}
+          isLoading={transactionsQuery.isLoading}
+          limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+          pagination={{
+            selectedPage: txsPagination.selectedPage,
+            linkToPage: txsPagination.linkToPage,
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -1,34 +1,22 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
-import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import Skeleton from '@mui/material/Skeleton'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { Account } from '../../components/Account'
-import { Transactions } from '../../components/Transactions'
 import { useGetConsensusAccountsAddress } from '../../../oasis-indexer/api'
-import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { useGetRosePrice } from '../../../coin-gecko/api'
-import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
-import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { TransactionsCard } from './TransactionsCard'
 
 export const AccountDetailsPage: FC = () => {
   const { t } = useTranslation()
   const { address } = useParams()
-  const txsPagination = useSearchParamsPagination('page')
-  const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   // TODO: switch to Emerald when API is ready
   const accountQuery = useGetConsensusAccountsAddress(address!)
   const account = accountQuery.data?.data
   const rosePriceQuery = useGetRosePrice()
-  const transactionsQuery = useGetEmeraldTransactions({
-    limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-    offset: txsOffset,
-    rel: address,
-  })
 
   return (
     <PageLayout>
@@ -40,20 +28,7 @@ export const AccountDetailsPage: FC = () => {
           </CardContent>
         )}
       </SubPageCard>
-      <Card>
-        <CardHeader disableTypography component="h3" title={t('account.transactionsListTitle')} />
-        <CardContent>
-          <Transactions
-            transactions={transactionsQuery.data?.data.transactions}
-            isLoading={transactionsQuery.isLoading}
-            limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-            pagination={{
-              selectedPage: txsPagination.selectedPage,
-              linkToPage: txsPagination.linkToPage,
-            }}
-          />
-        </CardContent>
-      </Card>
+      <TransactionsCard />
     </PageLayout>
   )
 }

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -1,14 +1,14 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
+import { useHref, useParams } from 'react-router-dom'
 import CardContent from '@mui/material/CardContent'
 import Skeleton from '@mui/material/Skeleton'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { Account } from '../../components/Account'
+import { RouterTabs } from '../../components/RouterTabs'
 import { useGetConsensusAccountsAddress } from '../../../oasis-indexer/api'
 import { useGetRosePrice } from '../../../coin-gecko/api'
-import { TransactionsCard } from './TransactionsCard'
 
 export const AccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -28,7 +28,13 @@ export const AccountDetailsPage: FC = () => {
           </CardContent>
         )}
       </SubPageCard>
-      <TransactionsCard />
+      <RouterTabs
+        tabs={[
+          { label: t('common.transactions'), to: useHref('') },
+          { label: t('account.erc-20'), to: useHref('tokens/erc-20') },
+          { label: t('account.erc-721'), to: useHref('tokens/erc-721') },
+        ]}
+      />
     </PageLayout>
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,9 +1,12 @@
 {
   "account": {
-    "showMore": "+ {{counter}} more",
+    "erc-20": "ERC-20",
+    "erc-721": "ERC-721",
     "noTokens": "This account holds no tokens",
+    "showMore": "+ {{counter}} more",
     "title": "Account",
     "tokens": "Tokens",
+    "tokensListTitle": "{{token}} Tokens",
     "transactionsListTitle": "Account Transactions"
   },
   "averageTransactionSize": {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,6 +6,8 @@ import { TransactionDetailPage } from './app/pages/TransactionDetailPage'
 import { DashboardPage } from './app/pages/DashboardPage'
 import { BlockDetailPage } from './app/pages/BlockDetailPage'
 import { AccountDetailsPage } from './app/pages/AccountDetailsPage'
+import { TransactionsCard } from './app/pages/AccountDetailsPage/TransactionsCard'
+import { TokensCard } from './app/pages/AccountDetailsPage/TokensCard'
 import { RouteUtils } from './app/utils/route-utils'
 
 export const routes: RouteObject[] = [
@@ -30,6 +32,20 @@ export const routes: RouteObject[] = [
       {
         path: `${paraTime}/account/:address`,
         element: <AccountDetailsPage />,
+        children: [
+          {
+            path: '',
+            element: <TransactionsCard />,
+          },
+          {
+            path: 'tokens/erc-20',
+            element: <TokensCard type="erc-20" />,
+          },
+          {
+            path: 'tokens/erc-721',
+            element: <TokensCard type="erc-721" />,
+          },
+        ],
       },
       {
         path: `/${paraTime}/transactions`,

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -35,4 +35,5 @@ export const COLORS = {
   denimBlue: '#3138bc',
   disabledPagination: '#7575a7',
   purpleBackground: '#e0e0f4',
+  inactiveTab: '#e5e5f6',
 } satisfies { [colorName: string]: string }

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -489,5 +489,41 @@ export const defaultTheme = createTheme({
         },
       ],
     },
+    MuiTabs: {
+      styleOverrides: {
+        root: {
+          // neglect the default border radius of sibling element (Card component in most cases)
+          '&& + *': {
+            borderTopLeftRadius: 0,
+          },
+        },
+        indicator: {
+          display: 'none',
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&.Mui-selected': {
+            color: COLORS.brandExtraDark,
+            backgroundColor: COLORS.white,
+          },
+
+          color: COLORS.brandDark,
+          backgroundColor: COLORS.inactiveTab,
+          marginRight: theme.spacing(2),
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          textTransform: 'capitalize',
+          [theme.breakpoints.down('sm')]: {
+            padding: `${theme.spacing(3)} ${theme.spacing(4)}`,
+          },
+          [theme.breakpoints.up('sm')]: {
+            padding: `${theme.spacing(4)} ${theme.spacing(5)}`,
+          },
+        }),
+      },
+    },
   },
 })


### PR DESCRIPTION
- adds `RouterTabs` that can be used in TX detail page as well 
- split account details into sub components and sub routes

I will ask Don to simplify tabs a little bit, because imo MUI tabs customisation is limited, or pixel perfect impl will need tons of additional overrides.

![Screenshot 2023-01-24 at 13 15 15](https://user-images.githubusercontent.com/891392/214304428-99701f2f-364e-4126-83a1-b5b58d7e2dce.png)

