### PR TITLE
Change ParaTime picker selection colors

### DIFF
--- a/.changelog/516.bugfix.md
+++ b/.changelog/516.bugfix.md
@@ -1,0 +1,1 @@
+Change ParaTime picker selection colors

--- a/src/app/components/ParaTimePicker/LayerMenu.tsx
+++ b/src/app/components/ParaTimePicker/LayerMenu.tsx
@@ -52,7 +52,7 @@ export const LayerMenuItem: FC<LayerMenuItemProps> = ({
 }) => {
   const { t } = useTranslation()
   const labels = getLayerLabels(t)
-  const activeLayerSelection = layer === activeLayer && network === selectedNetwork
+  const activeLayerSelection = layer === selectedLayer
 
   return (
     <MenuItem

--- a/src/app/components/ParaTimePicker/NetworkMenu.tsx
+++ b/src/app/components/ParaTimePicker/NetworkMenu.tsx
@@ -31,7 +31,7 @@ export const NetworkMenuItem: FC<NetworkMenuItemProps> = ({
   const { t } = useTranslation()
   const labels = getNetworkNames(t)
   const icons = getNetworkIcons()
-  const activeNetworkSelection = network === activeNetwork
+  const activeNetworkSelection = network === selectedNetwork
 
   return (
     <MenuItem


### PR DESCRIPTION
Apply "selected" styles to current selection instead of active network/layer. active network/layer keeps "currently active" badge.
