### PR TITLE
Display account token transfers

### DIFF
--- a/.changelog/624.feature.md
+++ b/.changelog/624.feature.md
@@ -1,0 +1,1 @@
+Account details: display token transfers

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -74,6 +74,7 @@ type TableProps = {
   rows?: TableRowProps[]
   rowsNumber?: number
   stickyColumn?: boolean
+  extraHorizontalSpaceOnMobile?: boolean
 }
 
 const stickyColumnStyles = {
@@ -81,6 +82,10 @@ const stickyColumnStyles = {
   left: 0,
   backgroundColor: COLORS.antiFlashWhite,
   zIndex: 1,
+}
+
+const extraHorizontalPaddingStyles = {
+  px: 4,
 }
 
 export const Table: FC<TableProps> = ({
@@ -91,6 +96,7 @@ export const Table: FC<TableProps> = ({
   rows,
   rowsNumber = 5,
   stickyColumn = false,
+  extraHorizontalSpaceOnMobile = false,
 }) => {
   const { isMobile } = useScreenSize()
 
@@ -128,7 +134,10 @@ export const Table: FC<TableProps> = ({
                   <TableCell
                     key={cell.key}
                     align={cell.align}
-                    sx={stickyColumn && !index && isMobile ? stickyColumnStyles : undefined}
+                    sx={{
+                      ...(stickyColumn && !index && isMobile ? stickyColumnStyles : {}),
+                      ...(extraHorizontalSpaceOnMobile && isMobile ? extraHorizontalPaddingStyles : {}),
+                    }}
                   >
                     {cell.content}
                   </TableCell>

--- a/src/app/components/Tokens/TokenTransferIcon.tsx
+++ b/src/app/components/Tokens/TokenTransferIcon.tsx
@@ -1,0 +1,71 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { TFunction } from 'i18next'
+import Tooltip from '@mui/material/Tooltip'
+import { tooltipDelay } from '../../../styles/theme'
+import { UnknownIcon } from './../CustomIcons/Unknown'
+import { TransferIcon } from './../CustomIcons/Transfer'
+import { COLORS } from '../../../styles/theme/colors'
+import Stream from '@mui/icons-material/Stream'
+import LocalFireDepartment from '@mui/icons-material/LocalFireDepartment'
+
+const getTokenTransferLabel = (t: TFunction, name: string | undefined): string => {
+  switch (name) {
+    case undefined:
+      return t('tokens.transferEventType.unavailable')
+    case 'Transfer':
+      return t('tokens.transferEventType.transfer')
+    case 'Minting':
+      return t('tokens.transferEventType.minting')
+    case 'Burning':
+      return t('tokens.transferEventType.burning')
+    default:
+      return t('tokens.transferEventType.unknown', { name })
+  }
+}
+
+const iconStyles = { fontSize: '40px' }
+const getTokenTransferIcon = (name: string | undefined) => {
+  switch (name) {
+    case undefined:
+      // Method may be undefined if the transaction was malformed.
+      return <UnknownIcon sx={iconStyles} />
+    case 'Transfer':
+      return <TransferIcon sx={iconStyles} />
+    case 'Minting':
+      return <Stream sx={iconStyles} htmlColor={COLORS.eucalyptus} />
+    case 'Burning':
+      return <LocalFireDepartment sx={iconStyles} htmlColor={COLORS.eucalyptus} />
+    default:
+      return <UnknownIcon sx={iconStyles} />
+  }
+}
+
+type TokenTransferLabelProps = {
+  /**
+   * The event name
+   */
+  name: string | undefined
+}
+
+export const TokenTransferLabel: FC<TokenTransferLabelProps> = ({ name }) => {
+  const { t } = useTranslation()
+
+  return <>{getTokenTransferLabel(t, name)}</>
+}
+
+export const TokenTransferIcon: FC<TokenTransferLabelProps> = ({ name }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Tooltip
+      arrow
+      placement="top"
+      title={getTokenTransferLabel(t, name)}
+      enterDelay={tooltipDelay}
+      enterNextDelay={tooltipDelay}
+    >
+      <span>{getTokenTransferIcon(name)}</span>
+    </Tooltip>
+  )
+}

--- a/src/app/components/Tokens/TokenTransfers.tsx
+++ b/src/app/components/Tokens/TokenTransfers.tsx
@@ -1,0 +1,176 @@
+import { FC } from 'react'
+import { styled } from '@mui/material/styles'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import { Table, TableCellAlign, TableColProps } from '../../components/Table'
+import { RuntimeEvent } from '../../../oasis-indexer/api'
+import { COLORS } from '../../../styles/theme/colors'
+import { TablePaginationProps } from '../Table/TablePagination'
+import { BlockLink } from '../Blocks/BlockLink'
+import { AccountLink } from '../Account/AccountLink'
+import { trimLongString } from '../../utils/trimLongString'
+import Typography from '@mui/material/Typography'
+import { TransactionLink } from '../Transactions/TransactionLink'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { TokenTransferIcon } from './TokenTransferIcon'
+import { RoundedBalance } from '../RoundedBalance'
+import { useScreenSize } from '../../hooks/useScreensize'
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const iconSize = '28px'
+const StyledCircle = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: iconSize,
+  height: iconSize,
+  color: COLORS.eucalyptus,
+  backgroundColor: COLORS.lightGreen,
+  borderRadius: iconSize,
+  marginLeft: theme.spacing(3),
+  marginRight: `-${theme.spacing(4)}`,
+}))
+
+type TableRuntimeEvent = RuntimeEvent & {
+  markAsNew?: boolean
+}
+
+type TokenTransfersProps = {
+  transfers?: TableRuntimeEvent[]
+  ownAddress?: string
+  isLoading: boolean
+  limit: number
+  pagination: false | TablePaginationProps
+}
+
+export const TokenTransfers: FC<TokenTransfersProps> = ({
+  isLoading,
+  limit,
+  pagination,
+  transfers,
+  ownAddress,
+}) => {
+  const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+  const tableColumns: TableColProps[] = [
+    { key: 'hash', content: t('common.hash') },
+    { key: 'block', content: t('common.block') },
+    { key: 'type', content: t('common.type'), align: TableCellAlign.Center },
+    { key: 'from', content: t('common.from'), width: '150px' },
+    { key: 'to', content: t('common.to'), width: '150px' },
+    { key: 'value', align: TableCellAlign.Right, content: t('common.value'), width: '250px' },
+  ]
+  const tableRows = transfers?.map((transfer, index) => {
+    const fromAddress = transfer.evm_log_params?.find(param => param.name === 'from')?.value as
+      | string
+      | undefined
+    const toAddress = transfer.evm_log_params?.find(param => param.name === 'to')?.value as string | undefined
+    const value = transfer.evm_log_params?.find(param => param.name === 'value')?.value as string | undefined
+    const ticker = '???' // TODO: how do I get the ticker?
+    const isMinting = fromAddress === NULL_ADDRESS
+    const isBurning = toAddress === NULL_ADDRESS
+
+    return {
+      key: `event-${index + (pagination ? (pagination.selectedPage - 1) * pagination.rowsPerPage : 0)}`,
+      data: [
+        {
+          content: (
+            <TransactionLink
+              scope={transfer}
+              alwaysTrim={isMobile}
+              hash={transfer.eth_tx_hash || transfer.tx_hash!}
+            />
+          ),
+          key: 'hash',
+        },
+        {
+          content: <BlockLink scope={transfer} height={transfer.round} />,
+          key: 'round',
+        },
+        {
+          key: 'type',
+          align: TableCellAlign.Center,
+          content: (
+            <TokenTransferIcon
+              name={isMinting ? 'Minting' : isBurning ? 'Burning' : transfer.evm_log_name || undefined}
+            />
+          ),
+        },
+
+        {
+          key: 'from',
+          align: TableCellAlign.Right,
+          content:
+            isMinting || fromAddress === undefined ? (
+              ''
+            ) : (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  position: 'relative',
+                  pr: 3,
+                }}
+              >
+                {!!ownAddress && fromAddress.toLowerCase() === ownAddress.toLowerCase() ? (
+                  <Typography
+                    variant="mono"
+                    component="span"
+                    sx={{
+                      fontWeight: 700,
+                    }}
+                  >
+                    {trimLongString(fromAddress)}
+                  </Typography>
+                ) : (
+                  <AccountLink scope={transfer} address={fromAddress} alwaysTrim={true} />
+                )}
+
+                <StyledCircle>
+                  <ArrowForwardIcon fontSize="inherit" />
+                </StyledCircle>
+              </Box>
+            ),
+        },
+        {
+          key: 'to',
+          content: !toAddress ? (
+            ''
+          ) : !!ownAddress && toAddress.toLowerCase() === ownAddress.toLowerCase() ? (
+            <Typography
+              variant="mono"
+              component="span"
+              sx={{
+                fontWeight: 700,
+              }}
+            >
+              {trimLongString(toAddress)}
+            </Typography>
+          ) : (
+            <AccountLink scope={transfer} address={toAddress} alwaysTrim={true} />
+          ),
+        },
+
+        {
+          key: 'value',
+          align: TableCellAlign.Right,
+          content: value === undefined ? '' : <RoundedBalance value={value} ticker={ticker} />,
+        },
+      ],
+      highlight: transfer.markAsNew,
+    }
+  })
+
+  return (
+    <Table
+      columns={tableColumns}
+      rows={tableRows}
+      rowsNumber={limit}
+      name={t('transactions.latest')}
+      isLoading={isLoading}
+      pagination={pagination}
+      extraHorizontalSpaceOnMobile
+    />
+  )
+}

