### PR TITLE
Improve charts

### DIFF
--- a/src/app/components/charts/BarChart.tsx
+++ b/src/app/components/charts/BarChart.tsx
@@ -12,7 +12,7 @@ import { COLORS } from '../../../styles/theme/colors'
 
 interface BarChartProps<T extends object> extends Formatters {
   data: T[]
-  dataKey: keyof T
+  dataKey: Extract<keyof T, string>
 }
 
 const BarChartCmp = <T extends object>({ data, dataKey, formatters }: BarChartProps<T>) => (
@@ -33,7 +33,7 @@ const BarChartCmp = <T extends object>({ data, dataKey, formatters }: BarChartPr
         content={<TooltipContent formatters={formatters} />}
         offset={15}
       />
-      <Bar dataKey={dataKey as string} barSize={12} fill={COLORS.denimBlue} radius={[10, 10, 0, 0]} />
+      <Bar dataKey={dataKey} barSize={12} fill={COLORS.denimBlue} radius={[10, 10, 0, 0]} />
     </RechartsBarChart>
   </ResponsiveContainer>
 )

--- a/src/app/components/charts/LineChart.tsx
+++ b/src/app/components/charts/LineChart.tsx
@@ -14,7 +14,7 @@ import { Formatters, TooltipContent } from './Tooltip'
 interface LineChartProps<T extends object> extends Formatters {
   cartesianGrid?: boolean
   data: T[]
-  dataKey: keyof T
+  dataKey: Extract<keyof T, string>
   margin?: Margin
   strokeWidth?: number | string
   tickMargin?: number
@@ -38,7 +38,7 @@ const LineChartCmp = <T extends object>({
       {cartesianGrid && <CartesianGrid vertical={false} stroke={COLORS.antiFlashWhite3} />}
       <Line
         type="monotone"
-        dataKey={dataKey as string}
+        dataKey={dataKey}
         stroke={COLORS.brandDark}
         strokeWidth={strokeWidth}
         dot={false}

--- a/src/app/pages/DashboardPage/AverageTransactionSize.tsx
+++ b/src/app/pages/DashboardPage/AverageTransactionSize.tsx
@@ -23,7 +23,7 @@ export const AverageTransactionSize: FC = () => {
             strokeWidth={3}
             dataKey="tx_volume"
             data={dailyVolumeQuery.data?.data.buckets.slice().reverse()}
-            margin={{ left: 16, right: 0, top: 16, bottom: 16 }}
+            margin={{ left: 16, right: 0 }}
             tickMargin={16}
             withLabels={true}
             formatters={{

--- a/src/app/pages/DashboardPage/AverageTransactionSize.tsx
+++ b/src/app/pages/DashboardPage/AverageTransactionSize.tsx
@@ -22,7 +22,7 @@ export const AverageTransactionSize: FC = () => {
             cartesianGrid={true}
             strokeWidth={3}
             dataKey="tx_volume"
-            data={dailyVolumeQuery.data?.data.buckets}
+            data={dailyVolumeQuery.data?.data.buckets.slice().reverse()}
             margin={{ left: 16, right: 0, top: 16, bottom: 16 }}
             tickMargin={16}
             withLabels={true}

--- a/src/app/pages/DashboardPage/RoseChartCard.tsx
+++ b/src/app/pages/DashboardPage/RoseChartCard.tsx
@@ -67,7 +67,7 @@ export const RoseChartCard: FC<RoseChartCardProps> = ({ chartDuration }) => {
             <LineChart
               dataKey="value"
               data={lineChartData}
-              margin={{ left: 0, right: isMobile ? 80 : 40, top: 15, bottom: 15 }}
+              margin={{ left: 0, right: isMobile ? 80 : 40 }}
               formatters={{
                 data: (value: number) =>
                   t('common.fiatValueInUSD', {

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -39,7 +39,7 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
       {lineChartData && (
         <LineChart
           dataKey="volume_per_second"
-          data={lineChartData}
+          data={lineChartData.slice().reverse()}
           margin={{ left: 0, right: isMobile ? 80 : 40 }}
           formatters={{
             data: (value: number) => t('transactionsTpsChart.tooltip', { value }),

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -42,7 +42,15 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
           data={lineChartData.slice().reverse()}
           margin={{ left: 0, right: isMobile ? 80 : 40 }}
           formatters={{
-            data: (value: number) => t('transactionsTpsChart.tooltip', { value }),
+            data: (value: number) =>
+              t('transactionsTpsChart.tooltip', {
+                value,
+                formatParams: {
+                  value: {
+                    maximumFractionDigits: 2,
+                  } satisfies Intl.NumberFormatOptions,
+                },
+              }),
             label: (value: string) => intlDateFormat(new Date(value)),
           }}
         />

--- a/src/app/pages/DashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/DashboardPage/TransactionsStats.tsx
@@ -20,7 +20,7 @@ export function TransactionsStats() {
       <CardContent>
         {dailyVolumeQuery.data?.data.buckets && (
           <BarChart
-            data={dailyVolumeQuery.data?.data.buckets}
+            data={dailyVolumeQuery.data?.data.buckets.slice().reverse()}
             dataKey="tx_volume"
             formatters={{
               data: (value: number) => t('transactionStats.tooltip', { value }),

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -144,7 +144,7 @@
     "tooltip": "{{value}} tx/day"
   },
   "transactionsTpsChart": {
-    "tooltip": "{{value}} TPS"
+    "tooltip": "{{value, number}} TPS"
   },
   "select": {
     "placeholder": "Select"

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,2 +1,6 @@
 /** FigtreeVariable */
 @import '../../node_modules/@fontsource/figtree/variable.css';
+
+svg.recharts-surface {
+  overflow: visible;
+}


### PR DESCRIPTION
- Allow line and dot to overflow chart surface
- Reverse charts to display latest data on the right :exclamation:
- Format tooltip number

| Before | After |
| --- | --- |
|  ![localhost_1234_emerald (1)](https://user-images.githubusercontent.com/3758846/220233465-bbd93a5f-f23c-4f8f-bba2-f8b0f30511cd.png) |  ![localhost_1234_emerald](https://user-images.githubusercontent.com/3758846/220233463-c67555c8-efed-4b43-9bd1-2d243a9613dc.png) |
