### PR TITLE
Remove the sapphire -> emerald mock

### DIFF
--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -45,15 +45,6 @@ function arrayify<T>(arrayOrItem: null | undefined | T | T[]): T[] {
   return arrayOrItem
 }
 
-// TODO: remove when sapphire API is ready
-axios.interceptors.request.use(config => {
-  // Mock sapphire
-  if (config.url?.startsWith('/sapphire')) {
-    config.url = config.url.replace('/sapphire', '/emerald')
-  }
-  return config
-})
-
 export const useGetConsensusTransactions: typeof generated.useGetConsensusTransactions = (
   params?,
   options?,


### PR DESCRIPTION
Since Sapphire data is now available via the API natively.