### PR TITLE
Limit deploy comments to workflow pull_request event

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       # In progress comment will be updated with a deploy status.
       - name: Add in progress comment to PR
+        # We want to add in progress comment on a pull request event only.
+        if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@v2
         with:
           message: |
@@ -65,7 +67,8 @@ jobs:
       # On a subsequent run the original comment will be updated.
       - name: Update PR comment
         uses: mshick/add-pr-comment@v2
-        if: always()
+        # We want to update a comment on a pull request event only.
+        if: github.event_name == 'pull_request' && always()
         with:
           message: |
             ## Deployed to <a href="https://pages.dev">Cloudflare Pages</a>


### PR DESCRIPTION
Workflow is triggered by two events. We care only about comments on `pull_request` event. 

Closes https://github.com/oasisprotocol/explorer/issues/357

current
https://github.com/oasisprotocol/explorer/actions/runs/4914016769/jobs/8774849482

updated action (fork)
https://github.com/buberdds/explorer/actions/runs/4914291066/jobs/8775421761




