### PR TITLE
Search across all networks

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,20 +1,11 @@
 import React from 'react'
 import { Preview } from '@storybook/react'
-import { defaultTheme } from '../src/styles/theme'
-import { ThemeProvider } from '@mui/material/styles'
-import CssBaseline from '@mui/material/CssBaseline'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import '../src/locales/i18n'
+import { withDefaultTheme } from '../src/app/components/ThemeByNetwork'
 
 const preview: Preview = {
-  decorators: [
-    Story => (
-      <ThemeProvider theme={defaultTheme}>
-        <CssBaseline />
-        <Story />
-      </ThemeProvider>
-    ),
-  ],
+  decorators: [Story => withDefaultTheme(<Story />)],
   parameters: {
     controls: {
       matchers: {

--- a/src/app/components/AppendMobileSearch/index.tsx
+++ b/src/app/components/AppendMobileSearch/index.tsx
@@ -3,7 +3,7 @@ import { styled, useTheme } from '@mui/material/styles'
 import Box from '@mui/material/Box'
 import { Search } from '../Search'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { NetworkOrGlobal } from '../../../types/network'
+import { Network } from '../../../types/network'
 
 interface AppendMobileSearchProps {
   action?: ReactNode
@@ -33,9 +33,11 @@ const SearchWrapper = styled(Box)(() => ({
   marginLeft: 'auto',
 }))
 
-export const AppendMobileSearch: FC<
-  PropsWithChildren<AppendMobileSearchProps> & { network: NetworkOrGlobal }
-> = ({ network, children, action }) => {
+export const AppendMobileSearch: FC<PropsWithChildren<AppendMobileSearchProps> & { network?: Network }> = ({
+  network,
+  children,
+  action,
+}) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { styled, useTheme } from '@mui/material/styles'
 import { useConstant } from '../../hooks/useConstant'
 import { AppendMobileSearch } from '../AppendMobileSearch'
-import { NetworkOrGlobal } from '../../../types/network'
+import { Network } from '../../../types/network'
 
 const FooterBox = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -20,7 +20,7 @@ const FooterBox = styled(Box)(({ theme }) => ({
 }))
 
 interface FooterProps {
-  network: NetworkOrGlobal
+  network?: Network
   mobileSearchAction?: ReactNode
 }
 

--- a/src/app/components/Search/SearchSuggestionsLinks.tsx
+++ b/src/app/components/Search/SearchSuggestionsLinks.tsx
@@ -5,10 +5,10 @@ import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
 import { RouteUtils } from '../../utils/route-utils'
 import { OptionalBreak } from '../OptionalBreak'
-import { NetworkOrGlobal } from '../../../types/network'
+import { Network } from '../../../types/network'
 
 interface Props {
-  network: NetworkOrGlobal
+  network?: Network
 }
 
 export const SearchSuggestionsLinks: FC<Props> = ({ network }) => {

--- a/src/app/components/Search/index.tsx
+++ b/src/app/components/Search/index.tsx
@@ -12,7 +12,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 import IconButton from '@mui/material/IconButton'
 import { SearchSuggestionsButtons } from './SearchSuggestionsButtons'
-import { NetworkOrGlobal } from '../../../types/network'
+import { Network } from '../../../types/network'
 
 export type SearchVariant = 'button' | 'icon' | 'expandable'
 
@@ -84,7 +84,7 @@ SearchButton.defaultProps = {
 }
 
 export interface SearchProps {
-  network: NetworkOrGlobal
+  network?: Network
   variant: SearchVariant
   disabled?: boolean
   onFocusChange?: (hasFocus: boolean) => void

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -7,7 +7,7 @@ import {
   isValidEthAddress,
   getEvmBech32Address,
 } from '../../utils/helpers'
-import { GlobalNetwork, Network } from '../../../types/network'
+import { Network } from '../../../types/network'
 import { RouteUtils } from '../../utils/route-utils'
 import { AppError, AppErrors } from '../../../types/errors'
 
@@ -65,10 +65,7 @@ export function isSearchValid(searchTerm: string) {
 
 export const searchParamLoader = async ({ request, params }: LoaderFunctionArgs) => {
   const { network } = params
-  if (
-    !network ||
-    (network !== GlobalNetwork && !RouteUtils.getEnabledNetworks().includes(network as Network))
-  ) {
+  if (!!network && !RouteUtils.getEnabledNetworks().includes(network as Network)) {
     throw new AppError(AppErrors.InvalidUrl)
   }
 

--- a/src/app/components/ThemeByNetwork/index.tsx
+++ b/src/app/components/ThemeByNetwork/index.tsx
@@ -1,0 +1,19 @@
+import React, { FC, ReactNode } from 'react'
+import { Network } from '../../../types/network'
+import { ThemeProvider } from '@mui/material/styles'
+import { getThemesForNetworks } from '../../../styles/theme'
+import CssBaseline from '@mui/material/CssBaseline'
+
+export const ThemeByNetwork: FC<{ network: Network; children: React.ReactNode }> = ({
+  network,
+  children,
+}) => (
+  <ThemeProvider theme={getThemesForNetworks()[network]}>
+    <CssBaseline />
+    {children}
+  </ThemeProvider>
+)
+
+export const withDefaultTheme = (node: ReactNode) => (
+  <ThemeByNetwork network={Network.mainnet}>{node}</ThemeByNetwork>
+)

--- a/src/app/hooks/useNetworkParam.ts
+++ b/src/app/hooks/useNetworkParam.ts
@@ -1,12 +1,11 @@
 import { useParams } from 'react-router-dom'
-import { Network, NetworkOrGlobal } from '../../types/network'
+import { Network } from '../../types/network'
 import { RouteUtils } from '../utils/route-utils'
 import { AppError, AppErrors } from '../../types/errors'
 
-export const useNetworkParam = (): NetworkOrGlobal => {
+export const useNetworkParam = (): Network | undefined => {
   const { network } = useParams()
-
-  return network as NetworkOrGlobal
+  return network as Network | undefined
 }
 
 /**
@@ -14,7 +13,7 @@ export const useNetworkParam = (): NetworkOrGlobal => {
  */
 export const useSafeNetworkParam = (): Network => {
   const network = useNetworkParam()
-  if (!RouteUtils.getEnabledNetworks().includes(network as any)) {
+  if (!network || !RouteUtils.getEnabledNetworks().includes(network as any)) {
     throw new AppError(AppErrors.UnsupportedNetwork)
   }
   return network as Network

--- a/src/app/pages/HomePage/Graph/NetworkSelector/index.tsx
+++ b/src/app/pages/HomePage/Graph/NetworkSelector/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TFunction } from 'i18next'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import AddIcon from '@mui/icons-material/Add'
@@ -11,7 +10,7 @@ import RemoveIcon from '@mui/icons-material/Remove'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../../../styles/theme/colors'
-import { Network } from '../../../../../types/network'
+import { getNetworkNames, Network } from '../../../../../types/network'
 import Collapse from '@mui/material/Collapse'
 import { RouteUtils } from '../../../../utils/route-utils'
 
@@ -60,18 +59,13 @@ type NetworkSelectorProps = {
   setNetwork: (network: Network) => void
 }
 
-const getLabels = (t: TFunction): { [key in Network]: string } => ({
-  mainnet: t('common.mainnet'),
-  testnet: t('common.testnet'),
-})
-
 export const NetworkSelector: FC<NetworkSelectorProps> = ({ network, setNetwork }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const [open, setOpen] = useState(false)
   const options: Network[] = RouteUtils.getEnabledNetworks()
-  const labels = getLabels(t)
+  const labels = getNetworkNames(t)
 
   return (
     <StyledNetworkSelector>

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -15,7 +15,6 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { useTranslation } from 'react-i18next'
 import { ParaTimeSelectorStep } from './Graph/types'
 import { BuildPreviewBanner } from '../../components/BuildPreviewBanner'
-import { GlobalNetwork } from '../../../types/network'
 
 export const zIndexHomePage = {
   paraTimeSelector: 1,
@@ -133,12 +132,7 @@ export const HomePage: FC = () => {
           </LogotypeBox>
           <SearchInputContainer>
             <SearchInputBox>
-              <Search
-                network={GlobalNetwork}
-                disabled={isApiOffline}
-                variant={searchVariant}
-                onFocusChange={onFocusChange}
-              />
+              <Search disabled={isApiOffline} variant={searchVariant} onFocusChange={onFocusChange} />
             </SearchInputBox>
             {isApiOffline && (
               <Box sx={{ display: 'flex', justifyContent: 'center' }}>
@@ -157,7 +151,7 @@ export const HomePage: FC = () => {
               <InfoOutlinedIcon fontSize="medium" sx={{ color: 'white' }} />
             </IconButton>
           )}
-          {!isMobile && <Footer network={GlobalNetwork} />}
+          {!isMobile && <Footer />}
         </FooterStyled>
       </HomepageLayout>
     </>

--- a/src/app/pages/SearchResultsPage/NoResults.tsx
+++ b/src/app/pages/SearchResultsPage/NoResults.tsx
@@ -7,14 +7,18 @@ import Link from '@mui/material/Link'
 import { SearchSuggestionsLinks } from '../../components/Search/SearchSuggestionsLinks'
 import { OptionalBreak } from '../../components/OptionalBreak'
 import { useTheme } from '@mui/material/styles'
-import { NetworkOrGlobal } from '../../../types/network'
+import { getNetworkNames, Network } from '../../../types/network'
 
-export const NoResults: FC<{ network: NetworkOrGlobal }> = ({ network }) => {
+export const NoResults: FC<{ network?: Network }> = ({ network }) => {
   const { t } = useTranslation()
   const theme = useTheme()
+  const title = !network
+    ? t('search.noResults.header')
+    : t('search.noResults.networkHeader', { network: getNetworkNames(t)[network] })
+
   return (
     <EmptyState
-      title={t('search.noResults.header')}
+      title={title}
       description={
         <Box
           sx={{ textAlign: 'center', a: { color: theme.palette.layout.main, textDecoration: 'underline' } }}

--- a/src/app/pages/SearchResultsPage/ResultsGroupByType.tsx
+++ b/src/app/pages/SearchResultsPage/ResultsGroupByType.tsx
@@ -1,10 +1,11 @@
-import { useTranslation } from 'react-i18next'
+import React from 'react'
 import { Link as RouterLink } from 'react-router-dom'
-import { SubPageCard } from '../../components/SubPageCard'
+import { useTranslation } from 'react-i18next'
 import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 import { styled } from '@mui/material/styles'
+import { SubPageCard } from '../../components/SubPageCard'
 
 interface Props<T> {
   title: string
@@ -24,7 +25,12 @@ export const ViewResultButton = (() => {
   return ViewResultButton as typeof Button
 })()
 
-export function ResultsGroup<T>({ title, results, resultComponent, link, linkLabel }: Props<T>) {
+/**
+ * Component for displaying search results of the same type, from the same network.
+ *
+ * It doesn't actually run a search query, but uses existing results.
+ */
+export function ResultsGroupByType<T>({ title, results, resultComponent, link, linkLabel }: Props<T>) {
   const { t } = useTranslation()
 
   if (!results || results.length <= 0) {

--- a/src/app/pages/SearchResultsPage/ResultsOnForeignNetworkThemed.tsx
+++ b/src/app/pages/SearchResultsPage/ResultsOnForeignNetworkThemed.tsx
@@ -1,0 +1,116 @@
+import { FC, useState } from 'react'
+import { getNetworkNames, Network } from '../../../types/network'
+import { Trans, useTranslation } from 'react-i18next'
+import { styled, useTheme } from '@mui/material/styles'
+import { getThemesForNetworks } from '../../../styles/theme'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import Box from '@mui/material/Box'
+import { ResultsOnNetwork } from './ResultsOnNetwork'
+import { SearchQueries } from './hooks'
+import { COLORS } from '../../../styles/theme/colors'
+import ZoomIn from '@mui/icons-material/ZoomIn'
+import Warning from '@mui/icons-material/Warning'
+
+const NotificationBox = styled(Box)(({ theme }) => ({
+  // TODO: this is probably not fully correct.
+  marginTop: 10,
+  marginBottom: 20,
+  fontSize: 14,
+
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '5px 10px',
+  gap: 10,
+
+  height: 50,
+
+  background: theme.palette.background.default,
+  border: `2px solid ${theme.palette.layout.border}`,
+  color: theme.palette.layout.main,
+
+  borderRadius: 50,
+}))
+
+/**
+ * Component for selectively displaying a subset of search results that belongs to a specific foreign network,
+ * with appropriate theming and collapse/open functionality.
+ *
+ * It doesn't actually run a search query, but uses existing results.
+ * Except the theming and the collapse functionality, it relies on ResultsOnNetwork.
+ */
+export const ResultsOnForeignNetworkThemed: FC<{
+  network: Network
+  alsoHasLocalResults: boolean
+  openByDefault?: boolean
+  searchQueries: SearchQueries
+  numberOfResults: number
+  roseFiatValue: number | undefined
+}> = ({
+  network,
+  searchQueries,
+  numberOfResults,
+  roseFiatValue,
+  openByDefault = false,
+  alsoHasLocalResults,
+}) => {
+  const [open, setOpen] = useState(openByDefault)
+  const { t } = useTranslation()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  const networkName = getNetworkNames(t)[network]
+  if (!numberOfResults) {
+    return null
+  }
+  const otherTheme = getThemesForNetworks()[network]
+
+  if (!open) {
+    return (
+      <NotificationBox theme={otherTheme} onClick={() => setOpen(true)}>
+        <ZoomIn />
+        <span>
+          <Trans
+            t={t}
+            i18nKey={
+              alsoHasLocalResults
+                ? 'search.otherResults.clickToShowMore'
+                : 'search.otherResults.clickToShowThem'
+            }
+            values={{
+              countLabel: t(alsoHasLocalResults ? 'search.results.moreCount' : 'search.results.count', {
+                count: numberOfResults,
+              }),
+              networkName,
+            }}
+          />
+        </span>
+      </NotificationBox>
+    )
+  }
+  return (
+    <Box
+      sx={{
+        marginTop: 50,
+        pt: 4,
+        px: isMobile ? 0 : '4%',
+        border: isMobile ? 'none' : `solid 15px ${otherTheme.palette.layout.border}`,
+        background: otherTheme.palette.background.default,
+      }}
+    >
+      <NotificationBox
+        sx={{
+          background: COLORS.white, // TODO should come from theme
+          color: COLORS.grayDark, // TODO should come from theme
+          border: `2px solid ${otherTheme.palette.layout.border}`,
+        }}
+        onClick={() => setOpen(false)}
+      >
+        <Warning />
+        {t('search.otherResults.clickToHide', { networkName })}
+      </NotificationBox>
+      <ResultsOnNetwork network={network} searchQueries={searchQueries} roseFiatValue={roseFiatValue} />
+    </Box>
+  )
+}

--- a/src/app/pages/SearchResultsPage/ResultsOnNetwork.tsx
+++ b/src/app/pages/SearchResultsPage/ResultsOnNetwork.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react'
+import { Network } from '../../../types/network'
+import { useTranslation } from 'react-i18next'
+import { ResultsGroupByType } from './ResultsGroupByType'
+import { BlockDetailView } from '../BlockDetailPage'
+import { RouteUtils } from '../../utils/route-utils'
+import { TransactionDetailView } from '../TransactionDetailPage'
+import { AccountDetailsView } from '../AccountDetailsPage'
+import { SearchQueries } from './hooks'
+
+/**
+ * Component for selectively displaying a subset of search results that belongs to a specific network
+ *
+ * It doesn't actually run a search query, but uses existing results.
+ */
+export const ResultsOnNetwork: FC<{
+  network: Network
+  searchQueries: SearchQueries
+  roseFiatValue: number | undefined
+}> = ({ network, searchQueries, roseFiatValue }) => {
+  const { t } = useTranslation()
+  return (
+    <>
+      <ResultsGroupByType
+        title={t('search.results.blocks.title')}
+        results={searchQueries.blockHeight.results.filter(result => result.network === network)}
+        resultComponent={item => <BlockDetailView isLoading={false} block={item} showLayer={true} />}
+        link={item => RouteUtils.getBlockRoute(item.network, item.round, item.layer)}
+        linkLabel={t('search.results.blocks.viewLink')}
+      />
+
+      <ResultsGroupByType
+        title={t('search.results.transactions.title')}
+        results={searchQueries.txHash.results.filter(result => result.network === network)}
+        resultComponent={item => (
+          <TransactionDetailView isLoading={false} transaction={item} showLayer={true} />
+        )}
+        link={item => RouteUtils.getTransactionRoute(item.network, item.eth_hash || item.hash, item.layer)}
+        linkLabel={t('search.results.transactions.viewLink')}
+      />
+
+      <ResultsGroupByType
+        title={t('search.results.accounts.title')}
+        results={[
+          ...(searchQueries.oasisAccount.results ?? []).filter(result => result.network === network),
+          ...(searchQueries.evmBech32Account.results ?? []).filter(result => result.network === network),
+        ]}
+        resultComponent={item => (
+          <AccountDetailsView
+            isLoading={false}
+            account={item}
+            roseFiatValue={roseFiatValue}
+            showLayer={true}
+          />
+        )}
+        link={item => RouteUtils.getAccountRoute(item.network, item.address_eth ?? item.address, item.layer)}
+        linkLabel={t('search.results.accounts.viewLink')}
+      />
+    </>
+  )
+}

--- a/src/app/pages/SearchResultsPage/ResultsOnNetworkThemed.tsx
+++ b/src/app/pages/SearchResultsPage/ResultsOnNetworkThemed.tsx
@@ -1,0 +1,55 @@
+import { FC } from 'react'
+import { getNetworkNames, Network } from '../../../types/network'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@mui/material/styles'
+import { getThemesForNetworks } from '../../../styles/theme'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import Box from '@mui/material/Box'
+import { ResultsOnNetwork } from './ResultsOnNetwork'
+import { SearchQueries } from './hooks'
+import Typography from '@mui/material/Typography'
+
+/**
+ * Component for selectively displaying a subset of search results that belongs to a specific network, with appropriate theming.
+ *
+ * It doesn't actually run a search query, but uses existing results.
+ * Except the theming, it relies on ResultsOnNetwork.
+ */
+export const ResultsOnNetworkThemed: FC<{
+  network: Network
+  searchQueries: SearchQueries
+  roseFiatValue: number | undefined
+}> = ({ network, searchQueries, roseFiatValue }) => {
+  const { t } = useTranslation()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  const networkName = getNetworkNames(t)[network]
+  const otherTheme = getThemesForNetworks()[network]
+
+  const content = (
+    <ResultsOnNetwork network={network} searchQueries={searchQueries} roseFiatValue={roseFiatValue} />
+  )
+
+  return (
+    <>
+      <Typography variant="h1" color={theme.palette.layout.main}>
+        {t('search.sectionHeader', { network: networkName })}
+      </Typography>
+      {network === Network.mainnet ? (
+        content
+      ) : (
+        <Box
+          sx={{
+            marginTop: 50,
+            pt: 4,
+            px: isMobile ? 0 : '4%',
+            border: isMobile ? 'none' : `solid 15px ${otherTheme.palette.layout.border}`,
+            background: otherTheme.palette.background.default,
+          }}
+        >
+          {content}
+        </Box>
+      )}
+    </>
+  )
+}

--- a/src/app/pages/SearchResultsPage/__tests__/SearchResultsView.test.tsx
+++ b/src/app/pages/SearchResultsPage/__tests__/SearchResultsView.test.tsx
@@ -21,7 +21,7 @@ describe('SearchResultsView', () => {
   it('block should correctly link to transactions', () => {
     renderWithProviders(
       <SearchResultsView
-        network={Network.mainnet}
+        wantedNetwork={Network.mainnet}
         searchQueries={{
           blockHeight: {
             isLoading: false,
@@ -52,7 +52,7 @@ describe('SearchResultsView', () => {
   it('account should correctly link to erc-20 tokens', () => {
     renderWithProviders(
       <SearchResultsView
-        network={Network.mainnet}
+        wantedNetwork={Network.mainnet}
         searchQueries={{
           blockHeight: { isLoading: false, results: [] },
           txHash: { isLoading: false, results: [] },

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -1,0 +1,148 @@
+import {
+  RuntimeAccount,
+  RuntimeBlock,
+  RuntimeTransaction,
+  useGetRuntimeAccountsAddress,
+  useGetRuntimeBlockByHeight,
+  useGetRuntimeTransactionsTxHash,
+  Runtime,
+} from '../../../oasis-indexer/api'
+import { Network } from '../../../types/network'
+import { RouteUtils } from '../../utils/route-utils'
+
+function isDefined<T>(item: T): item is NonNullable<T> {
+  return item != null
+}
+
+export type ConditionalResults<T> = { isLoading: boolean; results: T[] }
+
+export type SearchQueries = {
+  blockHeight: ConditionalResults<RuntimeBlock>
+  txHash: ConditionalResults<RuntimeTransaction>
+  oasisAccount: ConditionalResults<RuntimeAccount>
+  evmBech32Account: ConditionalResults<RuntimeAccount>
+}
+export function useBlocksConditionally(blockHeight: string | undefined): ConditionalResults<RuntimeBlock> {
+  const queries = [
+    useGetRuntimeBlockByHeight(Network.mainnet, Runtime.emerald, parseInt(blockHeight!), {
+      query: {
+        enabled:
+          !!blockHeight &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeBlockByHeight(Network.mainnet, Runtime.sapphire, parseInt(blockHeight!), {
+      query: {
+        enabled:
+          !!blockHeight &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeBlockByHeight(Network.testnet, Runtime.emerald, parseInt(blockHeight!), {
+      query: {
+        enabled:
+          !!blockHeight &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+    useGetRuntimeBlockByHeight(Network.testnet, Runtime.sapphire, parseInt(blockHeight!), {
+      query: {
+        enabled:
+          !!blockHeight &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+  ]
+  return {
+    isLoading: queries.some(query => query.isInitialLoading),
+    results: queries.map(query => query.data?.data).filter(isDefined),
+  }
+}
+export function useTransactionsConditionally(
+  txHash: string | undefined,
+): ConditionalResults<RuntimeTransaction> {
+  const queries = [
+    useGetRuntimeTransactionsTxHash(Network.mainnet, Runtime.emerald, txHash!, {
+      query: {
+        enabled:
+          !!txHash &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeTransactionsTxHash(Network.mainnet, Runtime.sapphire, txHash!, {
+      query: {
+        enabled:
+          !!txHash &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeTransactionsTxHash(Network.testnet, Runtime.emerald, txHash!, {
+      query: {
+        enabled:
+          !!txHash &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+    useGetRuntimeTransactionsTxHash(Network.testnet, Runtime.sapphire, txHash!, {
+      query: {
+        enabled:
+          !!txHash &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+  ]
+  return {
+    isLoading: queries.some(query => query.isInitialLoading),
+    results: queries.flatMap(query => query.data?.data.transactions).filter(isDefined),
+  }
+}
+export function useRuntimeAccountConditionally(
+  address: string | undefined,
+): ConditionalResults<RuntimeAccount> {
+  const queries = [
+    useGetRuntimeAccountsAddress(Network.mainnet, Runtime.emerald, address!, {
+      query: {
+        enabled:
+          !!address &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeAccountsAddress(Network.mainnet, Runtime.sapphire, address!, {
+      query: {
+        enabled:
+          !!address &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.mainnet),
+      },
+    }),
+    useGetRuntimeAccountsAddress(Network.testnet, Runtime.emerald, address!, {
+      query: {
+        enabled:
+          !!address &&
+          RouteUtils.getEnabledLayers().includes(Runtime.emerald) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+    useGetRuntimeAccountsAddress(Network.testnet, Runtime.sapphire, address!, {
+      query: {
+        enabled:
+          !!address &&
+          RouteUtils.getEnabledLayers().includes(Runtime.sapphire) &&
+          RouteUtils.getEnabledNetworks().includes(Network.testnet),
+      },
+    }),
+  ]
+  return {
+    isLoading: queries.some(query => query.isInitialLoading),
+    results: queries.map(query => query.data?.data).filter(isDefined),
+  }
+}

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -1,15 +1,20 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { SearchQueries } from '.'
+import { SearchQueries } from './hooks'
 import { RouteUtils } from '../../utils/route-utils'
+import { Network } from '../../../types/network'
+import { HasNetwork } from '../../../oasis-indexer/api'
 
 /** If search only finds one result then redirect to it */
-export function useRedirectIfSingleResult(queries: SearchQueries) {
+export function useRedirectIfSingleResult(network: Network | undefined, queries: SearchQueries) {
   const navigate = useNavigate()
 
   const isAnyLoading = Object.values(queries).some(query => query.isLoading)
+
+  const allResults = Object.values(queries).flatMap<HasNetwork>(query => query.results ?? [])
+
   const hasSingleResult =
-    !isAnyLoading && Object.values(queries).flatMap<unknown>(query => query.results ?? []).length === 1
+    !isAnyLoading && allResults.length === 1 && (!network || allResults[0].network === network)
 
   let redirectTo: string | undefined
   const block = queries.blockHeight.results?.[0]

--- a/src/app/utils/renderWithProviders.tsx
+++ b/src/app/utils/renderWithProviders.tsx
@@ -1,16 +1,10 @@
 import { MemoryRouter } from 'react-router-dom'
-import { ThemeProvider } from '@mui/material/styles'
-import CssBaseline from '@mui/material/CssBaseline'
-import { defaultTheme } from '../../styles/theme'
 import { render } from '@testing-library/react'
+import { withDefaultTheme } from '../components/ThemeByNetwork'
+import React from 'react'
 
 export function renderWithProviders(component: React.ReactElement) {
   return render(component, {
-    wrapper: ({ children }) => (
-      <ThemeProvider theme={defaultTheme}>
-        <CssBaseline />
-        <MemoryRouter>{children}</MemoryRouter>
-      </ThemeProvider>
-    ),
+    wrapper: ({ children }) => withDefaultTheme(<MemoryRouter>{children}</MemoryRouter>),
   })
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,11 +3,8 @@ import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { ThemeProvider } from '@mui/material/styles'
-import CssBaseline from '@mui/material/CssBaseline'
 import { register as registerSwiperElements } from 'swiper/element/swiper-element'
 import { routes } from './routes'
-import { defaultTheme, testnetTheme } from './styles/theme'
 import './styles/index.css'
 // Initialize languages
 import './locales/i18n'
@@ -30,15 +27,10 @@ const router = createBrowserRouter(routes)
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
-const wantedTheme = router.state.location.pathname.startsWith('/testnet') ? testnetTheme : defaultTheme
-
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={wantedTheme}>
-        <CssBaseline />
-        <RouterProvider router={router} />
-      </ThemeProvider>
+      <RouterProvider router={router} />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </React.StrictMode>,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -236,7 +236,13 @@
     "mobilePlaceholder": "Search Address, Block, Txn, etc",
     "noResults": {
       "header": "No results found",
+      "networkHeader": "No results found on {{network}}",
       "description": "Please try another search query <OptionalBreak>or <HomeLink>explore Oasis</HomeLink></OptionalBreak>"
+    },
+    "otherResults": {
+      "clickToShowThem": "We found <strong>{{ countLabel }}</strong> on the <strong>{{ networkName }}</strong>. Click to open these results.",
+      "clickToShowMore": "We also found <strong>{{ countLabel }}</strong> on the <strong>{{ networkName }}</strong>. Click to open these results.",
+      "clickToHide": "The {{ networkName }} results are shown below. Click to hide those results."
     },
     "results": {
       "accounts": {
@@ -252,9 +258,12 @@
         "viewLink": "View Transaction"
       },
       "count_one": "1 result",
-      "count_other": "{{ count }} results"
+      "count_other": "{{ count }} results",
+      "moreCount_one": "1 more result",
+      "moreCount_other": "{{ count }} more results"
     },
     "searchBtnText": "Search",
-    "searchSuggestions": "Not sure what to look for? Try out a search: <OptionalBreak><BlockLink><BlockIcon/> Block</BlockLink>, <TransactionLink><TransactionIcon/> Transaction</TransactionLink>, <AccountLink><AccountIcon/> Address</AccountLink></OptionalBreak>"
+    "searchSuggestions": "Not sure what to look for? Try out a search: <OptionalBreak><BlockLink><BlockIcon/> Block</BlockLink>, <TransactionLink><TransactionIcon/> Transaction</TransactionLink>, <AccountLink><AccountIcon/> Address</AccountLink></OptionalBreak>",
+    "sectionHeader": "Results on {{ network }}"
   }
 }

--- a/src/stories/ButtonsShowroom.stories.tsx
+++ b/src/stories/ButtonsShowroom.stories.tsx
@@ -4,7 +4,7 @@ import { SuggestionButton } from '../app/components/Search/SearchSuggestionsButt
 import { Select } from '../app/components/Select'
 import { ExploreBtn, ZoomOutBtn } from '../app/pages/HomePage/Graph/ParaTimeSelector'
 import { GetStartedBtn } from '../app/pages/HomePage/Graph/HelpScreen'
-import { ViewResultButton } from '../app/pages/SearchResultsPage/ResultsGroup'
+import { ViewResultButton } from '../app/pages/SearchResultsPage/ResultsGroupByType'
 import { LoadMoreButton } from '../app/components/LoadMoreButton'
 import { withRouter } from 'storybook-addon-react-router-v6'
 import { SelectNetworkButton } from '../app/pages/HomePage/Graph/NetworkSelector'

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -107,7 +107,7 @@ export const defaultTheme = createTheme({
     fontFamily: `"FigtreeVariable", "Helvetica", "Arial", sans-serif`,
     fontWeightLight: 200,
     fontWeightRegular: 400,
-    fontWeightBold: 500,
+    fontWeightBold: 700,
     body2: {
       fontSize: '16px',
     },

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -1,4 +1,14 @@
+import { Network } from '../../types/network'
+import { defaultTheme } from './defaultTheme'
+import { testnetTheme } from './testnet/theme'
+import type { Theme } from '@mui/material/styles/createTheme'
+
 export { defaultTheme } from './defaultTheme'
 export { testnetTheme } from './testnet/theme'
 
 export const tooltipDelay = 500
+
+export const getThemesForNetworks: () => Record<Network, Theme> = () => ({
+  [Network.mainnet]: defaultTheme,
+  [Network.testnet]: testnetTheme,
+})

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -8,10 +8,6 @@ export const Network = {
   testnet: 'testnet',
 } as const
 
-export const GlobalNetwork = 'global'
-
-export type NetworkOrGlobal = Network | typeof GlobalNetwork
-
 export const getNetworkNames = (t: TFunction): Record<Network, string> => ({
   [Network.mainnet]: t('common.mainnet'),
   [Network.testnet]: t('common.testnet'),


### PR DESCRIPTION
Task is https://app.clickup.com/t/862ju7v0a.

~This depends on #404.~

Some explanation: with this, we support two kinds of search. 

- One is launched from within a page belonging to a specific network. The URL is like `/mainnet/ember/search?q=whatever`. In this case, we are mainly showing the results from that network. (And maybe some indicators about results elsewhere.)
- Then there is the so-called "global" search, which is what you get if you launch a search right from the opening homepage, without actually entering any paratime first. The URL for this is `/global/search?q=whatever`. In this case, you see all results, grouped by networks of course.

In the URL, there is always something that specifies the flavor of the search. That is either a name of a network (mainnet or testnet), or "global" for global search.
