### PR TITLE
Use ellipsis instead of ... for trimming long strings (with different font)

### DIFF
--- a/src/app/components/TrimLinkLabel/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/TrimLinkLabel/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`TrimLinkLabel snapshot 1`] = `
     data-mui-internal-clone-element="true"
     href="/home"
   >
-    oasis1...0d5eq4
+    oasis1…0d5eq4
   </a>
 </div>
 `;

--- a/src/app/utils/__tests__/trimLongString.test.ts
+++ b/src/app/utils/__tests__/trimLongString.test.ts
@@ -2,8 +2,8 @@ import { trimLongString } from '../trimLongString'
 
 describe('trimLongString', () => {
   it('should return trimmed string', () => {
-    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4')).toEqual('oasis1...0d5eq4')
-    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4', 2, 2)).toEqual('oa...q4')
+    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4')).toEqual('oasis1…0d5eq4')
+    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4', 2, 2)).toEqual('oa…q4')
   })
 
   it('it should not return a "trimmed" version that is actually longer than the original, even if longer than trimStart', () => {

--- a/src/app/utils/trimLongString.ts
+++ b/src/app/utils/trimLongString.ts
@@ -1,8 +1,8 @@
-export function trimLongString(value: string, trimStart = 6, trimEnd = 6, ellipsis = '...') {
+export function trimLongString(value: string, trimStart = 6, trimEnd = 6, ellipsis = '…') {
   if (!value) {
     return
   }
-  const trimmedLength = trimStart + 3 + trimEnd
+  const trimmedLength = trimStart + ellipsis.length + trimEnd
   if (trimmedLength > value.length) {
     return value
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,6 +1,16 @@
 @import '../../node_modules/@fontsource/figtree/variable.css';
 @import '../../node_modules/@fontsource/roboto-mono/variable.css';
 
+/** Use Figtree for "…" instead of Roboto Mono. */
+@font-face {
+  font-family: 'Roboto MonoVariable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url('../../node_modules/@fontsource/figtree/files/figtree-latin-variable-wghtOnly-normal.woff2') format('woff2');
+  unicode-range: U+2026;
+}
+
 svg.recharts-surface {
   overflow: visible;
 }


### PR DESCRIPTION

| Before | After |
| --- | --- |
|  ![localhost_1234_emerald (2)](https://user-images.githubusercontent.com/3758846/222474348-8779b266-2bb5-493d-b73c-eb8cdb6aa032.png) | ![localhost_1234_emerald](https://user-images.githubusercontent.com/3758846/222474338-58b7f191-01cc-49bf-ad06-a737316e2667.png)  |

