### PR TITLE
Fix api spec url in footer

### DIFF
--- a/.changelog/614.trivial.md
+++ b/.changelog/614.trivial.md
@@ -1,0 +1,1 @@
+Add Docs and GitHub links in footer

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '@mui/material/styles'
 import { useConstant } from '../../hooks/useConstant'
 import { AppendMobileSearch } from '../AppendMobileSearch'
 import { SearchScope } from '../../../types/searchScope'
-import { docs, github } from '../../utils/externalLinks'
+import { api, github } from '../../utils/externalLinks'
 
 const FooterBox = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -108,7 +108,7 @@ export const Footer: FC<FooterProps> = ({ scope, mobileSearchAction }) => {
               <StyledLinksGroup>
                 <Typography variant="footer">
                   <Link
-                    href={docs.home}
+                    href={api.spec}
                     rel="noopener noreferrer"
                     target="_blank"
                     sx={{ color: theme.palette.layout.main }}

--- a/src/app/utils/externalLinks.ts
+++ b/src/app/utils/externalLinks.ts
@@ -38,3 +38,7 @@ export const github = {
 export const testnet = {
   faucet: 'https://faucet.testnet.oasis.dev',
 }
+
+export const api = {
+  spec: `${process.env.REACT_APP_API}spec/v1.html`,
+}


### PR DESCRIPTION
~We will need to change it again one day: https://github.com/oasisprotocol/explorer/issues/615`~
~I will just wait for a new domain~