### PR TITLE
Update Orval to latest (for API wrapper code generation)

### DIFF
--- a/src/oasis-indexer/package.json
+++ b/src/oasis-indexer/package.json
@@ -4,6 +4,6 @@
     "generate": "orval"
   },
   "dependencies": {
-    "orval": "^6.14.4"
+    "orval": "^6.16.0"
   }
 }

--- a/src/oasis-indexer/yarn.lock
+++ b/src/oasis-indexer/yarn.lock
@@ -107,24 +107,24 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orval/angular@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/angular/-/angular-6.14.4.tgz#630dfecf9219c48651cfa2e7688d81ecf6f20e78"
-  integrity sha512-NYc7Rh69AE+BaVS9EWZZpSQ/HmySghh8QdwKohQuQgLYWkdKa9ZY1lSKIOm03N44AepF/w1y5r4iezC7efztzg==
+"@orval/angular@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/angular/-/angular-6.16.0.tgz#65bdf9edac4dfe57c9c21dfe7d7ceebd861693b8"
+  integrity sha512-pdKQkmHG0YRZF1Vkh1kvuIVGseec4mArXW0BV8LzrtP7F2Wg51cDcYys/gh3w/rq6uE2FGa4ildl+wvPq6pLJg==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
 
-"@orval/axios@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/axios/-/axios-6.14.4.tgz#ec94a13a36699acbac4783d7d64fa6d6e9dc53c1"
-  integrity sha512-B1tvN8+rD4YNG2ScqBxdDyO8IKtocVXQBIEB4FwevmPM3rzxF6B9ejzywiqy/TnwrrtzVIosp8PFvIPRZ7TSMg==
+"@orval/axios@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/axios/-/axios-6.16.0.tgz#4929e9aae8f7bee303994fc943ac0d7d01010f13"
+  integrity sha512-RL/inKaJg5ivFcI0JrJPqlcR1MqFl2pv/j1GM79D4fKdTHFbXSD7/AVav6IQHnkQlrfuJxIca4flUphEXDc0kw==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
 
-"@orval/core@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/core/-/core-6.14.4.tgz#94413d45f76b90c7df63d51935a7e57829f1539f"
-  integrity sha512-ix1k5qx5tpTRQ06waQLyYNm2pljuZJ2TG8ViydSvug35lzdJKCjDSGUs4SN1LqhWX5k+6T5CiJgiWkWfctea7A==
+"@orval/core@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/core/-/core-6.16.0.tgz#afbe64df438d1f19ee5d06e9c47527201a9c0ab4"
+  integrity sha512-9OgVvRZSaZecV2srixw+eCANSvXiKOiLPBSi9LjSyzU7HMPh1eVvYEE/ZzV7l/n0XIErE/DFcuvQTNAidsrIaw==
   dependencies:
     "@apidevtools/swagger-parser" "^10.1.0"
     acorn "^8.8.0"
@@ -148,38 +148,38 @@
     swagger2openapi "^7.0.8"
     validator "^13.7.0"
 
-"@orval/msw@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/msw/-/msw-6.14.4.tgz#86c46855bac0808d7c744065f3d9f8888debe61b"
-  integrity sha512-I6iX5V+SrkfTESUP9kdZrsci7jPE45TjQXds+cH+Mg6VDEvVCrF/+ESR5Q4eNgBWvcmBeUrNn6TACJGllf0IgQ==
+"@orval/msw@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/msw/-/msw-6.16.0.tgz#3eba19237fb29ee0b525d824e24b45a1b8bec513"
+  integrity sha512-/SVDOHBDoYEUUbIbA4fKAmm+0gwbf/TjJTBU2he3Cu6LNAaxKjbiLKR9jSMsPU1haJczoIfq1LxctwRi1iW+mg==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
     cuid "^2.1.8"
     lodash.get "^4.4.2"
     lodash.omit "^4.5.0"
     openapi3-ts "^3.0.0"
 
