### PR TITLE
Remove persianBlue color and consistently use our brand color

### DIFF
--- a/src/app/pages/BlocksPage/index.tsx
+++ b/src/app/pages/BlocksPage/index.tsx
@@ -24,7 +24,7 @@ const BlockDetails = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: `0 ${theme.spacing(2)}`,
-  backgroundColor: COLORS.persianBlue,
+  backgroundColor: COLORS.brandDark,
 }))
 
 export const BlocksPage: FC = () => {

--- a/src/app/pages/DashboardPage/Social.tsx
+++ b/src/app/pages/DashboardPage/Social.tsx
@@ -52,7 +52,7 @@ export const Social: FC = () => {
         px: isMobile ? 5 : 6,
         pt: 5,
         pb: isMobile ? 4 : 5,
-        backgroundColor: COLORS.persianBlue,
+        backgroundColor: COLORS.brandDark,
         borderStyle: 'solid',
         borderWidth: '1px',
         borderColor: COLORS.white,

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -26,7 +26,7 @@ const TransactionDetails = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: `0 ${theme.spacing(2)}`,
-  backgroundColor: COLORS.persianBlue,
+  backgroundColor: COLORS.brandDark,
 }))
 
 export const TransactionsPage: FC = () => {

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -27,7 +27,7 @@ export const COLORS = {
   lightGreen: '#e0f5ee',
   lightSilver: '#d9d9d9',
   linen: '#fae8e8',
-  persianBlue: '#3038c3',
+  // persianBlue: '#3038c3', use brandDark instead
   platinum: '#e2e2e2',
   vistaBlue: '#8988dd',
   white: '#ffffff',

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -82,12 +82,12 @@ declare module '@mui/material/styles' {
 export const defaultTheme = createTheme({
   palette: {
     background: {
-      default: COLORS.persianBlue,
+      default: COLORS.brandDark,
       empty: COLORS.brandExtraDark,
     },
     layout: {
       main: COLORS.white,
-      border: COLORS.persianBlue,
+      border: COLORS.brandDark,
       darkBorder: COLORS.brandExtraDark,
       hoverBorder: COLORS.white,
       lightBorder: COLORS.aqua,


### PR DESCRIPTION

| Before | After |
| --- | --- |
| ![explorer dev oasis io_mainnet_emerald](https://github.com/oasisprotocol/explorer/assets/3758846/1be3d797-9d86-451c-b611-86508c900deb)  |  ![4946cff7 oasis-explorer pages dev_mainnet_emerald](https://github.com/oasisprotocol/explorer/assets/3758846/b45e6e93-ac86-4fa3-aae0-7f867c77b137) |

