### PR TITLE
Adjust description list padding for standalone variant

### DIFF
--- a/.changelog/525.bugfix.md
+++ b/.changelog/525.bugfix.md
@@ -1,0 +1,1 @@
+Fix description list paddings for mobile variant

--- a/src/app/components/StyledDescriptionList/index.tsx
+++ b/src/app/components/StyledDescriptionList/index.tsx
@@ -62,7 +62,7 @@ export const StyledDescriptionList = styled(InlineDescriptionList, {
   },
   ...(standalone && {
     '&&': {
-      padding: theme.spacing(2),
+      padding: `${theme.spacing(3)} ${theme.spacing(4)}`,
       backgroundColor: COLORS.white,
       marginBottom: theme.spacing(4),
       borderRadius: '12px',


### PR DESCRIPTION
Reviewed in https://github.com/oasisprotocol/explorer/pull/509 (which I removed by accident)