### PR TITLE
Add missing wrappers for API calls and block accidental mainnet fallback

### DIFF
--- a/src/app/components/Transactions/Logs.tsx
+++ b/src/app/components/Transactions/Logs.tsx
@@ -9,11 +9,11 @@ import { Network } from '../../../types/network'
 export const TransactionLogs: FC<{
   transaction: RuntimeTransaction
 }> = ({ transaction }) => {
-  const { layer } = transaction
+  const { network, layer } = transaction
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
   }
-  const eventsQuery = useGetRuntimeEvents(layer, {
+  const eventsQuery = useGetRuntimeEvents(network, layer, {
     tx_hash: transaction.hash,
     limit: 100, // We want to avoid pagination here, if possible
   })

--- a/src/app/pages/DashboardPage/ActiveAccounts.tsx
+++ b/src/app/pages/DashboardPage/ActiveAccounts.tsx
@@ -16,6 +16,7 @@ import {
   sumBucketsByStartDuration,
 } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const getActiveAccountsWindows = (duration: ChartDuration, windows: Windows[]) => {
   switch (duration) {
@@ -59,8 +60,10 @@ type ActiveAccountsProps = {
 export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
   const { limit, bucket_size_seconds } = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
   const activeAccountsQuery = useGetLayerStatsActiveAccounts(
+    network,
     layer,
     {
       limit,

--- a/src/app/pages/DashboardPage/Nodes.tsx
+++ b/src/app/pages/DashboardPage/Nodes.tsx
@@ -8,14 +8,16 @@ import { COLORS } from '../../../styles/theme/colors'
 import { Layer, useGetRuntimeStatus } from '../../../oasis-indexer/api'
 import { useLayerParam } from '../../hooks/useLayerParam'
 import { AppErrors } from '../../../types/errors'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const Nodes: FC = () => {
   const { t } = useTranslation()
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
   }
-  const runtimeStatusQuery = useGetRuntimeStatus(layer)
+  const runtimeStatusQuery = useGetRuntimeStatus(network, layer)
   const activeNodes = runtimeStatusQuery.data?.data?.active_nodes
 
   return (

--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -9,13 +9,15 @@ import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration, cumulativeSum } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
-  const dailyVolumeQuery = useGetLayerStatsTxVolume(layer, statsParams, {
+  const dailyVolumeQuery = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: {
       keepPreviousData: true,
       staleTime: chartUseQueryStaleTimeMs,

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -14,6 +14,7 @@ import { SnapshotCard } from './SnapshotCard'
 import { PercentageGain } from '../../components/PercentageGain'
 import startOfHour from 'date-fns/startOfHour'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 interface TransactionsChartCardProps {
   chartDuration: ChartDuration
@@ -24,8 +25,9 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const statsParams = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
-  const { data, isFetched } = useGetLayerStatsTxVolume(layer, statsParams, {
+  const { data, isFetched } = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: { staleTime: chartUseQueryStaleTimeMs },
   })
 

--- a/src/app/pages/DashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/DashboardPage/TransactionsStats.tsx
@@ -13,13 +13,15 @@ import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const TransactionsStats: FC = () => {
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
   const layer = useLayerParam()
-  const dailyVolumeQuery = useGetLayerStatsTxVolume(layer, statsParams, {
+  const network = useSafeNetworkParam()
+  const dailyVolumeQuery = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: {
       keepPreviousData: true,
       staleTime: chartUseQueryStaleTimeMs,

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -107,7 +107,8 @@ export const HomePage: FC = () => {
   const { t } = useTranslation()
   const infoAriaLabel = t('home.helpScreen.infoIconAria')
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const apiStatusQuery = useGetStatus()
+  const { network } = useSearchQueryNetworkParam()
+  const apiStatusQuery = useGetStatus(network)
   const isApiOffline = apiStatusQuery.isFetched && !apiStatusQuery.isSuccess
 
   const [searchHasFocus, setSearchHasFocus] = useState(false)
@@ -142,7 +143,7 @@ export const HomePage: FC = () => {
               </Box>
             )}
           </SearchInputContainer>
-          <ThemeByNetwork network={useSearchQueryNetworkParam().network}>
+          <ThemeByNetwork network={network}>
             <Box sx={{ zIndex: zIndexHomePage.paraTimeSelector }}>
               <ParaTimeSelector step={step} setStep={setStep} disabled={searchHasFocus} />
             </Box>

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -443,3 +443,81 @@ export const useGetRuntimeBlocks: typeof _f9 = (network, runtime, params, option
     },
   })
 }
+
+const _f10 = wrapWithNetwork(generated.useGetLayerStatsActiveAccounts)
+
+export const useGetLayerStatsActiveAccounts: typeof _f10 = (network, runtime, params, options) =>
+  generated.useGetLayerStatsActiveAccounts(runtime, params, {
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, `/${runtime}/stats/active_accounts`, ...(params ? [params] : [])],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+    },
+  })
+
+const _f11 = wrapWithNetwork(generated.useGetLayerStatsTxVolume)
+
+export const useGetLayerStatsTxVolume: typeof _f11 = (network, runtime, params, options) =>
+  generated.useGetLayerStatsTxVolume(runtime, params, {
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, `/${runtime}/stats/tx_volume`, ...(params ? [params] : [])],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+    },
+  })
+
+const _f12 = wrapWithNetwork(generated.useGetRuntimeStatus)
+
+export const useGetRuntimeStatus: typeof _f12 = (network, runtime, options) => {
+  return generated.useGetRuntimeStatus(runtime, {
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, `/${runtime}/status`],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+    },
+  })
+}
+
+const _f13 = wrapWithNetwork(generated.useGetStatus)
+
+export const useGetStatus: typeof _f13 = (network, options) => {
+  return generated.useGetStatus({
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, `/`],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+    },
+  })
+}
+
+const _f14 = wrapWithNetwork(generated.useGetRuntimeEvents)
+
+export const useGetRuntimeEvents: typeof _f14 = (network, runtime, params, options) => {
+  return generated.useGetRuntimeEvents(runtime, params, {
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, ...generated.getGetRuntimeEventsQueryKey(runtime, params)],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+    },
+  })
+}

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -9,7 +9,8 @@ import { Layer } from './generated/api'
 import { getEthAccountAddress } from '../app/utils/helpers'
 import { Network } from '../types/network'
 
-export * from './generated/api'
+export type * from './generated/api'
+export { Layer, Runtime, RuntimeEventType } from './generated/api'
 export type { RuntimeEvmBalance as Token } from './generated/api'
 
 export interface HasNetwork {


### PR DESCRIPTION
Since we need to be able to override the URL for testnet, and this functionality is currently only implemented in our manual API wrappers, we need manual wrappers for all API functions we want to use.

We already had them for most, but a few were missing, and thus those calls always went to mainnet, instead of testnet.

This change fixes that by adding the missing wrappers, and updating the app code to always add the network param.

**Update:** it also makes it impossible to accidentally use a wrapper-less API call in the future.