### PR TITLE
Fix failing test

### DIFF
--- a/src/app/pages/BlockDetailPage/BlockDetailView.test.tsx
+++ b/src/app/pages/BlockDetailPage/BlockDetailView.test.tsx
@@ -1,21 +1,32 @@
 import { render } from '@testing-library/react'
-import { BlockDetailView } from '.'
+import { BlockDetailView } from './'
 
-test('BlockDetailView should display formatted values', () => {
-  const { container } = render(
-    <BlockDetailView
-      isLoading={false}
-      block={{
-        round: 1158800,
-        hash: '194cdf5b6a75be37f0ee6ff52bb2680ec95a7c28a89c5214ba25809600c72f92',
-        timestamp: '2022-04-23T12:20:56Z',
-        num_transactions: 10,
-        size_bytes: 6434,
-        gas_used: 673539,
-      }}
-    />,
-  )
-  expect(container).toHaveTextContent('1158800')
-  expect(container).toHaveTextContent('April 23, 2022 at 12:20 PM UTC (9 months ago)')
-  expect(container).toHaveTextContent('6,434 bytes')
+describe('BlockDetailView', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2023, 1, 1))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should display formatted values', () => {
+    const { container } = render(
+      <BlockDetailView
+        isLoading={false}
+        block={{
+          round: 1158800,
+          hash: '194cdf5b6a75be37f0ee6ff52bb2680ec95a7c28a89c5214ba25809600c72f92',
+          timestamp: '2022-04-23T12:20:56Z',
+          num_transactions: 10,
+          size_bytes: 6434,
+          gas_used: 673539,
+        }}
+      />,
+    )
+    expect(container).toHaveTextContent('1158800')
+    expect(container).toHaveTextContent('April 23, 2022 at 12:20 PM UTC (9 months ago)')
+    expect(container).toHaveTextContent('6,434 bytes')
+  })
 })

--- a/src/app/pages/BlockDetailPage/__tests__/BlockDetailView.test.tsx
+++ b/src/app/pages/BlockDetailPage/__tests__/BlockDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { BlockDetailView } from '../'
 
 describe('BlockDetailView', () => {
@@ -12,7 +12,7 @@ describe('BlockDetailView', () => {
   })
 
   it('should display formatted values', () => {
-    const { container } = render(
+    render(
       <BlockDetailView
         isLoading={false}
         block={{
@@ -25,8 +25,8 @@ describe('BlockDetailView', () => {
         }}
       />,
     )
-    expect(container).toHaveTextContent('1158800')
-    expect(container).toHaveTextContent('April 23, 2022 at 12:20 PM UTC (9 months ago)')
-    expect(container).toHaveTextContent('6,434 bytes')
+    expect(screen.getByText('1158800')).toBeInTheDocument()
+    expect(screen.getByText('April 23, 2022 at 12:20 PM UTC (9 months ago)')).toBeInTheDocument()
+    expect(screen.getByText('6,434 bytes')).toBeInTheDocument()
   })
 })

--- a/src/app/pages/BlockDetailPage/__tests__/BlockDetailView.test.tsx
+++ b/src/app/pages/BlockDetailPage/__tests__/BlockDetailView.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react'
-import { BlockDetailView } from './'
+import { BlockDetailView } from '../'
 
 describe('BlockDetailView', () => {
   beforeEach(() => {


### PR DESCRIPTION
use fake timers to fix failing unit test

https://github.com/oasisprotocol/explorer/actions/runs/4074625889/jobs/7020120921
```
Expected element to have text content:
April 23, 2022 at 12:20 PM UTC (9 months ago)
Received:
April 23, 2022 at 12:20 PM UTC (10 months ago)
```      
