### PR TITLE
Dashboard: replace Avg tx size with Total Transactions

### DIFF
--- a/src/app/pages/DashboardPage/CardHeaderWithResponsiveActions.tsx
+++ b/src/app/pages/DashboardPage/CardHeaderWithResponsiveActions.tsx
@@ -1,0 +1,14 @@
+import CardHeader from '@mui/material/CardHeader'
+import { styled } from '@mui/material/styles'
+
+export const CardHeaderWithResponsiveActions = styled(CardHeader)(({ theme }) => ({
+  [theme.breakpoints.down('sm')]: {
+    alignItems: 'flex-start',
+    flexDirection: 'column',
+    '.MuiCardHeader-action': {
+      marginTop: theme.spacing(4),
+      marginBottom: theme.spacing(4),
+    },
+  },
+  // https://github.com/mui/material-ui/issues/15759#issuecomment-493994852
+})) as typeof CardHeader

--- a/src/app/pages/DashboardPage/DurationPills.tsx
+++ b/src/app/pages/DashboardPage/DurationPills.tsx
@@ -1,0 +1,57 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { styled } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Typography from '@mui/material/Typography'
+import { ChartDuration } from '../../utils/chart-utils'
+import { COLORS } from '../../../styles/theme/colors'
+
+export const StyledBox = styled(Box)(({ theme }) => ({
+  backgroundColor: COLORS.brandDark,
+  width: 14,
+  height: 14,
+  marginRight: theme.spacing(3),
+  borderRadius: 4,
+}))
+
+export const DurationPills: FC = () => {
+  const { t } = useTranslation()
+  const options = [
+    {
+      label: t('chartDuration.week'),
+      value: ChartDuration.WEEK,
+    },
+    {
+      label: t('chartDuration.month'),
+      value: ChartDuration.MONTH,
+    },
+    {
+      label: t('chartDuration.allTime'),
+      value: ChartDuration.ALL_TIME,
+    },
+  ]
+
+  return (
+    <>
+      {options.map(option => (
+        <Chip
+          key={option.value}
+          onClick={() => console.log('click')}
+          clickable
+          color="secondary"
+          label={
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <StyledBox />
+              <Typography component="span" sx={{ fontSize: 12 }}>
+                {option.label}
+              </Typography>
+            </Box>
+          }
+          sx={{ mr: 2 }}
+          variant="outlined"
+        />
+      ))}
+    </>
+  )
+}

--- a/src/app/pages/DashboardPage/DurationPills.tsx
+++ b/src/app/pages/DashboardPage/DurationPills.tsx
@@ -15,7 +15,12 @@ export const StyledBox = styled(Box)(({ theme }) => ({
   borderRadius: 4,
 }))
 
