### PR TITLE
Make code editors check types in js files by default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { defaultTheme } from '../src/styles/theme'
 import { ThemeProvider } from '@mui/material/styles'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 
     // Strictness
     "strict": true,
+    "checkJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
Previously, if there was a typo in orval.config.js, it would not get noticed. Most other .js files have an explicit `// @ts-check` at the top tho