### PR TITLE
Rename things to avoid confusion around error boundaries

### DIFF
--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -19,9 +19,8 @@ export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
   return errorMap[error.code]
 }
 
-export const ErrorBoundary: FC = () => {
+export const ErrorDisplay: FC<{ error: unknown }> = ({ error }) => {
   const { t } = useTranslation()
-  const error = useRouteError()
 
   let errorPayload: ErrorPayload
   if (isRouteErrorResponse(error)) {
@@ -38,3 +37,5 @@ export const ErrorBoundary: FC = () => {
 
   return <EmptyState title={title} description={message} />
 }
+
+export const RoutingErrorDisplay: FC = () => <ErrorDisplay error={useRouteError()} />

--- a/src/app/pages/RoutingErrorPage/index.tsx
+++ b/src/app/pages/RoutingErrorPage/index.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react'
 import Divider from '@mui/material/Divider'
 import { PageLayout } from '../../components/PageLayout'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { RoutingErrorDisplay } from '../../components/ErrorDisplay'
 
-export const ErrorPage: FC = () => {
+export const RoutingErrorPage: FC = () => {
   return (
     <PageLayout>
       <Divider variant="layout" />
-      <ErrorBoundary />
+      <RoutingErrorDisplay />
     </PageLayout>
   )
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,7 +14,7 @@ import {
   blockHeightParamLoader,
   transactionParamLoader,
 } from './app/utils/route-utils'
-import { ErrorPage } from './app/pages/ErrorPage'
+import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
 
 export const routes: RouteObject[] = [
   {
@@ -34,13 +34,13 @@ export const routes: RouteObject[] = [
       {
         path: `/${paraTime}/blocks/:blockHeight`,
         element: <BlockDetailPage />,
-        errorElement: <ErrorPage />,
+        errorElement: <RoutingErrorPage />,
         loader: blockHeightParamLoader,
       },
       {
         path: `${paraTime}/account/:address`,
         element: <AccountDetailsPage />,
-        errorElement: <ErrorPage />,
+        errorElement: <RoutingErrorPage />,
         loader: addressParamLoader,
         children: [
           {
@@ -67,7 +67,7 @@ export const routes: RouteObject[] = [
       {
         path: `${paraTime}/transactions/:hash`,
         element: <TransactionDetailPage />,
-        errorElement: <ErrorPage />,
+        errorElement: <RoutingErrorPage />,
         loader: transactionParamLoader,
       },
     ])


### PR DESCRIPTION
We are React Router's `errorElement` feature to catch some errors on some routes.
We have been calling this `ErrorBoundary`, but I find this a bit confusing, since React also has a feature / concept called `ErrorBounday`, which is slightly different.

In order to avoid any confusion, I propose renaming some of our components.