### PR TITLE
Design feedback: latest txs/blocks

### DIFF
--- a/src/app/components/RoundedRoseValue/index.tsx
+++ b/src/app/components/RoundedRoseValue/index.tsx
@@ -6,7 +6,7 @@ type RoundedRoseValueProps = {
   value?: string
 }
 
-const numberOfDecimals = 8
+const numberOfDecimals = 5
 
 export const RoundedRoseValue: FC<RoundedRoseValueProps> = ({ value }) => {
   const { t } = useTranslation()

--- a/src/app/components/SubPageCard/index.tsx
+++ b/src/app/components/SubPageCard/index.tsx
@@ -19,7 +19,7 @@ const StyledBox = styled(Box, {
 })<StyledComponentProps>(
   ({ featured, theme }) => css`
     ${featured && {
-      margin: `-${theme.spacing(4)} -${theme.spacing(6)} ${theme.spacing(5)}`,
+      margin: `-${theme.spacing(5)} -${theme.spacing(6)} ${theme.spacing(5)}`,
       padding: `${theme.spacing(5)} ${theme.spacing(6)} ${theme.spacing(4)}`,
       borderRadius: '12px',
       boxShadow: '-20px 4px 40px rgba(34, 47, 63, 0.24)',

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -18,13 +18,14 @@ type SkeletonTableRowsProps = {
   rowsNumber: number
   columnsNumber: number
 }
-
+// in designs table row has 61px height, but we need to take into account border and padding here
+const textSkeletonHeight = 28
 const SkeletonTableRows: FC<SkeletonTableRowsProps> = ({ rowsNumber, columnsNumber }) => (
   <>
     {[...Array(rowsNumber)].map((item, index) => (
       <TableRow key={index}>
         <TableCell colSpan={columnsNumber}>
-          <Skeleton variant="text" />
+          <Skeleton variant="text" height={textSkeletonHeight} />
         </TableCell>
       </TableRow>
     ))}

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -63,8 +63,8 @@ export const Transactions: FC<TransactionProps> = ({
     { content: t('common.type') },
     { content: t('common.from'), width: '150px' },
     { content: t('common.to'), width: '150px' },
-    { content: t('common.txnFee'), align: TableCellAlign.Right },
-    { align: TableCellAlign.Right, content: t('common.value') },
+    { content: t('common.txnFee'), align: TableCellAlign.Right, width: '250px' },
+    { align: TableCellAlign.Right, content: t('common.value'), width: '250px' },
   ]
   const tableRows = transactions?.map(transaction => ({
     key: transaction.hash,

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -247,6 +247,9 @@ export const defaultTheme = createTheme({
           boxShadow: 'none',
           [theme.breakpoints.down('sm')]: {
             padding: `${theme.spacing(4)} ${theme.spacing(4)} 0`,
+            ':has(table)': {
+              paddingRight: 0,
+            },
           },
           [theme.breakpoints.up('sm')]: {
             padding: `${theme.spacing(4)} ${theme.spacing(5)} 0`,
@@ -268,7 +271,7 @@ export const defaultTheme = createTheme({
           fontWeight: 600,
           fontSize: '24px',
           margin: 0,
-          padding: `0 0 ${theme.spacing(4)} 0`,
+          padding: `0 ${theme.spacing(4)} ${theme.spacing(4)} 0`,
         }),
         action: {
           alignSelf: 'center',
@@ -370,6 +373,15 @@ export const defaultTheme = createTheme({
           backgroundColor: COLORS.brandDark,
           borderRadius: 5,
         },
+      },
+    },
+    MuiTableContainer: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          [theme.breakpoints.down('sm')]: {
+            paddingRight: theme.spacing(4),
+          },
+        }),
       },
     },
     MuiTableCell: {

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -252,7 +252,7 @@ export const defaultTheme = createTheme({
             },
           },
           [theme.breakpoints.up('sm')]: {
-            padding: `${theme.spacing(4)} ${theme.spacing(5)} 0`,
+            padding: `${theme.spacing(5)} ${theme.spacing(5)} 0`,
           },
         }),
       },


### PR DESCRIPTION
- increase global card padding
- adjust skeleton text row to stabilise table height (issue with jumping vertically)
- there is an assumption that if there is a table in a mobile card its content won't feet and we will show horizontal scroll bar. In this case card  "should extend to the right side of the screen to emphasise the horizontal scroll" (screenshot)

<img width="548" alt="Screenshot 2023-02-21 at 12 56 43" src="https://user-images.githubusercontent.com/891392/220338600-a7b6ee48-08e0-4774-b710-949496a0f701.png">
- change rounding value

issues with table jumping horizontally moved to separate PRs (rounding / font updates / not sure what else)