### PR TITLE
Copy the correct value for block hash

### DIFF
--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -96,7 +96,7 @@ export const BlockDetailView: FC<{
       <dt>{t('common.hash')}</dt>
       <dd>
         <BlockHashLink network={block.network} hash={block.hash} height={block.round} layer={block.layer} />
-        <CopyToClipboard value={block.round.toString()} />
+        <CopyToClipboard value={block.hash.toString()} />
       </dd>
 
       <dt>{t('common.timestamp')}</dt>


### PR DESCRIPTION
Currently, attempting to copy the block hash actually gets is the block height number instead.
This is a one-liner fix for that.