### PR TITLE
Add missing wrappers for API calls and block accidental mainnet fallback, v2 (with more sugar)

### DIFF
--- a/src/app/components/Transactions/Logs.tsx
+++ b/src/app/components/Transactions/Logs.tsx
@@ -9,11 +9,11 @@ import { Network } from '../../../types/network'
 export const TransactionLogs: FC<{
   transaction: RuntimeTransaction
 }> = ({ transaction }) => {
-  const { layer } = transaction
+  const { network, layer } = transaction
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
   }
-  const eventsQuery = useGetRuntimeEvents(layer, {
+  const eventsQuery = useGetRuntimeEvents(network, layer, {
     tx_hash: transaction.hash,
     limit: 100, // We want to avoid pagination here, if possible
   })

--- a/src/app/pages/DashboardPage/ActiveAccounts.tsx
+++ b/src/app/pages/DashboardPage/ActiveAccounts.tsx
@@ -16,6 +16,7 @@ import {
   sumBucketsByStartDuration,
 } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const getActiveAccountsWindows = (duration: ChartDuration, windows: Windows[]) => {
   switch (duration) {
@@ -59,8 +60,10 @@ type ActiveAccountsProps = {
 export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
   const { limit, bucket_size_seconds } = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
   const activeAccountsQuery = useGetLayerStatsActiveAccounts(
+    network,
     layer,
     {
       limit,

--- a/src/app/pages/DashboardPage/Nodes.tsx
+++ b/src/app/pages/DashboardPage/Nodes.tsx
@@ -8,14 +8,16 @@ import { COLORS } from '../../../styles/theme/colors'
 import { Layer, useGetRuntimeStatus } from '../../../oasis-indexer/api'
 import { useLayerParam } from '../../hooks/useLayerParam'
 import { AppErrors } from '../../../types/errors'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const Nodes: FC = () => {
   const { t } = useTranslation()
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
   }
-  const runtimeStatusQuery = useGetRuntimeStatus(layer)
+  const runtimeStatusQuery = useGetRuntimeStatus(network, layer)
   const activeNodes = runtimeStatusQuery.data?.data?.active_nodes
 
   return (

--- a/src/app/pages/DashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/DashboardPage/TotalTransactions.tsx
@@ -9,13 +9,15 @@ import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration, cumulativeSum } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const TotalTransactions: FC = () => {
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
-  const dailyVolumeQuery = useGetLayerStatsTxVolume(layer, statsParams, {
+  const dailyVolumeQuery = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: {
       keepPreviousData: true,
       staleTime: chartUseQueryStaleTimeMs,

--- a/src/app/pages/DashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/DashboardPage/TransactionsChartCard.tsx
@@ -14,6 +14,7 @@ import { SnapshotCard } from './SnapshotCard'
 import { PercentageGain } from '../../components/PercentageGain'
 import startOfHour from 'date-fns/startOfHour'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 interface TransactionsChartCardProps {
   chartDuration: ChartDuration
@@ -24,8 +25,9 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const statsParams = durationToQueryParams[chartDuration]
+  const network = useSafeNetworkParam()
   const layer = useLayerParam()
-  const { data, isFetched } = useGetLayerStatsTxVolume(layer, statsParams, {
+  const { data, isFetched } = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: { staleTime: chartUseQueryStaleTimeMs },
   })
 

--- a/src/app/pages/DashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/DashboardPage/TransactionsStats.tsx
@@ -13,13 +13,15 @@ import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration } from '../../utils/chart-utils'
 import { useLayerParam } from '../../hooks/useLayerParam'
+import { useSafeNetworkParam } from '../../hooks/useNetworkParam'
 
 export const TransactionsStats: FC = () => {
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
   const layer = useLayerParam()
-  const dailyVolumeQuery = useGetLayerStatsTxVolume(layer, statsParams, {
+  const network = useSafeNetworkParam()
+  const dailyVolumeQuery = useGetLayerStatsTxVolume(network, layer, statsParams, {
     query: {
       keepPreviousData: true,
       staleTime: chartUseQueryStaleTimeMs,

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -15,6 +15,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { useTranslation } from 'react-i18next'
 import { ParaTimeSelectorStep } from './Graph/types'
 import { BuildPreviewBanner } from '../../components/BuildPreviewBanner'
+import { Network } from '../../../types/network'
 
 export const zIndexHomePage = {
   paraTimeSelector: 1,
@@ -105,7 +106,7 @@ export const HomePage: FC = () => {
   const { t } = useTranslation()
   const infoAriaLabel = t('home.helpScreen.infoIconAria')
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const apiStatusQuery = useGetStatus()
+  const apiStatusQuery = useGetStatus(Network.mainnet) // TODO: what is testnet is off-line? We need a combined status
   const isApiOffline = apiStatusQuery.isFetched && !apiStatusQuery.isSuccess
 
   const [searchHasFocus, setSearchHasFocus] = useState(false)

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -8,6 +8,7 @@ import { UseQueryOptions } from '@tanstack/react-query'
 import { Layer } from './generated/api'
 import { getEthAccountAddress } from '../app/utils/helpers'
 import { Network } from '../types/network'
+import { getOptionsFor, wrapWithNetwork } from './wrapper-helpers'
 
 export * from './generated/api'
 export type { RuntimeEvmBalance as Token } from './generated/api'
@@ -44,36 +45,6 @@ declare module './generated/api' {
   }
 }
 
-function wrapWithNetwork<P extends Array<any>, Q>(f: (...args: P) => Q): (net: Network, ...args: P) => Q {
-  return (net, ...args) => {
-    console.log('Should use', net)
-    return f(...args)
-  }
-}
-
-const baseUrlOverrides: Record<Network, string> = {
-  mainnet: process.env.REACT_APP_API!, // This is just here for the sake of completeness, since the default URL is already specified for Axios elsewhere.
-  testnet: process.env.REACT_APP_TESTNET_API!,
-}
-
-Object.keys(baseUrlOverrides).forEach(net => {
-  const url = baseUrlOverrides[net as Network]
-  if (!url) {
-    console.warn(
-      `URL for ${net} is not specified in config! Data from this network won't ba available. (See env.REACT_APP_*)`,
-    )
-  }
-})
-
-const getBaseUrlParamFor = (network: Network): Partial<AxiosRequestConfig<any>> => {
-  const override = baseUrlOverrides[network]
-  return override
-    ? { baseURL: override }
-    : {
-        // No override means that the default one (already specified for Axios) will suffice.
-      }
-}
-
 function fromBaseUnits(valueInBaseUnits: string, decimals: number): string {
   const value = new BigNumber(valueInBaseUnits).shiftedBy(-decimals) // / 10 ** decimals
   if (value.isNaN()) {
@@ -90,16 +61,10 @@ function arrayify<T>(arrayOrItem: null | undefined | T | T[]): T[] {
 
 const _f1 = wrapWithNetwork(generated.useGetConsensusTransactions)
 
-export const useGetConsensusTransactions: typeof _f1 = (network, params?, options?) => {
-  return generated.useGetConsensusTransactions(params, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/consensus/transactions`, ...(params ? [params] : [])],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetConsensusTransactions: typeof _f1 = (network, params?, options?) =>
+  generated.useGetConsensusTransactions(
+    params,
+    getOptionsFor(options, network, generated.getGetConsensusTransactionsQueryKey(params), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.TransactionList, headers, status) => {
@@ -117,22 +82,16 @@ export const useGetConsensusTransactions: typeof _f1 = (network, params?, option
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 const _f2 = wrapWithNetwork(generated.useGetRuntimeTransactions)
 
-export const useGetRuntimeTransactions: typeof _f2 = (network, runtime, params?, options?) => {
-  return generated.useGetRuntimeTransactions(runtime, params, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/${runtime}/transactions`, ...(params ? [params] : [])],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetRuntimeTransactions: typeof _f2 = (network, runtime, params?, options?) =>
+  generated.useGetRuntimeTransactions(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetRuntimeTransactionsQueryKey(runtime, params), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.RuntimeTransactionList, headers, status) => {
@@ -153,22 +112,15 @@ export const useGetRuntimeTransactions: typeof _f2 = (network, runtime, params?,
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 const _f3 = wrapWithNetwork(generated.useGetConsensusTransactionsTxHash)
 
-export const useGetConsensusTransactionsTxHash: typeof _f3 = (network, txHash, options?) => {
-  return generated.useGetConsensusTransactionsTxHash(txHash, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/consensus/transactions/${txHash}`],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetConsensusTransactionsTxHash: typeof _f3 = (network, txHash, options?) =>
+  generated.useGetConsensusTransactionsTxHash(
+    txHash,
+    getOptionsFor(options, network, generated.getGetConsensusTransactionsTxHashQueryKey(txHash), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.TransactionList, headers, status) => {
@@ -186,24 +138,18 @@ export const useGetConsensusTransactionsTxHash: typeof _f3 = (network, txHash, o
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 const _f5 = wrapWithNetwork(generated.useGetRuntimeTransactionsTxHash)
 
 export const useGetRuntimeTransactionsTxHash: typeof _f5 = (network, runtime, txHash, options?) => {
   // Sometimes we will call this with an undefined txHash, so we must be careful here.
   const actualHash = txHash?.startsWith('0x') ? txHash.substring(2) : txHash
-  return generated.useGetRuntimeTransactionsTxHash(runtime, actualHash, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/${runtime}/transactions/${actualHash}`],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+  return generated.useGetRuntimeTransactionsTxHash(
+    runtime,
+    actualHash,
+    getOptionsFor(options, network, generated.getGetRuntimeTransactionsTxHashQueryKey(runtime, actualHash), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.RuntimeTransactionList, headers, status) => {
@@ -224,22 +170,16 @@ export const useGetRuntimeTransactionsTxHash: typeof _f5 = (network, runtime, tx
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
+    }),
+  )
 }
 
 const _f6 = wrapWithNetwork(generated.useGetConsensusAccountsAddress)
 
-export const useGetConsensusAccountsAddress: typeof _f6 = (network, address, options?) => {
-  return generated.useGetConsensusAccountsAddress(address, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`${network}/consensus/accounts/${address}`],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetConsensusAccountsAddress: typeof _f6 = (network, address, options?) =>
+  generated.useGetConsensusAccountsAddress(
+    address,
+    getOptionsFor(options, network, generated.getGetConsensusAccountsAddressQueryKey(address), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.Account, headers, status) => {
@@ -252,22 +192,16 @@ export const useGetConsensusAccountsAddress: typeof _f6 = (network, address, opt
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 const _f7 = wrapWithNetwork(generated.useGetRuntimeAccountsAddress)
 
-export const useGetRuntimeAccountsAddress: typeof _f7 = (network, runtime, address, options?) => {
-  return generated.useGetRuntimeAccountsAddress(runtime, address, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/${runtime}/accounts/${address}`],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetRuntimeAccountsAddress: typeof _f7 = (network, runtime, address, options?) =>
+  generated.useGetRuntimeAccountsAddress(
+    runtime,
+    address,
+    getOptionsFor(options, network, generated.getGetRuntimeAccountsAddressQueryKey(runtime, address), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.RuntimeAccount, headers, status) => {
@@ -302,23 +236,17 @@ export const useGetRuntimeAccountsAddress: typeof _f7 = (network, runtime, addre
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 export function useGetConsensusBlockByHeight(
   network: Network,
   blockHeight: number,
-  options?: { query?: UseQueryOptions<any, any> },
+  options?: { query?: UseQueryOptions<any, any>; axios?: AxiosRequestConfig },
 ) {
-  const result = generated.useGetConsensusBlocksHeight<AxiosResponse<generated.Block, any>>(blockHeight, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/consensus/blocks/${blockHeight}`],
-    },
-    axios: {
-      ...getBaseUrlParamFor(network),
+  return generated.useGetConsensusBlocksHeight<AxiosResponse<generated.Block, any>>(
+    blockHeight,
+    getOptionsFor(options, network, generated.getGetConsensusBlocksHeightQueryKey(blockHeight), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (block: generated.Block, headers, status) => {
@@ -330,9 +258,8 @@ export function useGetConsensusBlockByHeight(
           }
         },
       ],
-    },
-  })
-  return result
+    }),
+  )
 }
 
 // TODO: replace with an appropriate API
@@ -340,17 +267,13 @@ export function useGetRuntimeBlockByHeight(
   network: Network,
   runtime: generated.Runtime,
   blockHeight: number,
-  options?: { query?: UseQueryOptions<any, any> },
+  options?: { query?: UseQueryOptions<any, any>; axios?: AxiosRequestConfig },
 ) {
   const params: generated.GetRuntimeBlocksParams = { to: blockHeight, limit: 1 }
-  const result = generated.useGetRuntimeBlocks<AxiosResponse<generated.RuntimeBlock, any>>(runtime, params, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/${runtime}/blocks`, params],
-    },
-    axios: {
-      ...getBaseUrlParamFor(network),
+  return generated.useGetRuntimeBlocks<AxiosResponse<generated.RuntimeBlock, any>>(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetRuntimeBlocksQueryKey(runtime, params), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         function (data: generated.RuntimeBlockList, headers, status) {
@@ -372,23 +295,16 @@ export function useGetRuntimeBlockByHeight(
           }
         },
       ],
-    },
-  })
-  return result
+    }),
+  )
 }
 
 const _f8 = wrapWithNetwork(generated.useGetConsensusBlocks)
 
-export const useGetConsensusBlocks: typeof _f8 = (network, params, options) => {
-  return generated.useGetConsensusBlocks(params, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/consensus/blocks`, ...(params ? [params] : [])],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetConsensusBlocks: typeof _f8 = (network, params, options) =>
+  generated.useGetConsensusBlocks(
+    params,
+    getOptionsFor(options, network, generated.getGetConsensusBlocksQueryKey(params), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.BlockList, headers, status) => {
@@ -406,22 +322,16 @@ export const useGetConsensusBlocks: typeof _f8 = (network, params, options) => {
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )
 
 const _f9 = wrapWithNetwork(generated.useGetRuntimeBlocks)
 
-export const useGetRuntimeBlocks: typeof _f9 = (network, runtime, params, options) => {
-  return generated.useGetRuntimeBlocks(runtime, params, {
-    ...options,
-    query: {
-      ...options?.query,
-      queryKey: [`/${network}/${runtime}/blocks`, ...(params ? [params] : [])],
-    },
-    axios: {
-      ...options?.axios,
-      ...getBaseUrlParamFor(network),
+export const useGetRuntimeBlocks: typeof _f9 = (network, runtime, params, options) =>
+  generated.useGetRuntimeBlocks(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetRuntimeBlocksQueryKey(runtime, params), {
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.RuntimeBlockList, headers, status) => {
@@ -439,6 +349,5 @@ export const useGetRuntimeBlocks: typeof _f9 = (network, runtime, params, option
         },
         ...arrayify(options?.axios?.transformResponse),
       ],
-    },
-  })
-}
+    }),
+  )

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -352,3 +352,43 @@ export const useGetRuntimeBlocks: typeof _f9 = (network, runtime, params, option
       ],
     }),
   )
+
+const _f10 = wrapWithNetwork(generated.useGetLayerStatsActiveAccounts)
+
+export const useGetLayerStatsActiveAccounts: typeof _f10 = (network, runtime, params, options) =>
+  generated.useGetLayerStatsActiveAccounts(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetLayerStatsActiveAccountsQueryKey(runtime)),
+  )
+
+const _f11 = wrapWithNetwork(generated.useGetLayerStatsTxVolume)
+
+export const useGetLayerStatsTxVolume: typeof _f11 = (network, runtime, params, options) =>
+  generated.useGetLayerStatsTxVolume(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetLayerStatsTxVolumeQueryKey(runtime)),
+  )
+
+const _f12 = wrapWithNetwork(generated.useGetRuntimeStatus)
+
+export const useGetRuntimeStatus: typeof _f12 = (network, runtime, options) =>
+  generated.useGetRuntimeStatus(
+    runtime,
+    getOptionsFor(options, network, generated.getGetRuntimeStatusQueryKey(runtime)),
+  )
+
+const _f13 = wrapWithNetwork(generated.useGetStatus)
+
+export const useGetStatus: typeof _f13 = (network, options) =>
+  generated.useGetStatus(getOptionsFor(options, network, generated.getGetStatusQueryKey()))
+
+const _f14 = wrapWithNetwork(generated.useGetRuntimeEvents)
+
+export const useGetRuntimeEvents: typeof _f14 = (network, runtime, params, options) =>
+  generated.useGetRuntimeEvents(
+    runtime,
+    params,
+    getOptionsFor(options, network, generated.getGetRuntimeEventsQueryKey(runtime, params)),
+  )

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -10,7 +10,8 @@ import { getEthAccountAddress } from '../app/utils/helpers'
 import { Network } from '../types/network'
 import { getOptionsFor, wrapWithNetwork } from './wrapper-helpers'
 
-export * from './generated/api'
+export type * from './generated/api'
+export { Layer, Runtime, RuntimeEventType } from './generated/api'
 export type { RuntimeEvmBalance as Token } from './generated/api'
 
 export interface HasNetwork {

--- a/src/oasis-indexer/wrapper-helpers.ts
+++ b/src/oasis-indexer/wrapper-helpers.ts
@@ -1,0 +1,82 @@
+import { Network } from '../types/network'
+import { AxiosRequestConfig } from 'axios'
+import { QueryKey, UseQueryOptions } from '@tanstack/react-query'
+
+export function wrapWithNetwork<P extends Array<any>, Q>(
+  f: (...args: P) => Q,
+): (net: Network, ...args: P) => Q {
+  return (net, ...args) => {
+    console.log('Should use', net)
+    return f(...args)
+  }
+}
+
+const baseUrlOverrides: Record<Network, string> = {
+  mainnet: process.env.REACT_APP_API!, // This is just here for the sake of completeness, since the default URL is already specified for Axios elsewhere.
+  testnet: process.env.REACT_APP_TESTNET_API!,
+}
+
+Object.keys(baseUrlOverrides).forEach(net => {
+  const url = baseUrlOverrides[net as Network]
+  if (!url) {
+    console.warn(
+      `URL for ${net} is not specified in config! Data from this network won't ba available. (See env.REACT_APP_*)`,
+    )
+  }
+})
+
+const getBaseUrlParamFor = (network: Network): Partial<AxiosRequestConfig<any>> => {
+  const override = baseUrlOverrides[network]
+  return override
+    ? { baseURL: override }
+    : {
+        // No override means that the default one (already specified for Axios) will suffice.
+      }
+}
+
+interface HasAxiosOptions {
+  axios?: AxiosRequestConfig
+}
+
+export const getAxiosOptionsFor = (
+  options: HasAxiosOptions = {},
+  network: Network,
+  moreOptions: Omit<AxiosRequestConfig, 'baseURL'> = {},
+): HasAxiosOptions => ({
+  axios: {
+    ...options.axios,
+    ...getBaseUrlParamFor(network),
+    ...moreOptions,
+  },
+})
+
+interface HasQueryOptions<A, B, C> {
+  query?: UseQueryOptions<A, B, C>
+}
+
+/**
+ * Helper function for adding query options for query key override and base URL override
+ * @param options
+ * @param network
+ * @param keyElements
+ * @param moreOptions
+ */
+export function getOptionsFor<A, B, C>(
+  options: (HasQueryOptions<A, B, C> & HasAxiosOptions) | undefined,
+  network: Network,
+  keyElements: QueryKey = [],
+  moreOptions: Omit<AxiosRequestConfig, 'baseURL'> = {},
+): HasQueryOptions<A, B, C> & HasAxiosOptions {
+  return {
+    ...options,
+    query: {
+      ...options?.query,
+      queryKey: [network, ...keyElements],
+    },
+    axios: {
+      ...options?.axios,
+      ...getBaseUrlParamFor(network),
+      ...moreOptions,
+    },
+  }
+}


### PR DESCRIPTION
This is another implementation of #440, built on top of #441, hence using more syntactic sugar.

To see the difference, compare [this](https://github.com/oasisprotocol/explorer/pull/440/files#diff-d7bfead1a5a25910a985675265e094d6b394c9de5d7c49ef2ab521787c71ea06) vs [this](https://github.com/oasisprotocol/explorer/pull/442/commits/6dd24bb285def9078f12e7f659f7920bcce9070e#diff-d7bfead1a5a25910a985675265e094d6b394c9de5d7c49ef2ab521787c71ea06).

| Default version | With more sugar |
| -----------------------| ------------------------- |
|![image](https://github.com/oasisprotocol/explorer/assets/2093792/936b9923-648a-4055-b258-d4c707183a77) | ![image](https://github.com/oasisprotocol/explorer/assets/2093792/7822caa7-4a63-41da-b765-5cb3a32b9271)  |
 
