### PR TITLE
Clean up / simplify code

### DIFF
--- a/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
@@ -31,7 +31,7 @@ export const ScopedSearchResultsView: FC<{
   const otherResults = searchResults.filter(isNotInWantedScope)
   const notificationTheme = themes[otherResults.some(isOnMainnet) ? Network.mainnet : Network.testnet]
 
-  useRedirectIfSingleResult(wantedScope, [...wantedResults, ...otherResults])
+  useRedirectIfSingleResult(wantedScope, searchResults)
 
   return (
     <>


### PR DESCRIPTION
No need to filter and regroup the results,
we can just use the whole input array,
since it has been filtered at the parent layer.