### PR TITLE
Pagination update

### DIFF
--- a/src/app/components/Blocks/index.tsx
+++ b/src/app/components/Blocks/index.tsx
@@ -17,6 +17,7 @@ export type TableRuntimeBlock = RuntimeBlock & {
 
 export type TableRuntimeBlockList = {
   blocks: TableRuntimeBlock[]
+  total_count: number
 }
 
 type BlocksProps = {

--- a/src/app/components/Table/TablePagination.tsx
+++ b/src/app/components/Table/TablePagination.tsx
@@ -5,13 +5,28 @@ import { useTranslation } from 'react-i18next'
 import { Link, To } from 'react-router-dom'
 
 export type TablePaginationProps = {
-  numberOfPages?: number
-  selectedPage: number
   linkToPage: (page: number) => To
+  rowsPerPage: number
+  selectedPage: number
+  totalCount: number | undefined
 }
 
-export const TablePagination: FC<TablePaginationProps> = ({ numberOfPages, selectedPage, linkToPage }) => {
+// API counts maximum 1000 items
+const maximumTotalCount = 1000
+
+export const TablePagination: FC<TablePaginationProps> = ({
+  selectedPage,
+  linkToPage,
+  rowsPerPage,
+  totalCount,
+}) => {
   const { t } = useTranslation()
+
+  if (!totalCount) {
+    return null
+  }
+  const totalCountBoundary = Math.min(totalCount + (selectedPage - 1) * rowsPerPage, maximumTotalCount)
+  const numberOfPages = Math.ceil(totalCountBoundary / rowsPerPage)
 
   return (
     <Pagination

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -155,11 +155,7 @@ export const Table: FC<TableProps> = ({
       </TableContainer>
       {pagination && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <TablePagination
-            numberOfPages={pagination.numberOfPages ?? 100} // TODO: fix hardcoded total number of pages
-            selectedPage={pagination.selectedPage}
-            linkToPage={pagination.linkToPage}
-          />
+          <TablePagination {...pagination} />
         </Box>
       )}
     </>

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -38,6 +38,7 @@ type TableRuntimeTransaction = RuntimeTransaction & {
 
 export type TableRuntimeTransactionList = {
   transactions: TableRuntimeTransaction[]
+  total_count: number
 }
 
 type TransactionProps = {

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -18,6 +18,7 @@ export const TransactionsList: FC<{ address: string }> = ({ address }) => {
     offset: txsOffset,
     rel: address,
   })
+
   return (
     <Transactions
       transactions={transactionsQuery.data?.data.transactions}
@@ -26,6 +27,8 @@ export const TransactionsList: FC<{ address: string }> = ({ address }) => {
       pagination={{
         selectedPage: txsPagination.selectedPage,
         linkToPage: txsPagination.linkToPage,
+        totalCount: transactionsQuery.data?.data.total_count,
+        rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
     />
   )

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -29,6 +29,8 @@ const TransactionList: FC<{ blockHeight: number }> = ({ blockHeight }) => {
       pagination={{
         selectedPage: txsPagination.selectedPage,
         linkToPage: txsPagination.linkToPage,
+        totalCount: transactionsQuery.data?.data.total_count,
+        rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
       verbose={false}
     />

--- a/src/app/pages/BlocksPage/index.tsx
+++ b/src/app/pages/BlocksPage/index.tsx
@@ -34,6 +34,7 @@ export const BlocksPage: FC = () => {
           return {
             ...nextState,
             data: {
+              ...nextState.data,
               blocks: nextState.data.blocks.map(block => {
                 return {
                   ...block,
@@ -59,6 +60,8 @@ export const BlocksPage: FC = () => {
           pagination={{
             selectedPage: pagination.selectedPage,
             linkToPage: pagination.linkToPage,
+            totalCount: blocksQuery.data?.data.total_count,
+            rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
           }}
         />
       </SubPageCard>

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -31,6 +31,7 @@ export const TransactionsPage: FC = () => {
           return {
             ...nextState,
             data: {
+              ...nextState.data,
               transactions: nextState.data.transactions.map(tx => {
                 return {
                   ...tx,
@@ -55,6 +56,8 @@ export const TransactionsPage: FC = () => {
           pagination={{
             selectedPage: pagination.selectedPage,
             linkToPage: pagination.linkToPage,
+            totalCount: transactionsQuery.data?.data.total_count,
+            rowsPerPage: limit,
           }}
         />
       </SubPageCard>

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -95,7 +95,9 @@ SampleTable.args = {
   isLoading: false,
   name: 'Sample table',
   pagination: {
-    selectedPage: 5,
+    selectedPage: 1,
     linkToPage: page => ({ search: `?page=${page}` }),
+    rowsPerPage: 10,
+    totalCount: data.length,
   },
 }


### PR DESCRIPTION
Based on discussion we will keep 100 pages cap 

`> 100 pages`
https://527cb3e5.oasis-explorer.pages.dev/emerald/transactions
https://527cb3e5.oasis-explorer.pages.dev/emerald/blocks

`< 100 pages`
https://527cb3e5.oasis-explorer.pages.dev/emerald/account/oasis1qqrr5yg64llx4k9gpqz0s5e5fuxutpg5ksg20lyz
https://527cb3e5.oasis-explorer.pages.dev/emerald/blocks/1201390

we want to render pagination even for `<= 10 items`
https://527cb3e5.oasis-explorer.pages.dev/emerald/account/oasis1qrl67qhm3sg7e58swdtgfq8vqvzgyvyy6gyf7ql8
