### PR TITLE
Setup gitlint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -19,15 +19,36 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          # Checkout pull request HEAD commit instead of merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch all history so gitlint can check the relevant commits.
+          fetch-depth: '0'
+      - name: Set up Python 3
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: '3.x'
       - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
           cache: yarn
+      - name: Install gitlint
+        run: |
+          python -m pip install gitlint
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Lint git commits
+        run: |
+          yarn gitlint
+        # Always run this step so that all linting errors can be seen at once.
+        if: always()
       - name: ESLint
         # Disallow warnings and always throw errors.
         run: yarn lint --max-warnings 0
+        # Always run this step so that all linting errors can be seen at once.
+        if: always()
       - name: Validate TypeScript
         run: yarn checkTs
+        # Always run this step so that all linting errors can be seen at once.
+        if: always()

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,24 @@
+# gitlint configuration.
+
+# For more information, see:
+# https://jorisroovers.com/gitlint/configuration/.
+
+[general]
+verbosity = 2
+ignore-merge-commits=true
+ignore-fixup-commits=false
+ignore-squash-commits=false
+ignore=body-is-missing
+contrib=contrib-disallow-cleanup-commits
+
+[title-max-length]
+line-length=72
+
+[body-max-line-length]
+line-length=80
+
+[body-min-length]
+min-length=20
+
+[title-must-not-contain-word]
+words=wip

--- a/internals/scripts/gitlint.js
+++ b/internals/scripts/gitlint.js
@@ -1,0 +1,16 @@
+// @ts-check
+// https://github.com/oasisprotocol/oasis-core/blob/50d972df71fed2bcaa88e6ce5430d919ec08087d/common.mk#L171-L180
+const execSync = require('child_process').execSync
+
+const GIT_ORIGIN_REMOTE = 'origin'
+const RELEASE_BRANCH = 'master'
+const BRANCH = `${GIT_ORIGIN_REMOTE}/${RELEASE_BRANCH}`
+const COMMIT_SHA = require('child_process').execSync(`git rev-parse ${BRANCH}`).toString().trim()
+
+console.log(`*** Running gitlint for commits from ${BRANCH} (${COMMIT_SHA})`)
+
+try {
+  execSync(`gitlint --commits ${BRANCH}..HEAD`, { stdio: 'inherit' })
+} catch (error) {
+  process.exit(1)
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "checkTs": "tsc --noEmit",
     "lint": "eslint --ext js,ts,tsx ./",
     "lint:fix": "yarn run lint --fix",
+    "gitlint": "node ./internals/scripts/gitlint.js",
     "prettify": "prettier src internals --write",
     "test": "jest",
     "start-storybook": "storybook dev -p 6006",


### PR DESCRIPTION
PR follows gitlint usage in other repos. Not sure if it's the best way to handle python tasks (we will have more soon).

original makefile output [sample action logs](https://github.com/oasisprotocol/oasis-rosetta-gateway/actions/runs/4737036144/jobs/8409343175?pr=432) 
```
*** Running gitlint for commits from origin/master (6d67e3a)... 
3: B1 Line exceeds max length (86>80)
make: *** [Makefile:77: lint-git] Error 1
Error: Process completed with exit code 2.
```

yarn gitlint [sample action logs](https://github.com/buberdds/explorer/actions/runs/4753973053/jobs/8446215733?pr=47)
```
Run yarn gitlint 
yarn run v1.22.19
$ node ./internals/scripts/gitlint.js
*** Running gitlint for commits from origin/master (ce0c8761d90419377e35b2e55a6fdd1701c499dc)
Commit b6ed02c76e:
1: CC2 Fixup commits are not allowed

Commit b33af2d565:
1: T1 Title exceeds max length (82>72)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
``` 

Need to update other repos configs to use `contrib=contrib-disallow-cleanup-commits` rule instead of a custom one.