### PR TITLE
Don't retry failed requests 3 times

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      retry: false,
     },
   },
 })


### PR DESCRIPTION
https://tanstack.com/query/v4/docs/react/guides/important-defaults
> Queries that fail are silently retried 3 times, with exponential backoff delay before capturing and displaying an error to the UI.

This would make searching across paratimes annoyingly slow. And it is already slow to display 404