### PR TITLE
Handle invalid pagination parameters via explicit checking

### DIFF
--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 import backgroundEmptyState from './images/background-empty-state.svg'
+import CancelIcon from '@mui/icons-material/Cancel'
 
 const StyledBox = styled(Box)(() => ({
   display: 'flex',
@@ -19,18 +20,40 @@ const StyledBox = styled(Box)(() => ({
   backgroundSize: 'cover',
 }))
 
+const StyledBoxLight = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  minHeight: '250px',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: 'cover',
+}))
+
 type EmptyStateProps = {
   description: ReactNode
   title: string
+  light?: boolean
 }
 
-export const EmptyState: FC<EmptyStateProps> = ({ description, title }) => (
-  <StyledBox>
-    <Typography component="span" sx={{ fontSize: '24px', fontWeight: 600 }}>
-      {title}
-    </Typography>
-    <Typography component="span" sx={{ fontSize: '16px' }}>
-      {description}
-    </Typography>
-  </StyledBox>
-)
+export const EmptyState: FC<EmptyStateProps> = ({ description, title, light }) => {
+  const content = (
+    <>
+      <Typography component="span" sx={{ fontSize: '24px', fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography component="span" sx={{ fontSize: '16px' }}>
+        {description}
+      </Typography>
+    </>
+  )
+  return light ? (
+    <StyledBoxLight>
+      {<CancelIcon color="error" fontSize="large" />}
+      {content}
+    </StyledBoxLight>
+  ) : (
+    <StyledBox>{content}</StyledBox>
+  )
+}

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -13,13 +13,16 @@ export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
       title: t('errors.invalidBlockHeight'),
       message: t('errors.validateURL'),
     },
-    [AppErrors.InvalidTxHash]: { title: t('errors.invalidTxHash'), message: t('errors.validateURL') },
+    [AppErrors.InvalidTxHash]: {
+      title: t('errors.invalidTxHash'),
+      message: t('errors.validateURLOrGoToFirstTab'),
+    },
   }
 
   return errorMap[error.code]
 }
 
-export const ErrorDisplay: FC<{ error: unknown }> = ({ error }) => {
+export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, light }) => {
   const { t } = useTranslation()
 
   let errorPayload: ErrorPayload
@@ -35,7 +38,7 @@ export const ErrorDisplay: FC<{ error: unknown }> = ({ error }) => {
 
   const { title, message } = errorFormatter(t, errorPayload)
 
-  return <EmptyState title={title} description={message} />
+  return <EmptyState title={title} description={message} light={light} />
 }
 
 export const RoutingErrorDisplay: FC = () => <ErrorDisplay error={useRouteError()} />

--- a/src/app/components/Table/PaginationError.tsx
+++ b/src/app/components/Table/PaginationError.tsx
@@ -6,9 +6,11 @@ import { useTheme } from '@mui/material/styles'
 import { PageLayout } from '../PageLayout'
 import { EmptyState } from '../EmptyState'
 
-export const PaginationError: FC = () => {
+export const PaginationError: FC<{ light?: boolean }> = ({ light }) => {
   const { t } = useTranslation()
-  return <EmptyState title={t('errors.invalidPageNumber')} description={t('errors.validateURL')} />
+  return (
+    <EmptyState title={t('errors.invalidPageNumber')} description={t('errors.validateURL')} light={light} />
+  )
 }
 
 export const PaginationErrorPage: FC = () => {

--- a/src/app/components/Table/PaginationError.tsx
+++ b/src/app/components/Table/PaginationError.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Divider from '@mui/material/Divider'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
+import { PageLayout } from '../PageLayout'
+import { EmptyState } from '../EmptyState'
+
+export const PaginationError: FC = () => {
+  const { t } = useTranslation()
+  return <EmptyState title={t('errors.invalidPageNumber')} description={t('errors.validateURL')} />
+}
+
+export const PaginationErrorPage: FC = () => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  return (
+    <PageLayout>
+      {!isMobile && <Divider variant="layout" />}
+      <PaginationError />
+    </PageLayout>
+  )
+}

--- a/src/app/components/Table/useSearchParamsPagination.ts
+++ b/src/app/components/Table/useSearchParamsPagination.ts
@@ -1,9 +1,28 @@
 import { To, useSearchParams } from 'react-router-dom'
 
-export function useSearchParamsPagination(paramName: string) {
+interface PaginationStatusCore {
+  valid: boolean
+}
+
+interface InvalidPaginationStatus extends PaginationStatusCore {
+  valid: false
+}
+
+interface ValidPaginationStatus extends PaginationStatusCore {
+  valid: true
+  selectedPage: number
+  linkToPage: (page: number) => To
+}
+
+export type PaginationStatus = ValidPaginationStatus | InvalidPaginationStatus
+
+export function useSearchParamsPagination(paramName: string): PaginationStatus {
   const [searchParams] = useSearchParams()
-  const selectedPage = parseInt(searchParams.get(paramName) ?? '1', 10)
-  if (isNaN(selectedPage)) throw new Error('400 Bad Request')
+  const selectedPageString = searchParams.get(paramName)
+  const selectedPage = parseInt(selectedPageString ?? '1', 10)
+  if (isNaN(selectedPage) || (!!selectedPageString && selectedPage.toString() !== selectedPageString)) {
+    return { valid: false }
+  }
 
   function linkToPage(page: number): To {
     const newSearchParams = new URLSearchParams(searchParams)
@@ -15,5 +34,5 @@ export function useSearchParamsPagination(paramName: string) {
     return { search: newSearchParams.toString() }
   }
 
-  return { selectedPage, linkToPage }
+  return { valid: true, selectedPage, linkToPage }
 }

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -10,11 +10,10 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { PaginationError } from '../../components/Table/PaginationError'
 
-export const TransactionsCard: FC = () => {
-  const { t } = useTranslation()
+const TransactionsList: FC = () => {
   const address = useLoaderData() as string
   const txsPagination = useSearchParamsPagination('page')
-  if (!txsPagination.valid) return <PaginationError />
+  if (!txsPagination.valid) return <PaginationError light={true} />
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
@@ -23,18 +22,25 @@ export const TransactionsCard: FC = () => {
   })
 
   return (
+    <Transactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+      pagination={{
+        selectedPage: txsPagination.selectedPage,
+        linkToPage: txsPagination.linkToPage,
+      }}
+    />
+  )
+}
+
+export const TransactionsCard: FC = () => {
+  const { t } = useTranslation()
+  return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('account.transactionsListTitle')} />
       <CardContent>
-        <Transactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-          pagination={{
-            selectedPage: txsPagination.selectedPage,
-            linkToPage: txsPagination.linkToPage,
-          }}
-        />
+        <TransactionsList />
       </CardContent>
     </Card>
   )

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -8,11 +8,13 @@ import { Transactions } from '../../components/Transactions'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { PaginationError } from '../../components/Table/PaginationError'
 
 export const TransactionsCard: FC = () => {
   const { t } = useTranslation()
   const address = useLoaderData() as string
   const txsPagination = useSearchParamsPagination('page')
+  if (!txsPagination.valid) return <PaginationError />
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -8,10 +8,12 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { Transactions } from '../../components/Transactions'
+import { PaginationError } from '../../components/Table/PaginationError'
 
 export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) => {
   const { t } = useTranslation()
   const txsPagination = useSearchParamsPagination('page')
+  if (!txsPagination.valid) return <PaginationError />
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
     block: blockHeight,

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -10,10 +10,9 @@ import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { Transactions } from '../../components/Transactions'
 import { PaginationError } from '../../components/Table/PaginationError'
 
-export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) => {
-  const { t } = useTranslation()
+const TransactionsList: FC<{ blockHeight: number }> = ({ blockHeight }) => {
   const txsPagination = useSearchParamsPagination('page')
-  if (!txsPagination.valid) return <PaginationError />
+  if (!txsPagination.valid) return <PaginationError light={true} />
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
     block: blockHeight,
@@ -21,18 +20,25 @@ export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) =
     offset: txsOffset,
   })
   return (
+    <Transactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+      pagination={{
+        selectedPage: txsPagination.selectedPage,
+        linkToPage: txsPagination.linkToPage,
+      }}
+    />
+  )
+}
+
+export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) => {
+  const { t } = useTranslation()
+  return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('common.transactions')} />
       <CardContent>
