### PR TITLE
Remove circular imports workaround

### DIFF
--- a/src/app/components/Blocks/index.tsx
+++ b/src/app/components/Blocks/index.tsx
@@ -8,7 +8,7 @@ import { VerticalProgressBar } from '../../components/ProgressBar'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { TrimLinkLabel } from '../../components/TrimLinkLabel'
 import { RouteUtils } from '../../utils/route-utils'
-import { getBlockGasLimit } from '../../../config'
+import { blockGasLimit } from '../../../config'
 import { TablePaginationProps } from '../Table/TablePagination'
 
 export type TableRuntimeBlock = RuntimeBlock & {
@@ -43,7 +43,6 @@ export const Blocks = (props: BlocksProps) => {
     ...(verbose ? [{ content: t('common.gasLimit'), align: TableCellAlign.Right }] : []),
   ]
 
-  const blockGasLimit = getBlockGasLimit()
   const tableRows = blocks?.map(block => ({
     key: block.hash,
     data: [

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -16,7 +16,7 @@ import { TransactionsCard } from './TransactionsCard'
 import { AppErrors } from '../../../types/errors'
 import { trimLongString } from '../../utils/trimLongString'
 import { COLORS } from '../../../styles/theme/colors'
-import { getBlockGasLimit } from '../../../config'
+import { blockGasLimit } from '../../../config'
 import { transactionsContainerId } from './TransactionsCard'
 import { useLayerParam } from '../../hooks/useLayerParam'
 
@@ -58,7 +58,6 @@ export const BlockDetailView: FC<{
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const formattedTime = useFormattedTimestampString(block?.timestamp)
   const transactionsAnchor = `${useHref('')}#${transactionsContainerId}`
-  const blockGasLimit = getBlockGasLimit()
 
   return (
     <>

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,21 +91,12 @@ type LayersConfig = {
   [key in Layer]: LayerConfig | null
 }
 
-let _paraTimesConfig: LayersConfig | undefined
-
-export const getParaTimesConfig = (): LayersConfig => {
-  if (!_paraTimesConfig) {
-    _paraTimesConfig = {
-      [Layer.cipher]: cipherConfig,
-      [Layer.emerald]: emeraldConfig,
-      [Layer.sapphire]: sapphireConfig,
-      [Layer.consensus]: null,
-    }
-  }
-  return _paraTimesConfig
+export const paraTimesConfig: LayersConfig = {
+  [Layer.cipher]: cipherConfig,
+  [Layer.emerald]: emeraldConfig,
+  [Layer.sapphire]: sapphireConfig,
+  [Layer.consensus]: null,
 }
 
 // TODO: refactor this when we have network specific builds and/or another paraTime is added
-export const getBlockGasLimit = () => {
-  return getParaTimesConfig()[Layer.emerald]?.mainnet.blockGasLimit!
-}
+export const blockGasLimit = paraTimesConfig[Layer.emerald]?.mainnet.blockGasLimit!

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -1,7 +1,7 @@
 /** @file Wrappers around generated API */
 
 import axios, { AxiosResponse } from 'axios'
-import { getParaTimesConfig } from '../config'
+import { paraTimesConfig } from '../config'
 import * as generated from './generated/api'
 import BigNumber from 'bignumber.js'
 import { UseQueryOptions } from '@tanstack/react-query'
@@ -87,7 +87,6 @@ export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactio
   params?,
   options?,
 ) => {
-  const paraTimesConfig = getParaTimesConfig()
   return generated.useGetRuntimeTransactions(runtime, params, {
     ...options,
     axios: {
@@ -147,7 +146,6 @@ export const useGetRuntimeTransactionsTxHash: typeof generated.useGetRuntimeTran
   txHash,
   options?,
 ) => {
-  const paraTimesConfig = getParaTimesConfig()
   return generated.useGetRuntimeTransactionsTxHash(runtime, txHash, {
     ...options,
     axios: {


### PR DESCRIPTION
Earlier we had some circular imports.
To make it work, we have introduced a workaround:
instead of exporting constants (which is unreliable in this situation),
we exported functions (which always works).

Now the circular import is gone, so we can get rid of this extra complexity.