### PR TITLE
Make EmptySpace / NoResults theme-aware

### DIFF
--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -2,18 +2,17 @@ import { FC, ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
-import { COLORS } from '../../../styles/theme/colors'
 import backgroundEmptyState from './images/background-empty-state.svg'
 import CancelIcon from '@mui/icons-material/Cancel'
 
-const StyledBox = styled(Box)(() => ({
+const StyledBox = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'column',
   minHeight: '250px',
-  color: COLORS.white,
-  backgroundColor: COLORS.brandExtraDark,
+  color: theme.palette.layout.main,
+  backgroundColor: theme.palette.background.empty,
   backgroundImage: `url("${backgroundEmptyState}")`,
   backgroundPosition: 'center',
   backgroundRepeat: 'no-repeat',

--- a/src/app/pages/SearchResultsPage/NoResults.tsx
+++ b/src/app/pages/SearchResultsPage/NoResults.tsx
@@ -5,16 +5,19 @@ import { Trans, useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
 import { SearchSuggestionsLinks } from '../../components/Search/SearchSuggestionsLinks'
-import { COLORS } from '../../../styles/theme/colors'
 import { OptionalBreak } from '../../components/OptionalBreak'
+import { useTheme } from '@mui/material/styles'
 
 export const NoResults: FC = () => {
   const { t } = useTranslation()
+  const theme = useTheme()
   return (
     <EmptyState
       title={t('search.noResults.header')}
       description={
-        <Box sx={{ textAlign: 'center', a: { color: COLORS.white, textDecoration: 'underline' } }}>
+        <Box
+          sx={{ textAlign: 'center', a: { color: theme.palette.layout.main, textDecoration: 'underline' } }}
+        >
           <p>
             <Trans
               t={t}

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -58,10 +58,18 @@ declare module '@mui/material/Chip' {
   }
 }
 
+declare module '@mui/material/styles' {
+  // allow configuration using `createTheme`
+  interface TypeBackground {
+    empty?: string
+  }
+}
+
 export const defaultTheme = createTheme({
   palette: {
     background: {
       default: COLORS.persianBlue,
+      empty: COLORS.brandExtraDark,
     },
     layout: {
       main: COLORS.white,

--- a/src/styles/theme/testnet/theme.ts
+++ b/src/styles/theme/testnet/theme.ts
@@ -8,6 +8,7 @@ export const testnetTheme = createTheme(
     palette: {
       background: {
         default: COLORS.testnetLight,
+        empty: COLORS.white,
       },
       layout: {
         main: COLORS.brandExtraDark,


### PR DESCRIPTION
This PR improves how the "no results found" message looks on the TestNet.

It can't be directly tested, unless you also have the changes from #404, but I'm opening this a separate PR to avoid later conflicts with other theming work.

Before:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/c8ce7762-5719-4208-acab-e972025879cd)

After:

![after](https://github.com/oasisprotocol/explorer/assets/2093792/bac903f3-0bb8-4b42-aacd-f7198c98fe50)

@donouwens says that the visual aspects are acceptable.
