### PR TITLE
Improve handling of nameless ERC-20 tokens

### DIFF
--- a/.changelog/523.trivial.md
+++ b/.changelog/523.trivial.md
@@ -1,0 +1,1 @@
+Improve handling of nameless ERC-20 tokens

--- a/src/app/components/Account/TokenPills.tsx
+++ b/src/app/components/Account/TokenPills.tsx
@@ -40,6 +40,7 @@ type PillProps = {
 }
 
 export const Pill: FC<PillProps> = ({ account, pill }) => {
+  const { t } = useTranslation()
   const tokenRoute = RouteUtils.getAccountTokensRoute(
     account,
     account.address_eth ?? account.address,
@@ -56,7 +57,7 @@ export const Pill: FC<PillProps> = ({ account, pill }) => {
       key={pill.token_contract_addr}
       label={
         <>
-          <RoundedBalance value={pill.balance} ticker={pill.token_symbol} />
+          <RoundedBalance value={pill.balance} ticker={pill.token_symbol || t('common.missing')} />
         </>
       }
       sx={{ mr: 2 }}

--- a/src/app/pages/AccountDetailsPage/TokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/TokensCard.tsx
@@ -45,7 +45,7 @@ export const TokensCard: FC<TokensCardProps> = ({ type }) => {
     key: item.token_contract_addr,
     data: [
       {
-        content: item.token_name,
+        content: item.token_name || t('common.missing'),
         key: 'name',
       },
       {
@@ -68,7 +68,7 @@ export const TokensCard: FC<TokensCardProps> = ({ type }) => {
       },
       {
         align: TableCellAlign.Right,
-        content: item.token_symbol,
+        content: item.token_symbol || t('common.missing'),
         key: 'ticker',
       },
     ],

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -59,6 +59,7 @@
     "loadMore": "Load more",
     "lessThanAmount": "< {{value}} {{ticker}}",
     "logs": "Logs",
+    "missing": "n/a",
     "name": "Name",
     "oasis": "Oasis",
     "paratime": "Paratime",


### PR DESCRIPTION
There are some ERC-20 tokens which don't have a name or a ticker, because these are (strictly speaking) not mandatory parts of the contract specification. We still need to display something on the UI.

This can be tested with account 0x0df7C50f085345a12A2d06cE0D5519607b6E9B47 (Sapphire, Testnet.)

Before:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/cbcd5751-27b9-439c-a1fd-f2329e616c95)

After:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/b7146a0d-1f23-4e9a-a1c5-db3583236b25)
