### PR TITLE
Fix charts height and animation

### DIFF
--- a/src/app/components/charts/BarChart.tsx
+++ b/src/app/components/charts/BarChart.tsx
@@ -30,7 +30,7 @@ const BarChartCmp = <T extends object>({
   withLabels,
   withBarBackground,
 }: BarChartProps<T>) => (
-  <ResponsiveContainer width="100%" aspect={4}>
+  <ResponsiveContainer width="100%">
     <RechartsBarChart data={data} margin={{ right: 8, bottom: 0, left: 8 }}>
       {cartesianGrid && <CartesianGrid vertical={false} stroke={COLORS.antiFlashWhite3} />}
       {withLabels && (

--- a/src/app/components/charts/LineChart.tsx
+++ b/src/app/components/charts/LineChart.tsx
@@ -33,7 +33,7 @@ const LineChartCmp = <T extends object>({
   tooltipActiveDotRadius = 5,
   withLabels,
 }: LineChartProps<T>): ReactElement => (
-  <ResponsiveContainer width="100%" aspect={4}>
+  <ResponsiveContainer width="100%">
     <RechartsLineChart data={data} margin={margin}>
       {cartesianGrid && <CartesianGrid vertical={false} stroke={COLORS.antiFlashWhite3} />}
       <Line

--- a/src/app/pages/DashboardPage/AverageTransactionSize.tsx
+++ b/src/app/pages/DashboardPage/AverageTransactionSize.tsx
@@ -15,7 +15,7 @@ export const AverageTransactionSize: FC = () => {
   return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('averageTransactionSize.header')} />
-      <CardContent>
+      <CardContent sx={{ height: 450 }}>
         {dailyVolumeQuery.data?.data.buckets && (
           <LineChart
             tooltipActiveDotRadius={9}

--- a/src/app/pages/DashboardPage/Nodes.tsx
+++ b/src/app/pages/DashboardPage/Nodes.tsx
@@ -31,7 +31,7 @@ export const Nodes: FC = () => {
         />
       }
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', pb: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <OfflineBoltIcon fontSize="large" sx={{ color: COLORS.eucalyptus, mr: 3 }} />
         <Typography component="span" sx={{ fontSize: '48px', fontWeight: 700, color: COLORS.brandDark }}>
           {t('nodes.value', { value: activeNodes })}

--- a/src/app/pages/DashboardPage/RoseChartCard.tsx
+++ b/src/app/pages/DashboardPage/RoseChartCard.tsx
@@ -62,32 +62,30 @@ export const RoseChartCard: FC<RoseChartCardProps> = ({ chartDuration }) => {
         <StyledBox>
           <CoinGeckoReferral />
         </StyledBox>
-        <Box sx={{ minHeight: '70px' }}>
-          {lineChartData && (
-            <LineChart
-              dataKey="value"
-              data={lineChartData}
-              margin={{ left: 0, right: isMobile ? 80 : 40 }}
-              formatters={{
-                data: (value: number) =>
-                  t('common.fiatValueInUSD', {
-                    value,
-                    formatParams: formatFiatRoseParams,
-                  }),
-                label: (value: string) =>
-                  t('common.formattedDateTime', {
-                    timestamp: new Date(value),
-                    formatParams: {
-                      timestamp: {
-                        dateStyle: 'short',
-                        timeStyle: 'short',
-                      } satisfies Intl.DateTimeFormatOptions,
-                    },
-                  }),
-              }}
-            />
-          )}
-        </Box>
+        {lineChartData && (
+          <LineChart
+            dataKey="value"
+            data={lineChartData}
+            margin={{ left: 0, right: isMobile ? 80 : 40 }}
+            formatters={{
+              data: (value: number) =>
+                t('common.fiatValueInUSD', {
+                  value,
+                  formatParams: formatFiatRoseParams,
+                }),
+              label: (value: string) =>
+                t('common.formattedDateTime', {
+                  timestamp: new Date(value),
+                  formatParams: {
+                    timestamp: {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    } satisfies Intl.DateTimeFormatOptions,
+                  },
+                }),
+            }}
+          />
+        )}
       </>
     </SnapshotCard>
   )

--- a/src/app/pages/DashboardPage/SnapshotCard.tsx
+++ b/src/app/pages/DashboardPage/SnapshotCard.tsx
@@ -16,9 +16,6 @@ export const StyledCard = styled(Card)(({ theme }) => ({
     padding: 0,
   },
   height: 186,
-  [theme.breakpoints.up('sm')]: {
-    height: 186,
-  },
 }))
 
 const StyledCardContent = styled(CardContent)(({ theme }) => ({

--- a/src/app/pages/DashboardPage/SnapshotCard.tsx
+++ b/src/app/pages/DashboardPage/SnapshotCard.tsx
@@ -8,19 +8,23 @@ import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 
 export const StyledCard = styled(Card)(({ theme }) => ({
+  display: 'flex',
   flex: 1,
-  // used to create a stronger selector to override default theme styles
-  [theme.breakpoints.down('sm')]: {
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  '&': {
     padding: 0,
   },
+  height: 186,
   [theme.breakpoints.up('sm')]: {
-    padding: 0,
+    height: 186,
   },
 }))
 
 const StyledCardContent = styled(CardContent)(({ theme }) => ({
   position: 'relative',
   paddingTop: theme.spacing(4),
+  height: 90,
 }))
 
 type SnapshotCardProps = PropsWithChildren & {
@@ -34,7 +38,7 @@ export const SnapshotCard: FC<SnapshotCardProps> = ({ badge, children, title, la
     <StyledCard>
       <CardHeader component="h5" title={title} sx={{ pb: 0, pl: 4, pt: 4 }} />
       <StyledCardContent>{children}</StyledCardContent>
-      <CardActions>
+      <CardActions sx={{ minHeight: 60 }}>
         <Box
           sx={{
             display: 'flex',

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -5,7 +5,7 @@ import { LineChart } from '../../components/charts/LineChart'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { intlDateFormat } from '../../utils/dateFormatter'
-import { FC, memo } from 'react'
+import { FC } from 'react'
 import { SnapshotCard } from './SnapshotCard'
 import { PercentageGain } from '../../components/PercentageGain'
 
@@ -13,19 +13,20 @@ interface TransactionsChartCardProps {
   chartDuration: ChartDuration
 }
 
-const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
+export const TransactionsChartCard: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const statsParams = durationToQueryParams[chartDuration]
-  const { data } = useGetLayerStatsTxVolume(Layer.emerald, statsParams)
+  const { data } = useGetLayerStatsTxVolume(Layer.emerald, durationToQueryParams[chartDuration])
 
-  const lineChartData = data?.data.buckets.map(bucket => {
-    return {
-      bucket_start: bucket.bucket_start,
-      volume_per_second: bucket.tx_volume / statsParams.bucket_size_seconds,
-    }
-  })
+  const lineChartData = data?.data.buckets
+    .map(bucket => {
+      return {
+        bucket_start: bucket.bucket_start,
+        volume_per_second: bucket.tx_volume / durationToQueryParams[chartDuration].bucket_size_seconds,
+      }
+    })
+    .reverse()
 
   const totalTransactions = data?.data.buckets.reduce((acc, curr) => acc + curr.tx_volume, 0) ?? 0
 
@@ -39,7 +40,7 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
       {lineChartData && (
         <LineChart
           dataKey="volume_per_second"
-          data={lineChartData.slice().reverse()}
+          data={lineChartData}
           margin={{ left: 0, right: isMobile ? 80 : 40 }}
           formatters={{
             data: (value: number) =>
@@ -58,5 +59,3 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
     </SnapshotCard>
   )
 }
-
-export const TransactionsChartCard = memo(TransactionsChartCardCmp)

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import { Layer, useGetLayerStatsTxVolume } from '../../../oasis-indexer/api'
-import { ChartDuration, durationToQueryParams } from '../../utils/chart-utils'
+import { ChartDuration, chartUseQueryStaleTimeMs, durationToQueryParams } from '../../utils/chart-utils'
 import { LineChart } from '../../components/charts/LineChart'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { intlDateFormat } from '../../utils/dateFormatter'
-import { FC } from 'react'
+import { FC, memo } from 'react'
 import { SnapshotCard } from './SnapshotCard'
 import { PercentageGain } from '../../components/PercentageGain'
 
@@ -13,20 +13,21 @@ interface TransactionsChartCardProps {
   chartDuration: ChartDuration
 }
 
-export const TransactionsChartCard: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
+const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const { data } = useGetLayerStatsTxVolume(Layer.emerald, durationToQueryParams[chartDuration])
+  const statsParams = durationToQueryParams[chartDuration]
+  const { data } = useGetLayerStatsTxVolume(Layer.emerald, statsParams, {
+    query: { staleTime: chartUseQueryStaleTimeMs },
+  })
 
-  const lineChartData = data?.data.buckets
-    .map(bucket => {
-      return {
-        bucket_start: bucket.bucket_start,
-        volume_per_second: bucket.tx_volume / durationToQueryParams[chartDuration].bucket_size_seconds,
-      }
-    })
-    .reverse()
+  const lineChartData = data?.data.buckets.map(bucket => {
+    return {
+      bucket_start: bucket.bucket_start,
+      volume_per_second: bucket.tx_volume / statsParams.bucket_size_seconds,
+    }
+  })
 
   const totalTransactions = data?.data.buckets.reduce((acc, curr) => acc + curr.tx_volume, 0) ?? 0
 
@@ -40,7 +41,7 @@ export const TransactionsChartCard: FC<TransactionsChartCardProps> = ({ chartDur
       {lineChartData && (
         <LineChart
           dataKey="volume_per_second"
-          data={lineChartData}
+          data={lineChartData.slice().reverse()}
           margin={{ left: 0, right: isMobile ? 80 : 40 }}
           formatters={{
             data: (value: number) =>
@@ -59,3 +60,5 @@ export const TransactionsChartCard: FC<TransactionsChartCardProps> = ({ chartDur
     </SnapshotCard>
   )
 }
+
+export const TransactionsChartCard = memo(TransactionsChartCardCmp)

--- a/src/app/pages/DashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/DashboardPage/TransactionsStats.tsx
@@ -17,7 +17,7 @@ export function TransactionsStats() {
   return (
     <Card>
       <CardHeader disableTypography component="h3" title={t('transactionStats.header')} />
-      <CardContent>
+      <CardContent sx={{ height: 450 }}>
         {dailyVolumeQuery.data?.data.buckets && (
           <BarChart
             cartesianGrid

--- a/src/app/utils/chart-utils.ts
+++ b/src/app/utils/chart-utils.ts
@@ -32,3 +32,5 @@ export const chartDurationToDaysMap = {
   [ChartDuration.MONTH]: 30,
   [ChartDuration.ALL_TIME]: 365,
 }
+
+export const chartUseQueryStaleTimeMs = durationToQueryParams[ChartDuration.TODAY].bucket_size_seconds * 1000


### PR DESCRIPTION
## Problem

- when using ParaTime Snapshot select/time filter Transactions chart disappears and container changes height of a box;
- no smooth transition on Transactions chart upon selecting time from filter;

## Solution

- Unify charts to match design;
- Smoother transition on Transactions chart upon changing the selection on time filter;

## Links

https://www.loom.com/share/855dad0b006d41e98c3491ef38f70e26