### PR TITLE
Fix emotion's runtime error that :first-child is unsafe for SSR

### DIFF
--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -460,9 +460,14 @@ export const defaultTheme = createTheme({
       styleOverrides: {
         root: ({ theme }) => ({
           borderRadius: '24px',
-          '.MuiInputBase-root > :first-child': {
+          '.MuiInputBase-root': {
             // Prevent first child's edges overflowing due to border-radius
-            marginLeft: theme.spacing(4),
+            '&.MuiInputBase-adornedStart .MuiInputAdornment-positionStart': {
+              marginLeft: theme.spacing(4),
+            },
+            '&:not(.MuiInputBase-adornedStart) .MuiInputBase-input': {
+              marginLeft: theme.spacing(4),
+            },
           },
           ':focus-within': {
             boxShadow: '0px 4px 50px 15px rgba(0, 0, 98, 0.54)',


### PR DESCRIPTION
Fixes e1950fc8b29c0e10539117627d835848e337cf0d from https://github.com/oasisprotocol/explorer/pull/126

`The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".`