### PR TITLE
Add links to the dashboard from search results

### DIFF
--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -17,6 +17,7 @@ import { AccountLink } from './AccountLink'
 import { RouteUtils } from '../../utils/route-utils'
 import { accountTransactionsContainerId } from '../../pages/AccountDetailsPage/TransactionsCard'
 import Link from '@mui/material/Link'
+import { DashboardLink } from '../../pages/DashboardPage/DashboardLink'
 
 export const StyledAvatarContainer = styled('dt')(({ theme }) => ({
   '&&': {
@@ -73,7 +74,9 @@ export const Account: FC<AccountProps> = ({ account, isLoading, roseFiatValue, s
           {showLayer && (
             <>
               <dt>{t('common.paratime')}</dt>
-              <dd>{t(`common.${account.layer}`)}</dd>
+              <dd>
+                <DashboardLink scope={account} />
+              </dd>
             </>
           )}
           <StyledAvatarContainer>

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -18,6 +18,7 @@ import { transactionsContainerId } from './TransactionsCard'
 import { BlockLink, BlockHashLink } from '../../components/Blocks/BlockLink'
 import { RouteUtils } from '../../utils/route-utils'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { DashboardLink } from '../DashboardPage/DashboardLink'
 
 export const BlockDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -78,7 +79,9 @@ export const BlockDetailView: FC<{
       {showLayer && (
         <>
           <dt>{t('common.paratime')}</dt>
-          <dd>{t(`common.${block.layer}`)}</dd>
+          <dd>
+            <DashboardLink scope={block} />
+          </dd>
         </>
       )}
       <dt>{t('common.height')}</dt>

--- a/src/app/pages/DashboardPage/DashboardLink.tsx
+++ b/src/app/pages/DashboardPage/DashboardLink.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react'
+import { getNameForScope, SearchScope } from '../../../types/searchScope'
+import Typography from '@mui/material/Typography'
+import { RouteUtils } from '../../utils/route-utils'
+import Link from '@mui/material/Link'
+import { Link as RouterLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+export const DashboardLink: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { t } = useTranslation()
+  return (
+    <Typography variant="mono">
+      <Link component={RouterLink} to={RouteUtils.getDashboardRoute(scope)}>
+        {getNameForScope(t, scope)}
+      </Link>
+    </Typography>
+  )
+}

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -27,6 +27,7 @@ import { BlockLink } from '../../components/Blocks/BlockLink'
 import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { TransactionLogs } from '../../components/Transactions/Logs'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { DashboardLink } from '../DashboardPage/DashboardLink'
 
 type TransactionSelectionResult = {
   wantedTransaction?: RuntimeTransaction
@@ -147,7 +148,9 @@ export const TransactionDetailView: FC<{
           {showLayer && (
             <>
               <dt>{t('common.paratime')}</dt>
-              <dd>{t(`common.${transaction.layer}`)}</dd>
+              <dd>
+                <DashboardLink scope={transaction} />
+              </dd>
             </>
           )}
           <dt>{t('common.hash')}</dt>

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'i18next'
+import { Layer } from '../oasis-indexer/api'
 
 export type Network = (typeof Network)[keyof typeof Network]
 
@@ -11,4 +12,11 @@ export const Network = {
 export const getNetworkNames = (t: TFunction): Record<Network, string> => ({
   [Network.mainnet]: t('common.mainnet'),
   [Network.testnet]: t('common.testnet'),
+})
+
+export const getLayerNames = (t: TFunction): Record<Layer, string> => ({
+  [Layer.emerald]: t('common.emerald'),
+  [Layer.sapphire]: t('common.sapphire'),
+  [Layer.cipher]: t('common.cipher'),
+  [Layer.consensus]: t('common.consensus'),
 })

--- a/src/types/searchScope.ts
+++ b/src/types/searchScope.ts
@@ -1,7 +1,11 @@
-import { Network } from './network'
+import { getLayerNames, getNetworkNames, Network } from './network'
 import { Layer } from '../oasis-indexer/api'
+import { TFunction } from 'i18next'
 
 export interface SearchScope {
   network: Network
   layer: Layer
 }
+
+export const getNameForScope = (t: TFunction, scope: SearchScope) =>
+  `${getLayerNames(t)[scope.layer]} ${getNetworkNames(t)[scope.network]}`


### PR DESCRIPTION
This is in search results:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/a8640e56-cd8f-41b2-befe-3b84735dd967)


The link takes to the dashboard of the referenced paratime/network variant.