### PR TITLE
Fix error handling vs routing

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -34,6 +34,7 @@ export const routes: RouteObject[] = [
       {
         path: `/:layer`,
         loader: layerLoader,
+        errorElement: <RoutingErrorPage />,
         children: [
           {
             path: '',


### PR DESCRIPTION
We need to insert an error element into the routing tree after the layer has already been parsed, so that
the layer parameter is available for the headers,
since the header depends on it.

Before:

![image](https://user-images.githubusercontent.com/2093792/225296103-487547e6-dc22-40e2-969f-e5dcffab6fd4.png)

After:

![image](https://user-images.githubusercontent.com/2093792/225295735-0bda887d-1a95-4769-aa4b-4cb92aa85791.png)
