### PR TITLE
Avoid exception in data transformation when there are no transactions

### DIFF
--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -32,7 +32,7 @@ export const useGetEmeraldTransactions: typeof generated.useGetEmeraldTransactio
         (data: generated.RuntimeTransactionList) => {
           return {
             ...data,
-            transactions: data.transactions.map(tx => {
+            transactions: (data.transactions || []).map(tx => {
               return {
                 ...tx,
                 fee: tx.fee ? fromBaseUnits(tx.fee, paraTimesConfig.emerald.decimals) : undefined,


### PR DESCRIPTION
When we try load transactions where there are none, sometimes we get an exception on the console.
This one-liner change fixes that.