### PR TITLE
Init average transaction size chart

### DIFF
--- a/src/app/components/charts/LineChart.tsx
+++ b/src/app/components/charts/LineChart.tsx
@@ -1,34 +1,68 @@
-import { LineChart as RechartsLineChart, Line, ResponsiveContainer, Tooltip, YAxis } from 'recharts'
+import {
+  CartesianGrid,
+  LineChart as RechartsLineChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  YAxis,
+} from 'recharts'
 import { Margin } from 'recharts/types/util/types'
 import { COLORS } from '../../../styles/theme/colors'
 import { memo, ReactElement } from 'react'
 import { Formatters, TooltipContent } from './Tooltip'
 
 interface LineChartProps<T extends object> extends Formatters {
+  cartesianGrid?: boolean
   data: T[]
   dataKey: keyof T
   margin?: Margin
   strokeWidth?: number | string
+  tickMargin?: number
+  tooltipActiveDotRadius?: number
+  withLabels?: boolean
 }
 
 const LineChartCmp = <T extends object>({
+  cartesianGrid,
   data,
-  margin,
-  strokeWidth = 2,
   dataKey,
   formatters,
+  margin,
+  strokeWidth = 2,
+  tickMargin = 0,
+  tooltipActiveDotRadius = 5,
+  withLabels,
 }: LineChartProps<T>): ReactElement => (
   <ResponsiveContainer width="100%" aspect={4}>
     <RechartsLineChart data={data} margin={margin}>
+      {cartesianGrid && <CartesianGrid vertical={false} stroke={COLORS.antiFlashWhite3} />}
       <Line
         type="monotone"
         dataKey={dataKey as string}
         stroke={COLORS.brandDark}
         strokeWidth={strokeWidth}
         dot={false}
-        activeDot={{ r: 5, fill: COLORS.brandExtraDark, strokeWidth: 20, stroke: '#0000621A' }}
+        activeDot={{
+          r: tooltipActiveDotRadius,
+          fill: COLORS.brandDark,
+          strokeWidth: tooltipActiveDotRadius * 4,
+          stroke: '#0000621A',
+        }}
       />
-      <YAxis domain={['dataMin', 'dataMax']} axisLine={false} tickLine={false} tick={false} mirror={true} />
+      <YAxis
+        domain={withLabels ? [0, 'auto'] : ['dataMin', 'dataMax']}
+        axisLine={false}
+        tickLine={false}
+        mirror={!withLabels}
+        tick={
+          withLabels
+            ? { fill: COLORS.brandDark, strokeWidth: 0, fontWeight: 600, fontStyle: 'italic' }
+            : false
+        }
+        type="number"
+        padding={{ bottom: 20 }}
+        tickMargin={tickMargin}
+      />
       <Tooltip
         cursor={false}
         wrapperStyle={{ outline: 'none' }}

--- a/src/app/pages/DashboardPage/AverageTransactionSize.tsx
+++ b/src/app/pages/DashboardPage/AverageTransactionSize.tsx
@@ -3,14 +3,48 @@ import { useTranslation } from 'react-i18next'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
+import { LineChart } from '../../components/charts/LineChart'
+import { useGetConsensusStatsTxVolume } from '../../../oasis-indexer/api'
 
 export const AverageTransactionSize: FC = () => {
   const { t } = useTranslation()
+  // TODO: Replace with real stats when available
+  const dailyVolumeQuery = useGetConsensusStatsTxVolume()
 
   return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('averageTransactionSize.header')} />
-      <CardContent></CardContent>
+      <CardContent>
+        {dailyVolumeQuery.data?.data.buckets && (
+          <LineChart
+            tooltipActiveDotRadius={9}
+            cartesianGrid={true}
+            strokeWidth={3}
+            dataKey="volume"
+            data={dailyVolumeQuery.data?.data.buckets}
+            margin={{ left: 16, right: 0, top: 16, bottom: 16 }}
+            tickMargin={16}
+            withLabels={true}
+            formatters={{
+              data: (value: number) =>
+                t('averageTransactionSize.tooltip', {
+                  value,
+                  formatParams: {
+                    value: {
+                      style: 'unit',
+                      unit: 'byte',
+                      unitDisplay: 'long',
+                    },
+                  },
+                }),
+              label: (value: string) =>
+                t('common.formattedDateTime', {
+                  timestamp: new Date(value),
+                }),
+            }}
+          />
+        )}
+      </CardContent>
     </Card>
   )
 }

--- a/src/app/pages/DashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/DashboardPage/TransactionsStats.tsx
@@ -3,7 +3,6 @@ import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { BarChart } from '../../components/charts/BarChart'
-import { intlDateFormat } from '../../utils/dateFormatter'
 import { useGetConsensusStatsTxVolume } from '../../../oasis-indexer/api'
 
 export function TransactionsStats() {
@@ -21,7 +20,10 @@ export function TransactionsStats() {
             dataKey="volume"
             formatters={{
               data: (value: number) => t('transactionStats.tooltip', { value }),
-              label: (value: string) => intlDateFormat(new Date(value)),
+              label: (value: string) =>
+                t('common.formattedDateTime', {
+                  timestamp: new Date(value),
+                }),
             }}
           />
         )}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -10,7 +10,8 @@
     "transactionsListTitle": "Account Transactions"
   },
   "averageTransactionSize": {
-    "header": "Average Transaction Size"
+    "header": "Average Transaction Size",
+    "tooltip": "Average Tx Size: {{value, number}}"
   },
   "blocks": {
     "latest": "Latest Blocks"


### PR DESCRIPTION
PR
- updates line chart to allow more customisations 
- renders avg chart with fake data (there is no endpoint for census or emerald, so I'm using tx volume as placeholder data)

![Screenshot 2023-01-30 at 14 48 09](https://user-images.githubusercontent.com/891392/215501240-91387f57-f956-4174-a4b0-9a783231c5cf.png)
