### PR TITLE
Break circular imports in config vs api

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-import { Layer } from './oasis-indexer/api'
+// eslint-disable-next-line no-restricted-imports
+import { Layer } from './oasis-indexer/generated/api' // We get this from the generated code to avoid circular imports
 
 export const consensusDecimals = 9
 


### PR DESCRIPTION
If _can_ work, but let's avoid the pain of hidden bugs.