### PR TITLE
Make sure to always scroll to transactions when requested

### DIFF
--- a/src/app/components/PageLayout/ScrollingCard.tsx
+++ b/src/app/components/PageLayout/ScrollingCard.tsx
@@ -1,0 +1,16 @@
+import Card from '@mui/material/Card'
+import { FC } from 'react'
+import { ScrollingDiv } from './ScrollingDiv'
+
+/**
+ * Native scrolling to an anchor name doesn't work if element is not rendered yet (e.g. after reload).
+ * This checks if id matches anchor name in URL fragment and scrolls to it when component is mounted.
+ */
+export const ScrollingCard: FC<Parameters<typeof Card>[0] & { id: string }> = props => {
+  const { id, ...rest } = props
+  return (
+    <ScrollingDiv id={id}>
+      <Card {...rest} />
+    </ScrollingDiv>
+  )
+}

--- a/src/app/components/PageLayout/ScrollingDiv.tsx
+++ b/src/app/components/PageLayout/ScrollingDiv.tsx
@@ -1,0 +1,29 @@
+import { FC, useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export const ScrollingDiv: FC<JSX.IntrinsicElements['div'] & { id: string }> = props => {
+  const { id } = props
+  const { hash } = useLocation()
+  const divRef = useRef<HTMLDivElement>(null)
+  const element = divRef.current
+
+  useEffect(() => {
+    if (hash === `#${id}`) {
+      if (element) {
+        element.scrollIntoView({
+          block: 'start',
+        })
+      } else {
+        setTimeout(() => {
+          if (divRef.current) {
+            divRef.current.scrollIntoView({
+              block: 'start',
+            })
+          }
+        })
+      }
+    }
+  }, [id, hash, element])
+
+  return <div {...props} ref={divRef} />
+}

--- a/src/app/pages/BlockDetailPage/TransactionsCard.tsx
+++ b/src/app/pages/BlockDetailPage/TransactionsCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Card from '@mui/material/Card'
+import { ScrollingCard } from '../../components/PageLayout/ScrollingCard'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 
@@ -47,13 +47,13 @@ const TransactionList: FC<{ layer: Layer; blockHeight: number }> = ({ layer, blo
 export const TransactionsCard: FC<{ layer: Layer; blockHeight: number }> = ({ layer, blockHeight }) => {
   const { t } = useTranslation()
   return (
-    <Card id={transactionsContainerId}>
+    <ScrollingCard id={transactionsContainerId}>
       <CardHeader disableTypography component="h3" title={t('common.transactions')} />
       <CardContent>
         <ErrorBoundary light={true}>
           <TransactionList layer={layer} blockHeight={blockHeight} />
         </ErrorBoundary>
       </CardContent>
-    </Card>
+    </ScrollingCard>
   )
 }


### PR DESCRIPTION
Task is [here](https://app.clickup.com/t/862jbmukx).

You can test the behavior [here](https://csillag-late-scrolling.oasis-explorer.pages.dev/emerald/blocks/1396255#transactions).

(Suggestion: make then window smaller, so that scrolling is required to see the transactions.)

Also, please note that reload can behave differently compared to the initial loading (i.e. when opening on a new tab), so test both.