-"@orval/query@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/query/-/query-6.14.4.tgz#4374b807ceca6b2c885ab8a980c0d75d0a04bb58"
-  integrity sha512-EvmEMaA7X062NnIgLSR4CfBFcjFopvsFSLD7Zz3rMRx+gaYJLQtp5VTETGMrYhp6gmY/d5dC1JRF4PWg4Lvv2A==
+"@orval/query@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/query/-/query-6.16.0.tgz#b04f6c5ce9b274dfb446991ac8cfa093fc59d4fe"
+  integrity sha512-X0d51at/6X5w3wWuyLTSjQ95oZHL4CqhWDgeDlgzYLRGORjX6YRvMODT/SM70rEDNvd+WwwZ+PHYgPL6tJhvNA==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
     lodash.omitby "^4.6.0"
 
-"@orval/swr@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/swr/-/swr-6.14.4.tgz#cc62854361eee7c388296bc054ae6c19c3fa9af4"
-  integrity sha512-ixGG86PvPQ7f2kiU3Fu7ocJb4kyg1bobfNzWMakUg6uiTnxVVbu2Nkg87lXQRYu+vDZPKh3JGyS+dU4oU+EYGg==
+"@orval/swr@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/swr/-/swr-6.16.0.tgz#f3244303fc82a6225409f2720da54227330c6e35"
+  integrity sha512-pbicl6Ado/fyorY1GZzQSzUIm0NwARo5mmPCqiSR5TrS0mBx+UXj65xV+T8vKI5Cs2atoch9Nz9BCb0hr0XpTw==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
 
-"@orval/zod@6.14.4":
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/@orval/zod/-/zod-6.14.4.tgz#5561c059fb5ce0aa4964c1d31286557a9e27cc70"
-  integrity sha512-9WRmwCXYBAKx6zEh8vvcDiVQe3JwrdKm8f+2qw3sARI8CLCwiIreyVY3HGmm3nMNxBtjCXEeLVqup0xZGNIX9g==
+"@orval/zod@6.16.0":
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/@orval/zod/-/zod-6.16.0.tgz#d7865efa0bf8b988837de5cdf8f0f8b98291b087"
+  integrity sha512-ptwVvuFYRdGHiLLdxk/afcYE92jAwtRELe1XWwakKUbKU5s4rXr/81zJumqLwVrdR2fUfnUiJCpqp5sgVLaECw==
   dependencies:
-    "@orval/core" "6.14.4"
+    "@orval/core" "6.16.0"
     lodash.uniq "^4.5.0"
 
 "@rollup/plugin-commonjs@~22.0.2":
@@ -2019,19 +2019,19 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-orval@^6.14.4:
-  version "6.14.4"
-  resolved "https://registry.yarnpkg.com/orval/-/orval-6.14.4.tgz#638f68bf650f732bbaf7fcb22953ab7b4ec5bdd6"
-  integrity sha512-kMFZsSjetAPang7bcitcxtdiQe8ImNCKl4U3tIRex9DrZsTWI0DHJvKjN1hRtDx/4Ya26jV9Wn7JZQWsreKbtg==
+orval@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/orval/-/orval-6.16.0.tgz#8ab8782004c936f5ed9b39053756a7821701e1ea"
+  integrity sha512-T04wzQr/pQaxpJoLvAnDeWlZCAnGuPteds/5bgGfN3qkx96k4QmmYHonO4N9xyUfxRVBdjWWc+LDxmO/jj/Apw==
   dependencies:
     "@apidevtools/swagger-parser" "^10.1.0"
-    "@orval/angular" "6.14.4"
-    "@orval/axios" "6.14.4"
-    "@orval/core" "6.14.4"
-    "@orval/msw" "6.14.4"
-    "@orval/query" "6.14.4"
-    "@orval/swr" "6.14.4"
-    "@orval/zod" "6.14.4"
+    "@orval/angular" "6.16.0"
+    "@orval/axios" "6.16.0"
+    "@orval/core" "6.16.0"
+    "@orval/msw" "6.16.0"
+    "@orval/query" "6.16.0"
+    "@orval/swr" "6.16.0"
+    "@orval/zod" "6.16.0"
     ajv "^8.11.0"
     cac "^6.7.12"
     chalk "^4.1.2"


### PR DESCRIPTION
There is a problem around number / bigint in the version of Orval we are currently using, as Luka has explained [here](https://github.com/oasisprotocol/explorer/pull/267#discussion_r1195385202).

This PR updates Orval to the latest release.

(Which I have verified to work.)

Doing this is necessary to get the latest API changes.