### PR TITLE
Refactor CopyToClipboard

### DIFF
--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -6,16 +6,26 @@ import Link from '@mui/material/Link'
 import { TrimLinkLabel } from '../TrimLinkLabel'
 import { ParaTime } from '../../../config'
 import { RouteUtils } from '../../utils/route-utils'
+import { CopyToClipboardButton } from '../CopyToClipboard'
 
-export const AccountLink: FC<{ address: string; paratime: ParaTime }> = ({ address, paratime }) => {
+export const AccountLink: FC<{ address: string; paratime: ParaTime; copyToClipboard?: boolean }> = ({
+  address,
+  paratime,
+  copyToClipboard,
+}) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const to = RouteUtils.getAccountRoute(address, paratime)
-  return isMobile ? (
-    <TrimLinkLabel label={address} to={to} />
-  ) : (
-    <Link component={RouterLink} to={to}>
-      {address}
-    </Link>
+  return (
+    <>
+      {isMobile ? (
+        <TrimLinkLabel label={address} to={to} />
+      ) : (
+        <Link component={RouterLink} to={to}>
+          {address}
+        </Link>
+      )}
+      {copyToClipboard && <CopyToClipboardButton value={address} />}
+    </>
   )
 }

--- a/src/app/components/CopyToClipboard/index.tsx
+++ b/src/app/components/CopyToClipboard/index.tsx
@@ -5,6 +5,9 @@ import Tooltip from '@mui/material/Tooltip'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import IconButton from '@mui/material/IconButton'
 import { COLORS } from '../../../styles/theme/colors'
+import { useTheme } from '@mui/material/styles'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { trimLongString } from '../../utils/trimLongString'
 
 const clipboardTooltipDuration = 2000
 
@@ -56,6 +59,9 @@ type CopyToClipboardProps = CopyToClipboardButtonProps & {
 export const CopyToClipboard: FC<CopyToClipboardProps> = ({ label, value }) => {
   let timeout = useRef<number | undefined>(undefined)
   const [isCopied, setIsCopied] = useState(false)
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+
   const handleCopyToClipboard = useCallback(() => {
     if (isCopied) {
       return
@@ -78,7 +84,7 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({ label, value }) => {
       onClick={handleCopyToClipboard}
       sx={{ display: 'inline-flex', alignItems: 'center' }}
     >
-      {label || value}
+      {label || (isMobile ? trimLongString(value) : value)}
       <CopyToClipboardButton value={value} />
     </Box>
   )

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -18,8 +18,7 @@ import { AccountLink } from '../../components/Account/AccountLink'
 import { Divider } from '@mui/material'
 import Alert from '@mui/material/Alert'
 import { styled } from '@mui/material/styles'
-import { trimLongString } from '../../utils/trimLongString'
-import { CopyToClipboardButton } from '../../components/CopyToClipboard'
+import { CopyToClipboard } from '../../components/CopyToClipboard'
 
 type TransactionSelectionResult = {
   wantedTransaction?: RuntimeTransaction
@@ -113,8 +112,7 @@ export const TransactionDetailPage: FC = () => {
           <StyledDescriptionList titleWidth="200px">
             <dt>{t('common.hash')}</dt>
             <dd>
-              {isMobile ? trimLongString(transaction.hash) : transaction.hash}
-              <CopyToClipboardButton value={transaction.hash} />
+              <CopyToClipboard value={transaction.hash} />
             </dd>
 
             <dt>{t('common.status')}</dt>

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -19,7 +19,7 @@ import { Divider } from '@mui/material'
 import Alert from '@mui/material/Alert'
 import { styled } from '@mui/material/styles'
 import { trimLongString } from '../../utils/trimLongString'
-import { CopyToClipboard } from '../../components/CopyToClipboard'
+import { CopyToClipboardButton } from '../../components/CopyToClipboard'
 
 type TransactionSelectionResult = {
   wantedTransaction?: RuntimeTransaction
@@ -114,7 +114,7 @@ export const TransactionDetailPage: FC = () => {
             <dt>{t('common.hash')}</dt>
             <dd>
               {isMobile ? trimLongString(transaction.hash) : transaction.hash}
-              <CopyToClipboard value={transaction.hash} label={' '} />
+              <CopyToClipboardButton value={transaction.hash} />
             </dd>
 
             <dt>{t('common.status')}</dt>
@@ -139,14 +139,16 @@ export const TransactionDetailPage: FC = () => {
 
             <dt>{t('common.from')}</dt>
             <dd>
-              <AccountLink address={transaction.sender_0} paratime={ParaTime.Emerald} />
-              <CopyToClipboard value={transaction.sender_0} label={' '} />
+              <AccountLink
+                address={transaction.sender_0}
+                paratime={ParaTime.Emerald}
+                copyToClipboard={true}
+              />
             </dd>
 
             <dt>{t('common.to')}</dt>
             <dd>
-              <AccountLink address={transaction.to!} paratime={ParaTime.Emerald} />
-              <CopyToClipboard value={transaction.to!} label={' '} />
+              <AccountLink address={transaction.to!} paratime={ParaTime.Emerald} copyToClipboard={true} />
             </dd>
 
             <dt>{t('common.value')}</dt>


### PR DESCRIPTION
This is a follow up to #103.

- Improve `CopyToClipboard` functionality:
  - Also offer the functionality as just a button, with no label
  - Automatically shorten value on mobile screen
- Integrate CopyToClipboard functionality to `AccountLink`
- Simplify how we copy data to the clipboard on the TX details page.
