### PR TITLE
Fix offline indicators showing out-of-date 2 minutes after opening page

### DIFF
--- a/.changelog/578.bugfix.md
+++ b/.changelog/578.bugfix.md
@@ -1,0 +1,1 @@
+Fix offline indicators showing out-of-date 2 minutes after opening page

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -47,7 +47,7 @@ export const useRuntimeFreshness = (scope: SearchScope): FreshnessInfo => {
       outOfDate: true,
     }
   }
-  const timeSinceLastUpdate = Date.now() - new Date(data.latest_update).getTime()
+  const timeSinceLastUpdate = query.dataUpdatedAt - new Date(data.latest_update).getTime()
   const { outOfDateThreshold } = paraTimesConfig[scope.layer]
   return {
     outOfDate: timeSinceLastUpdate > outOfDateThreshold,


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/explorer/issues/545