-        <Transactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-          pagination={{
-            selectedPage: txsPagination.selectedPage,
-            linkToPage: txsPagination.linkToPage,
-          }}
-        />
+        <TransactionsList blockHeight={blockHeight} />
       </CardContent>
     </Card>
   )

--- a/src/app/pages/BlocksPage/index.tsx
+++ b/src/app/pages/BlocksPage/index.tsx
@@ -10,6 +10,7 @@ import { useGetEmeraldBlocks } from '../../../oasis-indexer/api'
 import { Blocks, TableRuntimeBlockList } from '../../components/Blocks'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, REFETCH_INTERVAL } from '../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { PaginationErrorPage } from '../../components/Table/PaginationError'
 
 const PAGE_SIZE = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -18,6 +19,7 @@ export const BlocksPage: FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
+  if (!pagination.valid) return <PaginationErrorPage />
   const offset = (pagination.selectedPage - 1) * PAGE_SIZE
 
   const blocksQuery = useGetEmeraldBlocks<AxiosResponse<TableRuntimeBlockList>>(

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -10,6 +10,7 @@ import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, REFETCH_INTERVAL } from '../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { AxiosResponse } from 'axios'
+import { PaginationErrorPage } from '../../components/Table/PaginationError'
 
 const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -18,6 +19,7 @@ export const TransactionsPage: FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const pagination = useSearchParamsPagination('page')
+  if (!pagination.valid) return <PaginationErrorPage />
   const offset = (pagination.selectedPage - 1) * limit
 
   const transactionsQuery = useGetEmeraldTransactions<AxiosResponse<TableRuntimeTransactionList>>(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -69,7 +69,8 @@
     "invalidBlockHeight": "Invalid block height",
     "invalidTxHash": "Invalid transaction hash",
     "txNotFound": "Transaction not found",
-    "validateURL": "Please validate provided URL"
+    "validateURL": "Please validate provided URL",
+    "validateURLOrGoToFirstTab": "Please check the URL or load the first tab."
   },
   "footer": {
     "mobileTitle": "OPF",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -67,6 +67,7 @@
     "unknown": "Unknown error",
     "invalidAddress": "Invalid address",
     "invalidBlockHeight": "Invalid block height",
+    "invalidPageNumber": "Invalid page number",
     "invalidTxHash": "Invalid transaction hash",
     "txNotFound": "Transaction not found",
     "validateURL": "Please validate provided URL",


### PR DESCRIPTION
~**This depends on #124. (That's the first commit.) Please merge that one first, then rebase.**~

This implementation teaches the pagination hook to return an explicit invalid flag, when encountering an invalid page number.

## Analysis:
 * The drawback is that the happy path and the error path are not completely separated.
 * The benefits is that there is TypeScript-level check to make sure that we don't forget to add the error path. 
![image](https://user-images.githubusercontent.com/2093792/218024256-c8e2d91e-0d4a-4117-adca-1b1eea06bd03.png)


See #121 for an alternative, using an exception and React Router's error catching feature.