--- a/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
+import { CardEmptyState } from './CardEmptyState'
+import { useAccount, useAccountTokenTransfers } from './hook'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useLoaderData } from 'react-router-dom'
+import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
+
+export const accountTokenTransfersContainerId = 'transfers'
+
+export const AccountTokenTransfersCard: FC = () => {
+  const { t } = useTranslation()
+  const scope = useRequiredScopeParam()
+  const address = useLoaderData() as string
+
+  const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } =
+    useAccountTokenTransfers(scope, address)
+
+  const { account } = useAccount(scope, address)
+
+  return (
+    <Card>
+      <LinkableDiv id={accountTokenTransfersContainerId}>
+        <CardHeader disableTypography component="h3" title={t('tokens.transfers')} />
+      </LinkableDiv>
+      <CardContent>
+        <ErrorBoundary light={true}>
+          {isFetched && !transfers?.length && <CardEmptyState label={t('account.emptyTokenTransferList')} />}
+          <TokenTransfers
+            transfers={transfers}
+            ownAddress={account?.address_eth}
+            isLoading={isLoading}
+            limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+            pagination={{
+              selectedPage: pagination.selectedPage,
+              linkToPage: pagination.linkToPage,
+              totalCount,
+              isTotalCountClipped,
+              rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+            }}
+          />
+        </ErrorBoundary>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/AccountDetailsPage/hook.ts
+++ b/src/app/pages/AccountDetailsPage/hook.ts
@@ -1,4 +1,9 @@
-import { Layer, useGetRuntimeAccountsAddress, useGetRuntimeTransactions } from '../../../oasis-indexer/api'
+import {
+  Layer,
+  useGetRuntimeAccountsAddress,
+  useGetRuntimeEvents,
+  useGetRuntimeTransactions,
+} from '../../../oasis-indexer/api'
 import { AppErrors } from '../../../types/errors'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
@@ -45,6 +50,49 @@ export const useAccountTransactions = (scope: SearchScope, address: string) => {
     isLoading,
     isFetched,
     transactions,
+    pagination,
+    totalCount,
+    isTotalCountClipped,
+  }
+}
+
+const WANTED_EVM_LOG_EVENTS: string[] = ['Transfer']
+
+export const useAccountTokenTransfers = (scope: SearchScope, address: string) => {
+  const { network, layer } = scope
+  const pagination = useSearchParamsPagination('page')
+  const offset = (pagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+  if (layer === Layer.consensus) {
+    throw AppErrors.UnsupportedLayer
+    // Loading transactions on the consensus layer is not supported yet.
+    // We should use useGetConsensusTransactions()
+  }
+  const query = useGetRuntimeEvents(
+    network,
+    layer, // This is OK since consensus has been handled separately
+    {
+      limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+      offset: offset,
+      rel: address,
+      type: 'evm.log',
+    },
+  )
+
+  const { isFetched, isLoading, data } = query
+
+  const transfers = data?.data.events.filter(
+    event => !!event.evm_log_name && WANTED_EVM_LOG_EVENTS.includes(event.evm_log_name),
+  )
+
+  // TODO: fix pagination messed up by client-side filtering
+
+  const totalCount = data?.data.total_count
+  const isTotalCountClipped = data?.data.is_total_count_clipped
+
+  return {
+    isLoading,
+    isFetched,
+    transfers,
     pagination,
     totalCount,
     isTotalCountClipped,

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -10,12 +10,13 @@ import { Ticker } from '../../../types/ticker'
 
 import { EvmToken, EvmTokenType, RuntimeAccount } from '../../../oasis-indexer/api'
 import { accountTokenContainerId } from './AccountTokensCard'
-import { useAccount } from './hook'
+import { useAccount, useAccountTokenTransfers } from './hook'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { showEmptyAccountDetails } from '../../../config'
 import { CardEmptyState } from './CardEmptyState'
 import { contractCodeContainerId } from './ContractCodeCard'
 import { useTokenInfo } from '../TokenDashboardPage/hook'
+import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
 
 export const AccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -24,10 +25,13 @@ export const AccountDetailsPage: FC = () => {
   const address = useLoaderData() as string
   const { account, isLoading, isError } = useAccount(scope, address)
   const { token } = useTokenInfo(scope, address)
+  const { totalCount: numberOfTokenTransfers } = useAccountTokenTransfers(scope, address)
 
   const tokenPriceInfo = useTokenPrice(account?.ticker || Ticker.ROSE)
   const isContract = !!account?.evm_contract
 
+  const showTokenTransfers = showEmptyAccountDetails || !!numberOfTokenTransfers
+  const tokenTransfersLink = useHref(`token-transfers#${accountTokenTransfersContainerId}`)
   const showErc20 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC20].length
   const erc20Link = useHref(`tokens/erc-20#${accountTokenContainerId}`)
   const showTxs = showEmptyAccountDetails || showErc20 || !!account?.stats.num_txns
@@ -56,6 +60,7 @@ export const AccountDetailsPage: FC = () => {
         <RouterTabs
           tabs={[
             { label: t('common.transactions'), to: txLink, visible: showTxs },
+            { label: t('tokens.transfers'), to: tokenTransfersLink, visible: showTokenTransfers },
             { label: t('common.tokens'), to: erc20Link, visible: showErc20 },
             { label: t('contract.code'), to: codeLink, visible: showCode },
           ]}

--- a/src/app/utils/helpers.ts
+++ b/src/app/utils/helpers.ts
@@ -4,6 +4,7 @@ import * as oasis from '@oasisprotocol/client'
 import * as oasisRT from '@oasisprotocol/client-rt'
 // eslint-disable-next-line no-restricted-imports
 import { AddressPreimage } from '../../oasis-indexer/generated/api'
+import BigNumber from 'bignumber.js'
 
 export const isValidBlockHeight = (blockHeight: string): boolean => /^[0-9]+$/.test(blockHeight)
 export const isValidBlockHash = (hash: string): boolean => /^[0-9a-fA-F]{64}$/.test(hash)
@@ -69,4 +70,12 @@ export function getEthAccountAddressFromPreimage(preimage: AddressPreimage | und
 
 export function uniq<T>(input: T[] | undefined): T[] {
   return input === undefined ? [] : [...new Set(input)]
+}
+
+export function fromBaseUnits(valueInBaseUnits: string, decimals: number): string {
+  const value = new BigNumber(valueInBaseUnits).shiftedBy(-decimals) // / 10 ** decimals
+  if (value.isNaN()) {
+    throw new Error(`Not a number in fromBaseUnits(${valueInBaseUnits})`)
+  }
+  return value.toFixed()
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,6 +3,7 @@
     "cantLoadDetails": "Unfortunately we couldn't load the account details at this time. Please try again later.",
     "emptyTokenList": "This account holds no {{token}} tokens.",
     "emptyTransactionList": "There are no transactions on record for this account.",
+    "emptyTokenTransferList": "There are no token transfers on record for this account.",
     "ERC20": "ERC-20",
     "noTokens": "This account holds no tokens",
     "showMore": "+ {{counter}} more",
@@ -202,10 +203,20 @@
     "holdersCount_short": "Holders",
     "totalSupply": "Total Supply",
     "totalSupplyValue": "{{ value, number }}",
+    "transfers": "Token Transfers",
+    "transferEventType": {
+      "transfer": "Transfer",
+      "minting": "Minting",
+      "burning": "Burning",
+      "unavailable": "Unknown token transfer event",
+      "unknown": "Unknown: {{name}}"
+    },
     "type": "Token Type"
   },
   "tokenSnapshot": {
-    "header": "Token Snapshot"
+    "header": "Token Snapshot",
+    "supply": "Supply",
+    "title": "Tokens"
   },
   "totalTransactions": {
     "header": "Total Transactions",

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -3,10 +3,9 @@
 import axios, { AxiosResponse } from 'axios'
 import { paraTimesConfig } from '../config'
 import * as generated from './generated/api'
-import BigNumber from 'bignumber.js'
 import { UseQueryOptions } from '@tanstack/react-query'
 import { EvmToken, Layer, RuntimeAccount } from './generated/api'
-import { getEthAccountAddressFromPreimage } from '../app/utils/helpers'
+import { fromBaseUnits, getEthAccountAddressFromPreimage } from '../app/utils/helpers'
 import { Network } from '../types/network'
 import { SearchScope } from '../types/searchScope'
 import { getTickerForNetwork, NativeTicker } from '../types/ticker'
@@ -76,14 +75,6 @@ export const groupAccountTokenBalances = (account: Omit<RuntimeAccount, 'tokenBa
     ...account,
     tokenBalances,
   }
-}
-
-function fromBaseUnits(valueInBaseUnits: string, decimals: number): string {
-  const value = new BigNumber(valueInBaseUnits).shiftedBy(-decimals) // / 10 ** decimals
-  if (value.isNaN()) {
-    throw new Error(`Not a number in fromBaseUnits(${valueInBaseUnits})`)
-  }
-  return value.toFixed()
 }
 
 function arrayify<T>(arrayOrItem: null | undefined | T | T[]): T[] {

--- a/src/oasis-indexer/api.ts
+++ b/src/oasis-indexer/api.ts
@@ -46,6 +46,10 @@ declare module './generated/api' {
     ticker: NativeTicker
     tokenBalances: Record<EvmTokenType, generated.RuntimeEvmBalance[]>
   }
+  export interface RuntimeEvent {
+    network: Network
+    layer: Layer
+  }
 
   export interface EvmToken {
     network: Network
@@ -488,6 +492,37 @@ export const useGetRuntimeEvmTokensAddress: typeof generated.useGetRuntimeEvmTok
             total_supply: data.total_supply
               ? fromBaseUnits(data.total_supply, data.decimals || 0)
               : undefined,
+          }
+        },
+        ...arrayify(options?.request?.transformResponse),
+      ],
+    },
+  })
+}
+
+export const useGetRuntimeEvents: typeof generated.useGetRuntimeEvents = (
+  network,
+  runtime,
+  params,
+  options,
+) => {
+  return generated.useGetRuntimeEvents(network, runtime, params, {
+    ...options,
+    request: {
+      ...options?.request,
+      transformResponse: [
+        ...arrayify(axios.defaults.transformResponse),
+        (data: generated.RuntimeEventList, headers, status) => {
+          if (status !== 200) return data
+          return {
+            ...data,
+            events: data.events.map(event => {
+              return {
+                ...event,
+                layer: runtime,
+                network,
+              }
+            }),
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -22,6 +22,7 @@ import { useRequiredScopeParam } from './app/hooks/useScopeParam'
 import { TokensPage } from './app/pages/TokensOverviewPage'
 import { ContractCodeCard } from './app/pages/AccountDetailsPage/ContractCodeCard'
 import { TokenDashboardPage } from './app/pages/TokenDashboardPage'
+import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -81,6 +82,11 @@ export const routes: RouteObject[] = [
               {
                 path: '',
                 element: <AccountTransactionsCard />,
+                loader: addressParamLoader,
+              },
+              {
+                path: 'token-transfers',
+                element: <AccountTokenTransfersCard />,
                 loader: addressParamLoader,
               },
               {


### PR DESCRIPTION
~This is built on top of #616, so only the last few comments are relevant to this task.~

Display token transfers related to an account.

Design:
 - [Desktop](https://www.figma.com/file/ifCrok8cP5ymEYjMa2PIi9/Block-Explorer?type=design&node-id=6092-229916&mode=design&t=dHJtypAuJIfinMPW-0)
 - [Mobile](https://www.figma.com/file/ifCrok8cP5ymEYjMa2PIi9/Block-Explorer?type=design&node-id=6092-232862)

Can be tested (for example) with `0x643c8A8120eFB675E82C5C58d8D473f5aDd0B5e6`.

Unfortunately, our data requirements are not completely clear at this point, so only a part of the visual is implemented. However, this is probably all we can do before the launch, so it makes sense to review this now.