### PR TITLE
Include count clipped prop in pagination

### DIFF
--- a/src/app/components/Blocks/index.tsx
+++ b/src/app/components/Blocks/index.tsx
@@ -14,6 +14,7 @@ export type TableRuntimeBlock = RuntimeBlock & {
 export type TableRuntimeBlockList = {
   blocks: TableRuntimeBlock[]
   total_count: number
+  is_total_count_clipped: boolean
 }
 
 type BlocksProps = {

--- a/src/app/components/Table/TablePagination.tsx
+++ b/src/app/components/Table/TablePagination.tsx
@@ -9,24 +9,22 @@ export type TablePaginationProps = {
   rowsPerPage: number
   selectedPage: number
   totalCount: number | undefined
+  isTotalCountClipped: boolean | undefined
 }
-
-// API counts maximum 1000 items
-// https://github.com/oasisprotocol/oasis-indexer/blob/e220d3f2872abff45e5a78fe6b1a1de961e18765/storage/client/client.go#L30
-const maximumTotalCount = 1000
 
 export const TablePagination: FC<TablePaginationProps> = ({
   selectedPage,
   linkToPage,
   rowsPerPage,
   totalCount,
+  isTotalCountClipped,
 }) => {
   const { t } = useTranslation()
 
   if (!totalCount) {
     return null
   }
-  const totalCountBoundary = Math.min(totalCount + (selectedPage - 1) * rowsPerPage, maximumTotalCount)
+  const totalCountBoundary = totalCount + (selectedPage - 1) * rowsPerPage
   const numberOfPages = Math.ceil(totalCountBoundary / rowsPerPage)
 
   return (
@@ -37,11 +35,12 @@ export const TablePagination: FC<TablePaginationProps> = ({
         <PaginationItem
           slots={{
             first: () => <>{t('pagination.first')}</>,
-            last: () => <>{t('pagination.last')}</>,
+            last: () => <>{isTotalCountClipped ? '…' : t('pagination.last')}</>,
           }}
           component={Link}
           to={item.page == null ? '' : linkToPage(item.page)}
           {...item}
+          sx={isTotalCountClipped && item.type === 'last' ? { pointerEvents: 'none', cursor: 'default' } : {}}
         />
       )}
       showFirstButton

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -36,6 +36,7 @@ type TableRuntimeTransaction = RuntimeTransaction & {
 export type TableRuntimeTransactionList = {
   transactions: TableRuntimeTransaction[]
   total_count: number
+  is_total_count_clipped: boolean
 }
 
 type TransactionProps = {

--- a/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TransactionsCard.tsx
@@ -38,6 +38,7 @@ export const TransactionsList: FC<{ layer: Layer; address: string }> = ({ layer,
         selectedPage: txsPagination.selectedPage,
         linkToPage: txsPagination.linkToPage,
         totalCount: transactionsQuery.data?.data.total_count,
+        isTotalCountClipped: transactionsQuery.data?.data.is_total_count_clipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
     />

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -36,6 +36,7 @@ const TransactionList: FC<{ layer: Layer; blockHeight: number }> = ({ layer, blo
         selectedPage: txsPagination.selectedPage,
         linkToPage: txsPagination.linkToPage,
         totalCount: transactionsQuery.data?.data.total_count,
+        isTotalCountClipped: transactionsQuery.data?.data.is_total_count_clipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
       verbose={false}

--- a/src/app/pages/BlocksPage/index.tsx
+++ b/src/app/pages/BlocksPage/index.tsx
@@ -69,6 +69,7 @@ export const BlocksPage: FC = () => {
             selectedPage: pagination.selectedPage,
             linkToPage: pagination.linkToPage,
             totalCount: blocksQuery.data?.data.total_count,
+            isTotalCountClipped: blocksQuery.data?.data.is_total_count_clipped,
             rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
           }}
         />

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -65,6 +65,7 @@ export const TransactionsPage: FC = () => {
             selectedPage: pagination.selectedPage,
             linkToPage: pagination.linkToPage,
             totalCount: transactionsQuery.data?.data.total_count,
+            isTotalCountClipped: transactionsQuery.data?.data.is_total_count_clipped,
             rowsPerPage: limit,
           }}
         />

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -99,5 +99,6 @@ SampleTable.args = {
     linkToPage: page => ({ search: `?page=${page}` }),
     rowsPerPage: 10,
     totalCount: data.length,
+    isTotalCountClipped: true,
   },
 }


### PR DESCRIPTION
Based on discussion we want replace "Last" with "..." if clipped.

`> 100 pages`
https://859ba30c.oasis-explorer.pages.dev/emerald/transactions
https://859ba30c.oasis-explorer.pages.dev/emerald/blocks

last page of `> 100 pages`
https://859ba30c.oasis-explorer.pages.dev/emerald/account/oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw?page=5699

`< 100 pages`
https://859ba30c.oasis-explorer.pages.dev/emerald/blocks/1201390
https://859ba30c.oasis-explorer.pages.dev/emerald/account/0xE004dA9962A02c2F5EA66B2AA88360B49617ee56

we want to render pagination even for `<= 10 items`
https://859ba30c.oasis-explorer.pages.dev/emerald/blocks/5093464
