### PR TITLE
Use custom locale for formatting distance between dates

### DIFF
--- a/.changelog/527.feature.md
+++ b/.changelog/527.feature.md
@@ -1,0 +1,1 @@
+Use custom locale for formatting distance between dates

--- a/.changelog/528.bugfix.md
+++ b/.changelog/528.bugfix.md
@@ -1,0 +1,1 @@
+Fix paddings in table cell

--- a/src/app/components/Blocks/index.tsx
+++ b/src/app/components/Blocks/index.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import { RuntimeBlock } from '../../../oasis-indexer/api'
 import { VerticalProgressBar } from '../../components/ProgressBar'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { paraTimesConfig } from '../../../config'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { BlockHashLink, BlockLink } from './BlockLink'
+import { formatDistanceStrict } from '../../utils/dateFormatter'
 
 export type TableRuntimeBlock = RuntimeBlock & {
   markAsNew?: boolean
@@ -59,9 +59,7 @@ export const Blocks = (props: BlocksProps) => {
         },
         {
           align: TableCellAlign.Right,
-          content: formatDistanceStrict(new Date(block.timestamp), new Date(), {
-            addSuffix: true,
-          }),
+          content: formatDistanceStrict(new Date(block.timestamp), new Date()),
           key: 'timestamp',
         },
         {

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -20,18 +20,18 @@ import { doesAnyOfTheseLayersSupportEncryptedTransactions } from '../../../types
 import { TransactionEncryptionStatus } from '../TransactionEncryptionStatus'
 import { formatDistanceStrict } from '../../utils/dateFormatter'
 
+const iconSize = '28px'
 const StyledCircle = styled(Box)(({ theme }) => ({
-  position: 'absolute',
-  right: `-${theme.spacing(5)}`,
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  width: theme.spacing(5),
-  height: theme.spacing(5),
+  width: iconSize,
+  height: iconSize,
   color: COLORS.eucalyptus,
   backgroundColor: COLORS.lightGreen,
-  borderRadius: theme.spacing(5),
-  margin: theme.spacing(3),
+  borderRadius: iconSize,
+  marginLeft: theme.spacing(3),
+  marginRight: `-${theme.spacing(4)}`,
 }))
 
 type TableRuntimeTransaction = RuntimeTransaction & {
@@ -131,7 +131,7 @@ export const Transactions: FC<TransactionsProps> = ({
               display: 'flex',
               alignItems: 'center',
               position: 'relative',
-              pr: 4,
+              pr: 3,
             }}
           >
             {!!ownAddress &&

--- a/src/app/components/Transactions/index.tsx
+++ b/src/app/components/Transactions/index.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react'
 import { styled } from '@mui/material/styles'
 import { useTranslation } from 'react-i18next'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import Box from '@mui/material/Box'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import LockIcon from '@mui/icons-material/Lock'
@@ -19,6 +18,7 @@ import { trimLongString } from '../../utils/trimLongString'
 import Typography from '@mui/material/Typography'
 import { doesAnyOfTheseLayersSupportEncryptedTransactions } from '../../../types/layers'
 import { TransactionEncryptionStatus } from '../TransactionEncryptionStatus'
+import { formatDistanceStrict } from '../../utils/dateFormatter'
 
 const StyledCircle = styled(Box)(({ theme }) => ({
   position: 'absolute',
@@ -116,9 +116,7 @@ export const Transactions: FC<TransactionsProps> = ({
         : []),
       {
         align: TableCellAlign.Right,
-        content: formatDistanceStrict(new Date(transaction.timestamp), new Date(), {
-          addSuffix: true,
-        }),
+        content: formatDistanceStrict(new Date(transaction.timestamp), new Date()),
         key: 'timestamp',
       },
       {

--- a/src/app/utils/dateFormatter.ts
+++ b/src/app/utils/dateFormatter.ts
@@ -1,3 +1,36 @@
+import formatDistanceStrictDateFns from 'date-fns/formatDistanceStrict'
+import locale from 'date-fns/locale/en-US'
+
 const dateFormat = new Intl.DateTimeFormat()
 
 export const intlDateFormat = (date: Date | number) => dateFormat.format(date)
+
+const formatDistanceLocale = {
+  lessThanXSeconds: '{{count}}s',
+  xSeconds: '{{count}}s',
+  halfAMinute: 's',
+  lessThanXMinutes: '{{count}}m',
+  xMinutes: '{{count}}m',
+  aboutXHours: '{{count}}h',
+  xHours: '{{count}}h',
+  xDays: '{{count}}d',
+  aboutXWeeks: '{{count}}w',
+  xWeeks: '{{count}}w',
+  aboutXMonths: '{{count}}m',
+  xMonths: '{{count}}m',
+  aboutXYears: '{{count}}y',
+  xYears: '{{count}}y',
+  overXYears: '{{count}}y',
+  almostXYears: '{{count}}y',
+}
+
+export const formatDistance = (token: keyof typeof formatDistanceLocale, count: string) =>
+  formatDistanceLocale[token].replace('{{count}}', count)
+
+export const formatDistanceStrict = (date: Date, baseDate: Date) =>
+  formatDistanceStrictDateFns(date, baseDate, {
+    locale: {
+      ...locale,
+      formatDistance,
+    },
+  })

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -551,16 +551,17 @@ export const defaultTheme = createTheme({
     },
     MuiTableCell: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderColor: COLORS.antiFlashWhite2,
           color: COLORS.grayExtraDark,
           whiteSpace: 'nowrap',
+          padding: `${theme.spacing(4)} ${theme.spacing(3)}`,
           a: {
             color: COLORS.brandDark,
             fontWeight: 700,
             textDecoration: 'none',
           },
-        },
+        }),
         head: {
           border: 0,
           color: COLORS.grayDark,


### PR DESCRIPTION
We need compact/custom labels when showing Age column labels. 

Another PR will change table cell paddings so we should be able to resolve issue from Slack.