### PR TITLE
Prevent showing horizontal scrollbar on home page

### DIFF
--- a/.changelog/554.bugfix.md
+++ b/.changelog/554.bugfix.md
@@ -1,0 +1,1 @@
+Prevent showing horizontal scrollbar on home page

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -30,6 +30,7 @@ const HomepageLayout = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: '100vw',
+  maxWidth: '100%',
   height: 'fill-available',
   minHeight: '100vh',
   backgroundColor: COLORS.brandDark,


### PR DESCRIPTION
Reported via Internal Launch Feedback.

For me scrollbar is visible always on home page 
current `https://explorer.dev.oasis.io/`
![Screenshot 2023-06-19 at 14 10 15](https://github.com/oasisprotocol/explorer/assets/891392/afc58dd1-723d-47b7-aef9-b3a4fd5d6a98)

Issue here is that home page layout is using `100vw` width. Combo of `100vw` + vertical scroll + no max width  will cause horizontal scrolls to be visible.