### PR TITLE
Refactor expanded search field styling

### DIFF
--- a/src/app/components/Search/index.tsx
+++ b/src/app/components/Search/index.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, FormEvent, memo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import TextField from '@mui/material/TextField'
-import { InputAdornment } from '@mui/material'
+import InputAdornment from '@mui/material/InputAdornment'
 import { styled, useTheme } from '@mui/material/styles'
 import Button from '@mui/material/Button'
 import SearchIcon from '@mui/icons-material/Search'
@@ -41,24 +41,17 @@ const SearchForm = styled('form', {
 
 interface SearchTextFieldProps extends StandardTextFieldProps {
   searchVariant: SearchVariant
-  hasStartAdornment: boolean
 }
 
 const SearchTextField = styled(TextField, {
   shouldForwardProp: (prop: PropertyKey) =>
-    !(['searchVariant', 'hasStartAdornment'] as (keyof SearchTextFieldProps)[]).includes(
+    !(['searchVariant'] as (keyof SearchTextFieldProps)[]).includes(
       prop as keyof SearchTextFieldProps,
     ),
-})<SearchTextFieldProps>(({ theme, searchVariant, hasStartAdornment }) => ({
-  ...(hasStartAdornment
-    ? {}
-    : {
-        paddingLeft: theme.spacing(4),
-      }),
+})<SearchTextFieldProps>(({ searchVariant }) => ({
   ...(searchVariant === 'expandable'
     ? {
         ':not(:hover, :focus-within)': {
-          paddingLeft: 0,
           input: {
             display: 'none',
           },
@@ -173,7 +166,6 @@ const SearchCmp: FC<SearchProps> = ({ variant, disabled, onFocusChange }) => {
     >
       <SearchTextField
         searchVariant={variant}
-        hasStartAdornment={!!startAdornment}
         value={value}
         onChange={onChange}
         onFocus={() => onFocusChange?.(true)}

--- a/src/app/components/Search/index.tsx
+++ b/src/app/components/Search/index.tsx
@@ -153,7 +153,10 @@ const SearchCmp: FC<SearchProps> = ({ variant, disabled, onFocusChange }) => {
   }
 
   const startAdornment = variant === 'button' && (
-    <InputAdornment position="start">
+    <InputAdornment
+      position="start"
+      disablePointerEvents // Pass clicks through, so it focuses the input
+    >
       <SearchIcon sx={{ color: COLORS.grayMediumLight }} />
     </InputAdornment>
   )

--- a/src/app/components/Search/index.tsx
+++ b/src/app/components/Search/index.tsx
@@ -28,6 +28,18 @@ const SearchForm = styled('form', {
   ...(searchVariant === 'expandable'
     ? {
         position: 'absolute',
+        // Collapsed
+        ':not(:hover, :focus-within)': {
+          '.MuiTextField-root': {
+            input: {
+              display: 'none',
+            },
+            '.MuiInputAdornment-positionEnd': {
+              marginLeft: 0,
+            },
+          },
+        },
+        // Expanded
         ':hover, :focus-within': {
           left: 0,
           width: '100%',
@@ -37,42 +49,6 @@ const SearchForm = styled('form', {
         position: 'relative',
         width: '100%',
       }),
-}))
-
-interface SearchTextFieldProps extends StandardTextFieldProps {
-  searchVariant: SearchVariant
-}
-
-const SearchTextField = styled(TextField, {
-  shouldForwardProp: (prop: PropertyKey) =>
-    !(['searchVariant'] as (keyof SearchTextFieldProps)[]).includes(
-      prop as keyof SearchTextFieldProps,
-    ),
-})<SearchTextFieldProps>(({ searchVariant }) => ({
-  ...(searchVariant === 'expandable'
-    ? {
-        ':not(:hover, :focus-within)': {
-          input: {
-            display: 'none',
-          },
-        },
-      }
-    : {}),
-}))
-
-interface InputEndAdornmentProps extends StyledBaseProps {}
-
-const InputEndAdornment = styled(InputAdornment, {
-  shouldForwardProp: (prop: PropertyKey) =>
-    !(['searchVariant'] as (keyof InputEndAdornmentProps)[]).includes(prop as keyof InputEndAdornmentProps),
-})<InputEndAdornmentProps>(({ searchVariant }) => ({
-  ...(searchVariant === 'expandable'
-    ? {
-        ':not(:hover, :focus-within)': {
-          marginLeft: 0,
-        },
-      }
-    : {}),
 }))
 
 interface SearchButtonProps extends StyledBaseProps {}
@@ -164,8 +140,7 @@ const SearchCmp: FC<SearchProps> = ({ variant, disabled, onFocusChange }) => {
       role="search"
       aria-label={searchPlaceholderTranslated}
     >
-      <SearchTextField
-        searchVariant={variant}
+      <TextField
         value={value}
         onChange={onChange}
         onFocus={() => onFocusChange?.(true)}
@@ -176,7 +151,7 @@ const SearchCmp: FC<SearchProps> = ({ variant, disabled, onFocusChange }) => {
           },
           startAdornment,
           endAdornment: (
-            <InputEndAdornment position="end" searchVariant={variant}>
+            <InputAdornment position="end">
               <>
                 {variant === 'icon' && value && (
                   <IconButton color="inherit" onClick={onClearValue}>
@@ -193,7 +168,7 @@ const SearchCmp: FC<SearchProps> = ({ variant, disabled, onFocusChange }) => {
                   {searchButtonContent}
                 </SearchButton>
               </>
-            </InputEndAdornment>
+            </InputAdornment>
           ),
         }}
         placeholder={searchPlaceholderTranslated}

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -459,24 +459,22 @@ export const defaultTheme = createTheme({
     },
     MuiTextField: {
       styleOverrides: {
-        root: {
-          borderRadius: '46px',
+        root: ({ theme }) => ({
+          borderRadius: '24px',
+          '.MuiInputBase-root > :first-child': {
+            // Prevent first child's edges overflowing due to border-radius
+            marginLeft: theme.spacing(4),
+          },
           ':focus-within': {
             boxShadow: '0px 4px 50px 15px rgba(0, 0, 98, 0.54)',
           },
           backgroundColor: COLORS.white,
           transition: 'box-shadow 250ms ease-in-out',
-        },
+        }),
       },
     },
     MuiInputAdornment: {
       variants: [
-        {
-          props: { position: 'start' },
-          style: ({ theme }) => ({
-            padding: theme.spacing(4),
-          }),
-        },
         {
           props: { position: 'end' },
           style: {


### PR DESCRIPTION
- Collapsing and expanding logic is all in one place
- Clicking the search icon now passes through and focuses search field
- Reduced search icon padding

| Before | After |
| --- | --- |
| ![localhost_1234_ (1)](https://user-images.githubusercontent.com/3758846/218465924-4f69d7af-693d-4d2c-80f2-a2c2562f75fb.png)  |  ![localhost_1234_](https://user-images.githubusercontent.com/3758846/218465922-ba861b0a-6f63-4a32-b25d-85b036b573e1.png)
 |