### PR TITLE
Fix selecting tabs with hash fragment in the URL (e.g. /erc-20#tokens)

### DIFF
--- a/src/app/components/RouterTabs/index.tsx
+++ b/src/app/components/RouterTabs/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { useLocation, matchPath, Link as RouterLink, Outlet } from 'react-router-dom'
+import { useLocation, Link as RouterLink, Outlet } from 'react-router-dom'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 
@@ -10,9 +10,13 @@ type RouterTabsProps = {
   }[]
 }
 
+function getPathname(tab: { to: string }) {
+  return new URL(tab.to, 'https://a.b').pathname
+}
+
 export const RouterTabs: FC<RouterTabsProps> = ({ tabs }) => {
   const { pathname } = useLocation()
-  const currentTab = tabs.find(tab => matchPath(tab.to, pathname))
+  const currentTab = tabs.find(tab => getPathname(tab) === pathname)
 
   return (
     <>


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/explorer/pull/401 and https://github.com/oasisprotocol/explorer/pull/419

| Before | After |
| --- | --- |
|  ![localhost_1234_mainnet_emerald_account_0xBA504818FdD8D3dBA2Ef8fD9B4F4D5c71aD1d1D3_tokens_erc-20 (1)](https://github.com/oasisprotocol/explorer/assets/3758846/b5803b5a-6ac0-4e72-8454-f2a83b749a40) | ![localhost_1234_mainnet_emerald_account_0xBA504818FdD8D3dBA2Ef8fD9B4F4D5c71aD1d1D3_tokens_erc-20](https://github.com/oasisprotocol/explorer/assets/3758846/3a691e98-86b5-4fac-b437-1b8fb67f9fb2)  |