### PR TITLE
Account details: add missing rows 

### DIFF
--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -11,7 +11,11 @@ import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { JazzIcon } from '../../components/JazzIcon'
 import { CoinGeckoReferral } from '../../components/CoinGeckoReferral'
 import { trimLongString } from '../../utils/trimLongString'
-import { type Account as AccountDetailsProps } from '../../../oasis-indexer/api'
+import {
+  type Account as AccountDetailsProps,
+  type RuntimeSdkBalance,
+  RuntimeName,
+} from '../../../oasis-indexer/api'
 import { TokenPills } from './TokenPills'
 import { COLORS } from '../../../styles/theme/colors'
 
@@ -35,11 +39,16 @@ type AccountProps = {
   roseFiatValue?: number
 }
 
+const getChainBalance = (runtime: string, balance?: RuntimeSdkBalance[]) => {
+  const chainBalance = balance?.find(chain => chain.runtime === runtime)
+  return chainBalance?.balance || '0'
+}
+
 export const Account: FC<AccountProps> = ({ account, roseFiatValue }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const mockedRuntimeBalance = 1000 // TODO: replace with real value when API is ready
+  const balance = getChainBalance(RuntimeName.emerald, account.runtime_sdk_balances)
 
   return (
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
@@ -56,15 +65,19 @@ export const Account: FC<AccountProps> = ({ account, roseFiatValue }) => {
           value={account.address}
         />
       </dd>
+
       <dt>{t('account.chain')}</dt>
       <dd>{t('common.emerald')}</dd>
+
+      <dt>{t('common.balance')}</dt>
+      <dd>{t('common.valueInRose', { value: balance })}</dd>
       {roseFiatValue && (
         <>
           <dt>{t('common.fiatValue')}</dt>
           <dd>
             <StyledBox>
               {t('common.fiatValueInUSD', {
-                value: mockedRuntimeBalance * roseFiatValue,
+                value: parseFloat(balance) * roseFiatValue,
                 formatParams: {
                   value: {
                     currency: 'USD',
@@ -76,14 +89,18 @@ export const Account: FC<AccountProps> = ({ account, roseFiatValue }) => {
           </dd>
         </>
       )}
+
       <dt>{t('common.transactions')}</dt>
       <dd>{/* TODO: waiting for API update */}</dd>
+
       <dt>{t('account.evmTokens')}</dt>
       <dd>
         <TokenPills tokens={account.runtime_evm_balances} />
       </dd>
+
       <dt>{t('account.totalReceived')}</dt>
       <dd>{/* TODO: waiting for API update */}</dd>
+
       <dt>{t('account.totalSent')}</dt>
       <dd>{/* TODO: waiting for API update */}</dd>
     </StyledDescriptionList>

--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -56,6 +56,8 @@ export const Account: FC<AccountProps> = ({ account, roseFiatValue }) => {
           value={account.address}
         />
       </dd>
+      <dt>{t('account.chain')}</dt>
+      <dd>{t('common.emerald')}</dd>
       {roseFiatValue && (
         <>
           <dt>{t('common.fiatValue')}</dt>
@@ -74,10 +76,16 @@ export const Account: FC<AccountProps> = ({ account, roseFiatValue }) => {
           </dd>
         </>
       )}
+      <dt>{t('common.transactions')}</dt>
+      <dd>{/* TODO: waiting for API update */}</dd>
       <dt>{t('account.evmTokens')}</dt>
       <dd>
         <TokenPills tokens={account.runtime_evm_balances} />
       </dd>
+      <dt>{t('account.totalReceived')}</dt>
+      <dd>{/* TODO: waiting for API update */}</dd>
+      <dt>{t('account.totalSent')}</dt>
+      <dd>{/* TODO: waiting for API update */}</dd>
     </StyledDescriptionList>
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "account": {
+    "chain": "Chain",
     "emptyTokenList": "This account holds no {{token}} tokens.",
     "ERC20": "ERC-20",
     "ERC721": "ERC-721",
@@ -8,7 +9,9 @@
     "title": "Account",
     "evmTokens": "EVM tokens",
     "tokensListTitle": "{{token}} Tokens",
-    "transactionsListTitle": "Account Transactions"
+    "transactionsListTitle": "Account Transactions",
+    "totalReceived": "Total Received",
+    "totalSent": "Total Sent"
   },
   "averageTransactionSize": {
     "header": "Average Transaction Size",

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -67,6 +67,12 @@ export const useGetConsensusAccountsAddress: typeof generated.useGetConsensusAcc
                 balance: token.balance ? fromBaseUnits(token.balance, token.token_decimals) : undefined,
               }
             }),
+            runtime_sdk_balances: data.runtime_sdk_balances?.map(token => {
+              return {
+                ...token,
+                balance: token.balance ? fromBaseUnits(token.balance, token.token_decimals) : undefined,
+              }
+            }),
           }
         },
         ...arrayify(options?.axios?.transformResponse),


### PR DESCRIPTION
We still don't have data in API for three rows, but all of them are required for MVP anyway. 