### PR TITLE
Handle invalid pagination parameters via exceptions

### DIFF
--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 import backgroundEmptyState from './images/background-empty-state.svg'
+import CancelIcon from '@mui/icons-material/Cancel'
 
 const StyledBox = styled(Box)(() => ({
   display: 'flex',
@@ -19,18 +20,40 @@ const StyledBox = styled(Box)(() => ({
   backgroundSize: 'cover',
 }))
 
+const StyledBoxLight = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  minHeight: '250px',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: 'cover',
+}))
+
 type EmptyStateProps = {
   description: ReactNode
   title: string
+  light?: boolean
 }
 
-export const EmptyState: FC<EmptyStateProps> = ({ description, title }) => (
-  <StyledBox>
-    <Typography component="span" sx={{ fontSize: '24px', fontWeight: 600 }}>
-      {title}
-    </Typography>
-    <Typography component="span" sx={{ fontSize: '16px' }}>
-      {description}
-    </Typography>
-  </StyledBox>
-)
+export const EmptyState: FC<EmptyStateProps> = ({ description, title, light }) => {
+  const content = (
+    <>
+      <Typography component="span" sx={{ fontSize: '24px', fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography component="span" sx={{ fontSize: '16px' }}>
+        {description}
+      </Typography>
+    </>
+  )
+  return light ? (
+    <StyledBoxLight>
+      {<CancelIcon color="error" fontSize="large" />}
+      {content}
+    </StyledBoxLight>
+  ) : (
+    <StyledBox>{content}</StyledBox>
+  )
+}

--- a/src/app/components/ErrorBoundary/index.tsx
+++ b/src/app/components/ErrorBoundary/index.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { ErrorDisplay } from '../ErrorDisplay'
+
+type HasChildren = {
+  children: React.ReactNode
+}
+
+type ErrorBoundaryProps = HasChildren & {
+  light?: boolean
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  { hasError: boolean; error?: unknown }
+> {
+  constructor(props: HasChildren) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, error }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorDisplay error={this.state.error} light={this.props.light} />
+    }
+
+    return this.props.children
+  }
+}

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -19,7 +19,7 @@ export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
   return errorMap[error.code]
 }
 
-export const ErrorDisplay: FC<{ error: unknown }> = ({ error }) => {
+export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, light }) => {
   const { t } = useTranslation()
 
   let errorPayload: ErrorPayload
@@ -35,7 +35,7 @@ export const ErrorDisplay: FC<{ error: unknown }> = ({ error }) => {
 
   const { title, message } = errorFormatter(t, errorPayload)
 
-  return <EmptyState title={title} description={message} />
+  return <EmptyState title={title} description={message} light={light} />
 }
 
 export const RoutingErrorDisplay: FC = () => <ErrorDisplay error={useRouteError()} />

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -5,18 +5,20 @@ import { EmptyState } from '../EmptyState'
 import { AppError, AppErrors, ErrorPayload } from '../../../types/errors'
 import { TFunction } from 'i18next'
 
-export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
-  const errorMap: { [code in AppErrors]: { title: string; message: string } } = {
-    [AppErrors.Unknown]: { title: t('errors.unknown'), message: error.message },
-    [AppErrors.InvalidAddress]: { title: t('errors.invalidAddress'), message: t('errors.validateURL') },
-    [AppErrors.InvalidBlockHeight]: {
-      title: t('errors.invalidBlockHeight'),
-      message: t('errors.validateURL'),
-    },
-    [AppErrors.InvalidTxHash]: { title: t('errors.invalidTxHash'), message: t('errors.validateURL') },
-  }
+type FormattedError = { title: string; message: string }
 
-  return errorMap[error.code]
+const errorMap: Record<AppErrors, (t: TFunction, error: ErrorPayload) => FormattedError> = {
+  [AppErrors.Unknown]: (t, error) => ({ title: t('errors.unknown'), message: error.message }),
+  [AppErrors.InvalidAddress]: t => ({ title: t('errors.invalidAddress'), message: t('errors.validateURL') }),
+  [AppErrors.InvalidBlockHeight]: t => ({
+    title: t('errors.invalidBlockHeight'),
+    message: t('errors.validateURL'),
+  }),
+  [AppErrors.InvalidTxHash]: t => ({ title: t('errors.invalidTxHash'), message: t('errors.validateURL') }),
+}
+
+export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
+  return errorMap[error.code](t, error)
 }
 
 export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, light }) => {
@@ -29,6 +31,8 @@ export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, l
     errorPayload = { code: error.type, message: error.message }
   } else if (error instanceof Error) {
     errorPayload = { code: AppErrors.Unknown, message: error.message }
+  } else if (typeof error === 'string' && errorMap[error as AppErrors]) {
+    errorPayload = { code: error as AppErrors, message: 'oops' }
   } else {
     errorPayload = { code: AppErrors.Unknown, message: error as string }
   }

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -17,7 +17,7 @@ const errorMap: Record<AppErrors, (t: TFunction, error: ErrorPayload) => Formatt
   [AppErrors.InvalidTxHash]: t => ({ title: t('errors.invalidTxHash'), message: t('errors.validateURL') }),
   [AppErrors.InvalidPageNumber]: t => ({
     title: t('errors.invalidPageNumber'),
-    message: t('errors.validateURL'),
+    message: t('errors.validateURLOrGoToFirstTab'),
   }),
 }
 

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
+import { isRouteErrorResponse } from 'react-router-dom'
 import { EmptyState } from '../EmptyState'
 import { AppError, AppErrors, ErrorPayload } from '../../../types/errors'
 import { TFunction } from 'i18next'