-export const DurationPills: FC = () => {
+type DurationPillsProps = {
+  handleChange: (duration: ChartDuration) => void
+  value?: ChartDuration
+}
+
+export const DurationPills: FC<DurationPillsProps> = ({ handleChange, value }) => {
   const { t } = useTranslation()
   const options = [
     {
@@ -37,7 +42,7 @@ export const DurationPills: FC = () => {
       {options.map(option => (
         <Chip
           key={option.value}
-          onClick={() => console.log('click')}
+          onClick={() => handleChange(option.value)}
           clickable
           color="secondary"
           label={
@@ -49,7 +54,7 @@ export const DurationPills: FC = () => {
             </Box>
           }
           sx={{ mr: 2 }}
-          variant="outlined"
+          variant={value === option.value ? 'outlined-selected' : 'outlined'}
         />
       ))}
     </>

--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -1,14 +1,20 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
+import { useTheme } from '@mui/material/styles'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { LineChart } from '../../components/charts/LineChart'
 import { Layer, useGetLayerStatsTxVolume } from '../../../oasis-indexer/api'
 import { chartUseQueryStaleTimeMs } from '../../utils/chart-utils'
+import { DurationPills } from './DurationPills'
 
 export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const dailyVolumeQuery = useGetLayerStatsTxVolume(
     Layer.emerald,
     {},
@@ -19,7 +25,17 @@ export const TotalTransactions: FC = () => {
 
   return (
     <Card>
-      <CardHeader disableTypography component="h3" title={t('totalTransactions.header')} />
+      <CardHeader
+        action={!isMobile && <DurationPills />}
+        disableTypography
+        component="h3"
+        title={t('totalTransactions.header')}
+      />
+      {isMobile && (
+        <Box sx={{ mb: 5 }}>
+          <DurationPills />
+        </Box>
+      )}
       <CardContent sx={{ height: 450 }}>
         {dailyVolumeQuery.data?.data.buckets && (
           <LineChart

--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -5,36 +5,39 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { LineChart } from '../../components/charts/LineChart'
 import { Layer, useGetLayerStatsTxVolume } from '../../../oasis-indexer/api'
+import { chartUseQueryStaleTimeMs } from '../../utils/chart-utils'
 
-export const AverageTransactionSize: FC = () => {
+export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
   const dailyVolumeQuery = useGetLayerStatsTxVolume(
-    Layer.consensus, // TODO: switch to Emerald when it becomes available
+    Layer.emerald,
+    {},
+    {
+      query: { staleTime: chartUseQueryStaleTimeMs },
+    },
   )
 
   return (
     <Card>
-      <CardHeader disableTypography component="h3" title={t('averageTransactionSize.header')} />
+      <CardHeader disableTypography component="h3" title={t('totalTransactions.header')} />
       <CardContent sx={{ height: 450 }}>
         {dailyVolumeQuery.data?.data.buckets && (
           <LineChart
             tooltipActiveDotRadius={9}
-            cartesianGrid={true}
+            cartesianGrid
             strokeWidth={3}
             dataKey="tx_volume"
             data={dailyVolumeQuery.data?.data.buckets.slice().reverse()}
             margin={{ left: 16, right: 0 }}
             tickMargin={16}
-            withLabels={true}
+            withLabels
             formatters={{
               data: (value: number) =>
-                t('averageTransactionSize.tooltip', {
+                t('totalTransactions.tooltip', {
                   value,
                   formatParams: {
                     value: {
-                      style: 'unit',
-                      unit: 'byte',
-                      unitDisplay: 'long',
+                      maximumFractionDigits: 2,
                     } satisfies Intl.NumberFormatOptions,
                   },
                 }),

--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -1,41 +1,33 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
-import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
-import { useTheme } from '@mui/material/styles'
-import useMediaQuery from '@mui/material/useMediaQuery'
 import { LineChart } from '../../components/charts/LineChart'
 import { Layer, useGetLayerStatsTxVolume } from '../../../oasis-indexer/api'
-import { chartUseQueryStaleTimeMs } from '../../utils/chart-utils'
+import { chartUseQueryStaleTimeMs, durationToQueryParams } from '../../utils/chart-utils'
 import { DurationPills } from './DurationPills'
+import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
+import { ChartDuration } from '../../utils/chart-utils'
 
 export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const dailyVolumeQuery = useGetLayerStatsTxVolume(
-    Layer.emerald,
-    {},
-    {
-      query: { staleTime: chartUseQueryStaleTimeMs },
+  const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.WEEK)
+  const statsParams = durationToQueryParams[chartDuration]
+  const dailyVolumeQuery = useGetLayerStatsTxVolume(Layer.emerald, statsParams, {
+    query: {
+      keepPreviousData: true,
+      staleTime: chartUseQueryStaleTimeMs,
     },
-  )
+  })
 
   return (
     <Card>
-      <CardHeader
-        action={!isMobile && <DurationPills />}
+      <CardHeaderWithResponsiveActions
+        action={<DurationPills handleChange={setChartDuration} value={chartDuration} />}
         disableTypography
         component="h3"
         title={t('totalTransactions.header')}
       />
-      {isMobile && (
-        <Box sx={{ mb: 5 }}>
-          <DurationPills />
-        </Box>
-      )}
       <CardContent sx={{ height: 450 }}>
         {dailyVolumeQuery.data?.data.buckets && (
           <LineChart

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -4,7 +4,6 @@ import { ChartDuration, chartUseQueryStaleTimeMs, durationToQueryParams } from '
 import { LineChart } from '../../components/charts/LineChart'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { intlDateFormat } from '../../utils/dateFormatter'
 import { FC, memo } from 'react'
 import { SnapshotCard } from './SnapshotCard'
 import { PercentageGain } from '../../components/PercentageGain'
@@ -53,7 +52,10 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
                   } satisfies Intl.NumberFormatOptions,
                 },
               }),
-            label: (value: string) => intlDateFormat(new Date(value)),
+            label: (value: string) =>
+              t('common.formattedDateTime', {
+                timestamp: new Date(value),
+              }),
           }}
         />
       )}

--- a/src/app/pages/DashboardPage/index.tsx
+++ b/src/app/pages/DashboardPage/index.tsx
@@ -8,7 +8,7 @@ import { LearningMaterials } from './LearningMaterials'
 import { LatestBlocks } from './LatestBlocks'
 import { LatestTransactions } from './LatestTransactions'
 import { TransactionsStats } from './TransactionsStats'
-import { AverageTransactionSize } from './AverageTransactionSize'
+import { TotalTransactions } from './TotalTransactions'
 import { PageLayout } from '../../components/PageLayout'
 import { ParaTimeSnapshot } from './ParaTimeSnapshot'
 
@@ -30,7 +30,7 @@ export const DashboardPage: FC = () => {
         </Grid>
       </Grid>
       <TransactionsStats />
-      <AverageTransactionSize />
+      <TotalTransactions />
       <Social />
     </PageLayout>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -156,7 +156,9 @@
     "today": "Today",
     "thisWeek": "This week",
     "thisMonth": "This month",
-    "allTime": "All time"
+    "allTime": "All time",
+    "week": "Week",
+    "month": "Month"
   },
   "paraTimeSnapshot": {
     "header": "ParaTime Snapshot"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -16,10 +16,6 @@
   "activeAccounts": {
     "title": "Active Accounts"
   },
-  "averageTransactionSize": {
-    "header": "Average Transaction Size",
-    "tooltip": "Average Tx Size: {{value, number}}"
-  },
   "blocks": {
     "latest": "Latest Blocks"
   },
@@ -125,6 +121,10 @@
     "telegram": "Telegram",
     "twitter": "Twitter",
     "youtube": "Youtube"
+  },
+  "totalTransactions": {
+    "header": "Total Transactions",
+    "tooltip": "{{value, number}} transactions"
   },
   "transactions": {
     "latest": "Latest Transactions",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,3 +4,8 @@
 svg.recharts-surface {
   overflow: visible;
 }
+
+/* https://github.com/recharts/recharts/issues/2153 */
+.recharts-cartesian-grid-horizontal line:last-child {
+  stroke-opacity: 0;
+}

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -311,6 +311,15 @@ export const defaultTheme = createTheme({
         },
       ],
       styleOverrides: {
+        colorSecondary: {
+          color: COLORS.brandExtraDark,
+        },
+        filledSecondary: {
+          backgroundColor: COLORS.grayMediumLight,
+          ':hover': {
+            backgroundColor: COLORS.grayMediumLight,
+          },
+        },
         root: ({ theme }) => ({
           fontSize: '15px',
           lineHeight: '18px',

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -41,6 +41,9 @@ declare module '@mui/material/Chip' {
   export interface ChipPropsColorOverrides {
     tertiary: true
   }
+  export interface ChipPropsVariantOverrides {
+    ['outlined-selected']: true
+  }
 }
 
 export const defaultTheme = createTheme({
@@ -282,7 +285,6 @@ export const defaultTheme = createTheme({
           },
         }),
         action: {
-          alignSelf: 'center',
           margin: 0,
           fontWeight: 400,
           fontSize: '16px',
@@ -309,17 +311,22 @@ export const defaultTheme = createTheme({
             borderWidth: theme.spacing(1),
           }),
         },
+        {
+          props: { variant: 'outlined-selected', color: 'secondary' },
+          style: () => ({
+            border: `solid 1px ${COLORS.grayMediumLight}`,
+            backgroundColor: COLORS.grayMediumLight,
+            ':hover': {
+              backgroundColor: COLORS.grayMediumLight,
+            },
+          }),
+        },
       ],
       styleOverrides: {
         colorSecondary: {
           color: COLORS.brandExtraDark,
         },
-        filledSecondary: {
-          backgroundColor: COLORS.grayMediumLight,
-          ':hover': {
-            backgroundColor: COLORS.grayMediumLight,
-          },
-        },
+
         root: ({ theme }) => ({
           fontSize: '15px',
           lineHeight: '18px',


### PR DESCRIPTION
Average Transaction Size section was removed from MVP and we want repeat data from ParaTime Snaphot

<img width="1307" alt="Screenshot 2023-03-01 at 17 39 44" src="https://user-images.githubusercontent.com/891392/222204526-74aa20c4-2598-40e8-abf0-31e0853b25f0.png">
