### PR TITLE
Api sync

### DIFF
--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -91,7 +91,7 @@ export const Account: FC<AccountProps> = ({ account, isLoading, roseFiatValue, s
           )}
 
           <dt>{t('common.transactions')}</dt>
-          <dd>{/* TODO: waiting for API update */}</dd>
+          <dd>{account.stats.num_txns}</dd>
 
           <dt>{t('account.evmTokens')}</dt>
           <dd>
@@ -99,10 +99,10 @@ export const Account: FC<AccountProps> = ({ account, isLoading, roseFiatValue, s
           </dd>
 
           <dt>{t('account.totalReceived')}</dt>
-          <dd>{/* TODO: waiting for API update */}</dd>
+          <dd>{t('common.valueInRose', { value: account.stats.total_received })}</dd>
 
           <dt>{t('account.totalSent')}</dt>
-          <dd>{/* TODO: waiting for API update */}</dd>
+          <dd>{t('common.valueInRose', { value: account.stats.total_sent })}</dd>
         </StyledDescriptionList>
       )}
     </>

--- a/src/app/pages/DashboardPage/Nodes.tsx
+++ b/src/app/pages/DashboardPage/Nodes.tsx
@@ -21,7 +21,7 @@ export const Nodes: FC = () => {
   return (
     <SnapshotCard title={t('nodes.title')}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {activeNodes && (
+        {runtimeStatusQuery.isFetched && (
           <>
             <OfflineBoltIcon fontSize="large" sx={{ color: COLORS.eucalyptus, mr: 3 }} />
             <Typography component="span" sx={{ fontSize: '48px', fontWeight: 700, color: COLORS.brandDark }}>

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -215,6 +215,15 @@ export const useGetRuntimeAccountsAddress: typeof generated.useGetRuntimeAccount
               }
             }),
             layer: runtime,
+            stats: {
+              ...data.stats,
+              total_received: data.stats?.total_received
+                ? fromBaseUnits(data.stats?.total_received, paraTimesConfig.emerald!.decimals)
+                : undefined,
+              total_sent: data.stats?.total_sent
+                ? fromBaseUnits(data.stats?.total_sent, paraTimesConfig.emerald!.decimals)
+                : undefined,
+            },
           }
         },
         ...arrayify(options?.axios?.transformResponse),


### PR DESCRIPTION
- show nodes number even if it's 0
- both total_sent and total_received are now available in API 