@@ -45,5 +45,3 @@ export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, l
 
   return <EmptyState title={title} description={message} light={light} />
 }
-
-export const RoutingErrorDisplay: FC = () => <ErrorDisplay error={useRouteError()} />

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -15,6 +15,10 @@ const errorMap: Record<AppErrors, (t: TFunction, error: ErrorPayload) => Formatt
     message: t('errors.validateURL'),
   }),
   [AppErrors.InvalidTxHash]: t => ({ title: t('errors.invalidTxHash'), message: t('errors.validateURL') }),
+  [AppErrors.InvalidPageNumber]: t => ({
+    title: t('errors.invalidPageNumber'),
+    message: t('errors.validateURL'),
+  }),
 }
 
 export const errorFormatter = (t: TFunction, error: ErrorPayload) => {

--- a/src/app/components/Table/useSearchParamsPagination.ts
+++ b/src/app/components/Table/useSearchParamsPagination.ts
@@ -1,9 +1,16 @@
 import { To, useSearchParams } from 'react-router-dom'
+import { AppErrors } from '../../../types/errors'
 
 export function useSearchParamsPagination(paramName: string) {
   const [searchParams] = useSearchParams()
-  const selectedPage = parseInt(searchParams.get(paramName) ?? '1', 10)
-  if (isNaN(selectedPage)) throw new Error('400 Bad Request')
+  const selectedPageString = searchParams.get(paramName)
+  const selectedPage = parseInt(selectedPageString ?? '1', 10)
+  if (isNaN(selectedPage) || (!!selectedPageString && selectedPage.toString() !== selectedPageString)) {
+    // This would be nicer, but this would also trigger react-error-overlay (besides our error boundary).
+    // We don't want that, so now, we are stuck with throwing a string, instead of a proper error.
+    // throw new AppError(AppErrors.InvalidPageNumber)
+    throw AppErrors.InvalidPageNumber
+  }
 
   function linkToPage(page: number): To {
     const newSearchParams = new URLSearchParams(searchParams)

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -8,10 +8,9 @@ import { Transactions } from '../../components/Transactions'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
-export const TransactionsCard: FC = () => {
-  const { t } = useTranslation()
-  const address = useLoaderData() as string
+export const TransactionsList: FC<{ address: string }> = ({ address }) => {
   const txsPagination = useSearchParamsPagination('page')
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
@@ -19,20 +18,29 @@ export const TransactionsCard: FC = () => {
     offset: txsOffset,
     rel: address,
   })
+  return (
+    <Transactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+      pagination={{
+        selectedPage: txsPagination.selectedPage,
+        linkToPage: txsPagination.linkToPage,
+      }}
+    />
+  )
+}
 
+export const TransactionsCard: FC = () => {
+  const { t } = useTranslation()
+  const address = useLoaderData() as string
   return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('account.transactionsListTitle')} />
       <CardContent>
-        <Transactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-          pagination={{
-            selectedPage: txsPagination.selectedPage,
-            linkToPage: txsPagination.linkToPage,
-          }}
-        />
+        <ErrorBoundary light={true}>
+          <TransactionsList address={address} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -8,9 +8,9 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { useGetEmeraldTransactions } from '../../../oasis-indexer/api'
 import { Transactions } from '../../components/Transactions'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
-export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) => {
-  const { t } = useTranslation()
+const TransactionList: FC<{ blockHeight: number }> = ({ blockHeight }) => {
   const txsPagination = useSearchParamsPagination('page')
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   const transactionsQuery = useGetEmeraldTransactions({
@@ -18,19 +18,29 @@ export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) =
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
     offset: txsOffset,
   })
+
+  return (
+    <Transactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+      pagination={{
+        selectedPage: txsPagination.selectedPage,
+        linkToPage: txsPagination.linkToPage,
+      }}
+    />
+  )
+}
+
+export const TransactionsCard: FC<{ blockHeight: number }> = ({ blockHeight }) => {
+  const { t } = useTranslation()
   return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('common.transactions')} />
       <CardContent>
-        <Transactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-          pagination={{
-            selectedPage: txsPagination.selectedPage,
-            linkToPage: txsPagination.linkToPage,
-          }}
-        />
+        <ErrorBoundary light={true}>
+          <TransactionList blockHeight={blockHeight} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -13,6 +13,7 @@ import { CopyToClipboard } from '../../components/CopyToClipboard'
 
 import { useFormattedTimestampString } from '../../hooks/useFormattedTimestamp'
 import { TransactionsCard } from './TransactionsCard'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 // TODO: replace with an appropriate API
 function useGetEmeraldBlockByHeight(blockHeight: number) {
@@ -32,7 +33,9 @@ export const BlockDetailPage: FC = () => {
   return (
     <PageLayout>
       <BlockDetailView isLoading={isLoading} block={block}></BlockDetailView>
-      <TransactionsCard blockHeight={blockHeight} />
+      <ErrorBoundary>
+        <TransactionsCard blockHeight={blockHeight} />
+      </ErrorBoundary>
     </PageLayout>
   )
 }

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -13,7 +13,6 @@ import { CopyToClipboard } from '../../components/CopyToClipboard'
 
 import { useFormattedTimestampString } from '../../hooks/useFormattedTimestamp'
 import { TransactionsCard } from './TransactionsCard'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 // TODO: replace with an appropriate API
 function useGetEmeraldBlockByHeight(blockHeight: number) {
@@ -33,9 +32,7 @@ export const BlockDetailPage: FC = () => {
   return (
     <PageLayout>
       <BlockDetailView isLoading={isLoading} block={block}></BlockDetailView>
-      <ErrorBoundary>
-        <TransactionsCard blockHeight={blockHeight} />
-      </ErrorBoundary>
+      <TransactionsCard blockHeight={blockHeight} />
     </PageLayout>
   )
 }

--- a/src/app/pages/RoutingErrorPage/index.tsx
+++ b/src/app/pages/RoutingErrorPage/index.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react'
 import Divider from '@mui/material/Divider'
 import { PageLayout } from '../../components/PageLayout'
-import { RoutingErrorDisplay } from '../../components/ErrorDisplay'
+import { ErrorDisplay } from '../../components/ErrorDisplay'
+import { useRouteError } from 'react-router-dom'
 
 export const RoutingErrorPage: FC = () => {
   return (
     <PageLayout>
       <Divider variant="layout" />
-      <RoutingErrorDisplay />
+      <ErrorDisplay error={useRouteError()} />
     </PageLayout>
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -67,6 +67,7 @@
     "unknown": "Unknown error",
     "invalidAddress": "Invalid address",
     "invalidBlockHeight": "Invalid block height",
+    "invalidPageNumber": "Invalid page number",
     "invalidTxHash": "Invalid transaction hash",
     "txNotFound": "Transaction not found",
     "validateURL": "Please validate provided URL"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -70,7 +70,8 @@
     "invalidPageNumber": "Invalid page number",
     "invalidTxHash": "Invalid transaction hash",
     "txNotFound": "Transaction not found",
-    "validateURL": "Please validate provided URL"
+    "validateURL": "Please validate provided URL",
+    "validateURLOrGoToFirstTab": "Please check the URL or load the first tab."
   },
   "footer": {
     "mobileTitle": "OPF",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -18,64 +18,64 @@ import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
 
 export const routes: RouteObject[] = [
   {
-    path: '/',
-    element: <HomePage />,
-  },
-  ...RouteUtils.getEnabledParaTimes()
-    .map(paraTime => [
+    errorElement: <RoutingErrorPage />,
+    children: [
       {
-        path: `/${paraTime}`,
-        element: <DashboardPage />,
+        path: '/',
+        element: <HomePage />,
       },
+      ...RouteUtils.getEnabledParaTimes()
+        .map(paraTime => [
+          {
+            path: `/${paraTime}`,
+            element: <DashboardPage />,
+          },
+          {
+            path: `/${paraTime}/blocks`,
+            element: <BlocksPage />,
+          },
+          {
+            path: `/${paraTime}/blocks/:blockHeight`,
+            element: <BlockDetailPage />,
+            loader: blockHeightParamLoader,
+          },
+          {
+            path: `${paraTime}/account/:address`,
+            element: <AccountDetailsPage />,
+            loader: addressParamLoader,
+            children: [
+              {
+                path: '',
+                element: <TransactionsCard />,
+                loader: addressParamLoader,
+              },
+              {
+                path: 'tokens/erc-20',
+                element: <TokensCard type="ERC20" />,
+                loader: addressParamLoader,
+              },
+              {
+                path: 'tokens/erc-721',
+                element: <TokensCard type="ERC721" />,
+                loader: addressParamLoader,
+              },
+            ],
+          },
+          {
+            path: `/${paraTime}/transactions`,
+            element: <TransactionsPage />,
+          },
+          {
+            path: `${paraTime}/transactions/:hash`,
+            element: <TransactionDetailPage />,
+            loader: transactionParamLoader,
+          },
+        ])
+        .flat(),
       {
-        path: `/${paraTime}/blocks`,
-        element: <BlocksPage />,
-        errorElement: <RoutingErrorPage />,
-      },
-      {
-        path: `/${paraTime}/blocks/:blockHeight`,
+        path: `/blocks/:blockHeight`,
         element: <BlockDetailPage />,
-        errorElement: <RoutingErrorPage />,
-        loader: blockHeightParamLoader,
       },
-      {
-        path: `${paraTime}/account/:address`,
-        element: <AccountDetailsPage />,
-        errorElement: <RoutingErrorPage />,
-        loader: addressParamLoader,
-        children: [
-          {
-            path: '',
-            element: <TransactionsCard />,
-            loader: addressParamLoader,
-          },
-          {
-            path: 'tokens/erc-20',
-            element: <TokensCard type="ERC20" />,
-            loader: addressParamLoader,
-          },
-          {
-            path: 'tokens/erc-721',
-            element: <TokensCard type="ERC721" />,
-            loader: addressParamLoader,
-          },
-        ],
-      },
-      {
-        path: `/${paraTime}/transactions`,
-        element: <TransactionsPage />,
-        errorElement: <RoutingErrorPage />,
-      },
-      {
-        path: `${paraTime}/transactions/:hash`,
-        element: <TransactionDetailPage />,
-        errorElement: <RoutingErrorPage />,
-        loader: transactionParamLoader,
-      },
-    ])
-    .flat(),
-  {
-    path: `/blocks/:blockHeight`,
-    element: <BlockDetailPage />,
+    ],
   },
 ]

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,6 +15,7 @@ import {
   transactionParamLoader,
 } from './app/utils/route-utils'
 import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
+import { RoutingErrorDisplay } from './app/components/ErrorDisplay'
 
 export const routes: RouteObject[] = [
   {
@@ -30,6 +31,7 @@ export const routes: RouteObject[] = [
       {
         path: `/${paraTime}/blocks`,
         element: <BlocksPage />,
+        errorElement: <RoutingErrorPage />,
       },
       {
         path: `/${paraTime}/blocks/:blockHeight`,
@@ -47,6 +49,7 @@ export const routes: RouteObject[] = [
             path: '',
             element: <TransactionsCard />,
             loader: addressParamLoader,
+            errorElement: <RoutingErrorDisplay />,
           },
           {
             path: 'tokens/erc-20',
@@ -63,6 +66,7 @@ export const routes: RouteObject[] = [
       {
         path: `/${paraTime}/transactions`,
         element: <TransactionsPage />,
+        errorElement: <RoutingErrorPage />,
       },
       {
         path: `${paraTime}/transactions/:hash`,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,7 +15,6 @@ import {
   transactionParamLoader,
 } from './app/utils/route-utils'
 import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
-import { RoutingErrorDisplay } from './app/components/ErrorDisplay'
 
 export const routes: RouteObject[] = [
   {
@@ -49,7 +48,6 @@ export const routes: RouteObject[] = [
             path: '',
             element: <TransactionsCard />,
             loader: addressParamLoader,
-            errorElement: <RoutingErrorDisplay />,
           },
           {
             path: 'tokens/erc-20',

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -9,6 +9,7 @@ export enum AppErrors {
   InvalidAddress = 'invalid_address',
   InvalidBlockHeight = 'invalid_block_height',
   InvalidTxHash = 'invalid_tx_hash',
+  InvalidPageNumber = 'invalid_page_number',
 }
 
 export interface ErrorPayload {


### PR DESCRIPTION
~**This depends on #124. (That's the first commit.) Please merge that one first, then rebase.**~

This is an alternate implementation of #119. (We only need one of them.)

This time we throw an error from the pagination hook, and apply React Router's `errorElement` feature to catch it.

## Analysis:
* The benefit is that the happy path and the error path are completely separated.
* The drawback is that there is no TypeScript-level test to verify that the errorElement (or some other error boundary) is always there.
