### PR TITLE
Show proper values in TotalTransactions

### DIFF
--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -7,7 +7,7 @@ import { Layer, useGetLayerStatsTxVolume } from '../../../oasis-indexer/api'
 import { chartUseQueryStaleTimeMs, durationToQueryParams } from '../../utils/chart-utils'
 import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
-import { ChartDuration } from '../../utils/chart-utils'
+import { ChartDuration, getTotalTxValues } from '../../utils/chart-utils'
 
 export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
@@ -19,6 +19,7 @@ export const TotalTransactions: FC = () => {
       staleTime: chartUseQueryStaleTimeMs,
     },
   })
+  const buckets = getTotalTxValues(dailyVolumeQuery.data?.data.buckets.slice().reverse())
 
   return (
     <Card>
@@ -29,13 +30,13 @@ export const TotalTransactions: FC = () => {
         title={t('totalTransactions.header')}
       />
       <CardContent sx={{ height: 450 }}>
-        {dailyVolumeQuery.data?.data.buckets && (
+        {buckets && (
           <LineChart
             tooltipActiveDotRadius={9}
             cartesianGrid
             strokeWidth={3}
             dataKey="tx_volume"
-            data={dailyVolumeQuery.data?.data.buckets.slice().reverse()}
+            data={buckets}
             margin={{ left: 16, right: 0 }}
             tickMargin={16}
             withLabels

--- a/src/app/utils/chart-utils.ts
+++ b/src/app/utils/chart-utils.ts
@@ -64,6 +64,16 @@ export const getMonthlyBucketsDailyAverage = (buckets: Buckets): Buckets => {
   }))
 }
 
+export const getTotalTxValues = (buckets: Buckets): Buckets => {
+  return buckets?.reduce((acc: TxVolume[], cur, index) => {
+    acc.push({
+      bucket_start: cur.bucket_start,
+      tx_volume: index > 0 ? cur.tx_volume + acc[index - 1].tx_volume : cur.tx_volume,
+    })
+    return acc
+  }, [])
+}
+
 export const filterHourlyActiveAccounts = (
   windows: ActiveAccounts[] | undefined,
 ): ActiveAccounts[] | undefined => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -135,7 +135,7 @@
   },
   "totalTransactions": {
     "header": "Total Transactions",
-    "tooltip": "{{value, number}} transactions"
+    "tooltip": "{{value, number}} total transactions"
   },
   "transactions": {
     "latest": "Latest Transactions",


### PR DESCRIPTION
Based on Don's feedback we want to have a sum of TXs over time here to differentiate Total Transactions chart a little bit as we have three charts that are using the same endpoint. 