### PR TITLE
Update Renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":disableDependencyDashboard"],
   "packageRules": [
     {
       "groupName": "lint dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,6 @@
       "groupName": "CI github-actions",
       "matchManagers": ["github-actions"]
     }
-  ]
+  ],
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
- I don't use renovate dashboard gh issue tracker
- it's easier to scan dependency versions via package.json. Bump both package.json and lock file when semver change satisfies the range in package.json