### PR TITLE
Revert "Move banners into sticky header"

### DIFF
--- a/src/app/components/PageLayout/Header.tsx
+++ b/src/app/components/PageLayout/Header.tsx
@@ -8,8 +8,6 @@ import { Logotype } from './Logotype'
 import { NetworkSelector } from './NetworkSelector'
 import Box from '@mui/material/Box'
 import { useScopeParam } from '../../hooks/useScopeParam'
-import { BuildBanner } from '../BuildBanner'
-import { NetworkOfflineBanner, RuntimeOfflineBanner } from '../OfflineBanner'
 
 export const Header: FC = () => {
   const theme = useTheme()
@@ -36,9 +34,6 @@ export const Header: FC = () => {
           : 'none',
       }}
     >
-      <BuildBanner />
-      <NetworkOfflineBanner />
-      {scope && <RuntimeOfflineBanner />}
       <Box sx={{ px: '15px' }}>
         <Grid
           container

--- a/src/app/components/PageLayout/index.tsx
+++ b/src/app/components/PageLayout/index.tsx
@@ -4,7 +4,9 @@ import { Footer } from './Footer'
 import Box from '@mui/material/Box'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { styled, useTheme } from '@mui/material/styles'
+import { BuildBanner } from '../BuildBanner'
 import { useScopeParam } from '../../hooks/useScopeParam'
+import { NetworkOfflineBanner, RuntimeOfflineBanner } from '../OfflineBanner'
 import { Search } from '../Search'
 import { useIsApiOffline } from '../OfflineBanner/hook'
 import { Network } from '../../../types/network'
@@ -26,6 +28,9 @@ export const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({ children, m
 
   return (
     <>
+      <BuildBanner />
+      <NetworkOfflineBanner />
+      {scope && <RuntimeOfflineBanner />}
       <Box
         sx={{
           minHeight: '100vh',


### PR DESCRIPTION
This reverts commit 56fc8ccb72dc04ae3db3e9332bff8e8936ac8eee.

> @donouwens:  Actually, I would prefer the warning banners to not remain within the viewport, to reduce the screen estate the take up