### PR TITLE
Fix deep links on search results

### DIFF
--- a/src/app/components/Account/ShowMoreTokensLink.tsx
+++ b/src/app/components/Account/ShowMoreTokensLink.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react'
-import { Link as RouterLink, useHref } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
-import { type Token } from '../../../oasis-indexer/api'
+import { RuntimeAccount, type Token } from '../../../oasis-indexer/api'
+import { RouteUtils } from '../../utils/route-utils'
 
 export const StyledLink = styled(RouterLink)(({ theme }) => ({
   color: COLORS.brandDark,
@@ -14,14 +15,15 @@ export const StyledLink = styled(RouterLink)(({ theme }) => ({
 }))
 
 type ShowMoreTokensLinkProps = {
+  account: RuntimeAccount
   tokens: Token[]
   pills: Token[]
 }
 
-export const ShowMoreTokensLink: FC<ShowMoreTokensLinkProps> = ({ tokens, pills }) => {
+export const ShowMoreTokensLink: FC<ShowMoreTokensLinkProps> = ({ account, tokens, pills }) => {
   const { t } = useTranslation()
-  const erc20link = useHref('tokens/erc-20')
-  const erc721Link = useHref('tokens/erc-721')
+  const erc20link = `${RouteUtils.getAccountRoute(account.address, account.layer)}/tokens/erc-20`
+  const erc721Link = `${RouteUtils.getAccountRoute(account.address, account.layer)}/tokens/erc-721`
   const additionalTokensCounter = tokens.length - pills.length
 
   if (!additionalTokensCounter) {

--- a/src/app/components/Account/TokenPills.tsx
+++ b/src/app/components/Account/TokenPills.tsx
@@ -7,19 +7,20 @@ import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { ShowMoreTokensLink } from './ShowMoreTokensLink'
 import { RoundedBalance } from '../RoundedBalance'
-import { type RuntimeEvmBalance } from '../../../oasis-indexer/api'
-import { useHref } from 'react-router-dom'
+import { RuntimeAccount, type RuntimeEvmBalance } from '../../../oasis-indexer/api'
+import { RouteUtils } from '../../utils/route-utils'
 
 type TokenPillsProps = {
-  tokens: RuntimeEvmBalance[] | undefined
+  account: RuntimeAccount
+  tokens: RuntimeEvmBalance[]
 }
 
-export const TokenPills: FC<TokenPillsProps> = ({ tokens }) => {
+export const TokenPills: FC<TokenPillsProps> = ({ account, tokens }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
-  if (!tokens?.length) {
+  if (!tokens.length) {
     return <Typography sx={{ opacity: '0.5' }}>{t('account.noTokens')}</Typography>
   }
   const pills = tokens.slice(0, isMobile ? 1 : 3)
@@ -27,22 +28,23 @@ export const TokenPills: FC<TokenPillsProps> = ({ tokens }) => {
   return (
     <>
       {pills.map(item => (
-        <Pill key={item.token_contract_addr} pill={item} />
+        <Pill key={item.token_contract_addr} account={account} pill={item} />
       ))}
 
-      <ShowMoreTokensLink tokens={tokens} pills={pills} />
+      <ShowMoreTokensLink account={account} tokens={tokens} pills={pills} />
     </>
   )
 }
 
 type PillProps = {
+  account: RuntimeAccount
   pill: RuntimeEvmBalance
 }
 
-export const Pill: FC<PillProps> = ({ pill }) => {
-  const href = `${useHref(pill.token_type === 'ERC20' ? 'tokens/erc-20' : 'tokens/erc-721')}#${
-    pill.token_contract_addr
-  }`
+export const Pill: FC<PillProps> = ({ account, pill }) => {
+  const erc20link = `${RouteUtils.getAccountRoute(account.address, account.layer)}/tokens/erc-20`
+  const erc721Link = `${RouteUtils.getAccountRoute(account.address, account.layer)}/tokens/erc-721`
+  const href = `${pill.token_type === 'ERC20' ? erc20link : erc721Link}#${pill.token_contract_addr}`
 
   return (
     <Chip

--- a/src/app/components/Account/__tests__/ShowMoreTokensLink.test.tsx
+++ b/src/app/components/Account/__tests__/ShowMoreTokensLink.test.tsx
@@ -1,7 +1,12 @@
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '../../../utils/renderWithProviders'
 import { ShowMoreTokensLink } from './../ShowMoreTokensLink'
-import { Token } from '../../../../oasis-indexer/api'
+import { RuntimeAccount, Token } from '../../../../oasis-indexer/api'
+
+const mockedAccount = {
+  address: 'oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t',
+  layer: 'emerald',
+} as RuntimeAccount
 
 const mockedToken1: Token = {
   balance: '1123.5',
@@ -41,34 +46,44 @@ const mockedToken4: Token = {
 
 describe('ShowMoreTokensLink', () => {
   it('should not render show more link', () => {
-    const { rerender } = renderWithProviders(<ShowMoreTokensLink tokens={[]} pills={[]} />)
+    const { rerender } = renderWithProviders(
+      <ShowMoreTokensLink account={mockedAccount} tokens={[]} pills={[]} />,
+    )
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
 
-    rerender(<ShowMoreTokensLink tokens={[mockedToken1]} pills={[mockedToken1]} />)
+    rerender(<ShowMoreTokensLink account={mockedAccount} tokens={[mockedToken1]} pills={[mockedToken1]} />)
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 
   it('should render ERC20 link if there is any ERC20 token not included in pills', () => {
     renderWithProviders(
       <ShowMoreTokensLink
+        account={mockedAccount}
         tokens={[mockedToken1, mockedToken2, mockedToken3, mockedToken4]}
         pills={[mockedToken1]}
       />,
     )
 
     expect(screen.getByText('+ 3 more')).toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/tokens/erc-20')
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/emerald/account/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-20',
+    )
   })
 
   it('should render ERC721 link if there is no ERC20 token', () => {
     renderWithProviders(
       <ShowMoreTokensLink
+        account={mockedAccount}
         tokens={[mockedToken1, mockedToken2, mockedToken3]}
         pills={[mockedToken1, mockedToken2]}
       />,
     )
 
     expect(screen.getByText('+ 1 more')).toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/tokens/erc-721')
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/emerald/account/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-721',
+    )
   })
 })

--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -98,7 +98,7 @@ export const Account: FC<AccountProps> = ({ account, isLoading, roseFiatValue, s
 
           <dt>{t('account.evmTokens')}</dt>
           <dd>
-            <TokenPills tokens={account.evm_balances} />
+            <TokenPills account={account} tokens={account.evm_balances} />
           </dd>
 
           <dt>{t('account.totalReceived')}</dt>

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useHref, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTheme } from '@mui/material/styles'
 import Link from '@mui/material/Link'
@@ -17,6 +17,7 @@ import { paraTimesConfig } from '../../../config'
 import { transactionsContainerId } from './TransactionsCard'
 import { useLayerParam } from '../../hooks/useLayerParam'
 import { BlockLink, BlockHashLink } from '../../components/Blocks/BlockLink'
+import { RouteUtils } from '../../utils/route-utils'
 
 export const BlockDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -55,11 +56,14 @@ export const BlockDetailView: FC<{
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const formattedTime = useFormattedTimestampString(block?.timestamp)
-  const transactionsAnchor = `${useHref('')}#${transactionsContainerId}`
 
   if (isLoading) return <TextSkeleton numberOfRows={7} />
   if (!block) return <></>
 
+  const transactionsAnchor = `${RouteUtils.getBlockRoute(
+    block.round,
+    block.layer,
+  )}#${transactionsContainerId}`
   const blockGasLimit = paraTimesConfig[block.layer]?.mainnet.blockGasLimit
   if (!blockGasLimit) throw new Error('blockGasLimit is not configured')
   return (

--- a/src/app/pages/SearchResultsPage/__tests__/SearchResultsView.test.tsx
+++ b/src/app/pages/SearchResultsPage/__tests__/SearchResultsView.test.tsx
@@ -1,7 +1,11 @@
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '../../../utils/renderWithProviders'
 import { SearchResultsView } from '../'
-import { suggestedParsedAccount, suggestedParsedBlock } from '../../../utils/test-fixtures'
+import {
+  sapphireParsedBlock,
+  suggestedParsedAccount,
+  suggestedParsedBlock,
+} from '../../../utils/test-fixtures'
 
 describe('SearchResultsView', () => {
   beforeEach(() => {
@@ -13,14 +17,13 @@ describe('SearchResultsView', () => {
     jest.useRealTimers()
   })
 
-  it.todo('unskip tests') // TODO: fix deep links
-  it.skip('block should correctly link to transactions', () => {
+  it('block should correctly link to transactions', () => {
     renderWithProviders(
       <SearchResultsView
         searchQueries={{
           blockHeight: {
             isLoading: false,
-            results: [suggestedParsedBlock],
+            results: [suggestedParsedBlock, sapphireParsedBlock],
           },
           txHash: { isLoading: false, results: [] },
           oasisAccount: { isLoading: false, results: [] },
@@ -35,9 +38,16 @@ describe('SearchResultsView', () => {
       'href',
       '/emerald/blocks/1396255#transactions',
     )
+
+    expect(screen.getByText('143,553')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '1 transaction' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '1 transaction' })).toHaveAttribute(
+      'href',
+      '/sapphire/blocks/143553#transactions',
+    )
   })
 
-  it.skip('account should correctly link to erc-20 tokens', () => {
+  it('account should correctly link to erc-20 tokens', () => {
     renderWithProviders(
       <SearchResultsView
         searchQueries={{
@@ -50,10 +60,12 @@ describe('SearchResultsView', () => {
       />,
     )
     expect(screen.getByText('EVM tokens')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '337325.43837 FTP' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '337325.43837 FTP' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: '337325.43836 FTP' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '337325.43836 FTP' })).toHaveAttribute(
       'href',
-      '/emerald/account/0xBA504818FdD8D3dBA2Ef8fD9B4F4D5c71aD1d1D3/tokens/erc-20#oasis1qpssvkplnlpzdvwxpgmrhf9j5lkyvaylcvujhjhg',
+      '/emerald/account/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-20#oasis1qpssvkplnlpzdvwxpgmrhf9j5lkyvaylcvujhjhg',
+      // TODO: use evm account address
+      // '/emerald/account/0xBA504818FdD8D3dBA2Ef8fD9B4F4D5c71aD1d1D3/tokens/erc-20#oasis1qpssvkplnlpzdvwxpgmrhf9j5lkyvaylcvujhjhg',
     )
   })
 })

--- a/src/app/utils/test-fixtures.ts
+++ b/src/app/utils/test-fixtures.ts
@@ -10,6 +10,16 @@ export const suggestedParsedBlock: RuntimeBlock = {
   layer: 'emerald',
 }
 
+export const sapphireParsedBlock: RuntimeBlock = {
+  round: 143553,
+  hash: '91cc80baead4779221cadfe756a959273697850f9ef994b0e2b2ac0a178b86ca',
+  timestamp: '2023-02-17T10:57:09Z',
+  size: 292,
+  num_transactions: 1,
+  gas_used: 11292,
+  layer: 'sapphire',
+}
+
 export const suggestedParsedAccount: RuntimeAccount = {
   address: 'oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t',
   address_preimage: {


### PR DESCRIPTION
Before: `/tokens/erc-20#oasis1qpssvkplnlpzdvwxpgmrhf9j5lkyvaylcvujhjhg` (broken link)
After: `/emerald/account/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-20#oasis1qpssvkplnlpzdvwxpgmrhf9j5lkyvaylcvujhjhg`