### PR TITLE
Improve how tabs are displayed on small screens

### DIFF
--- a/.changelog/629.trivial.md
+++ b/.changelog/629.trivial.md
@@ -1,0 +1,1 @@
+Imrove how tabs are displayed on small screens

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -738,12 +738,15 @@ export const defaultTheme = createTheme({
     },
     MuiTabs: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           // neglect the default border radius of sibling element (Card component in most cases)
           '&& + *': {
             borderTopLeftRadius: 0,
+            [theme.breakpoints.down('sm')]: {
+              borderTopRightRadius: 0,
+            },
           },
-        },
+        }),
         indicator: {
           display: 'none',
         },


### PR DESCRIPTION
Our Cards have rounded corners, which is nice, but when used under a tab menu, on mobile, sometimes it causes a problem. Look at just below the tabs, at the edges:

| Before | After |
| ------ | ------
| ![image](https://github.com/oasisprotocol/explorer/assets/2093792/8fbca9cc-eee9-4a99-89db-9fe4aa4e7b57) | ![image](https://github.com/oasisprotocol/explorer/assets/2093792/d1e741bc-9af3-4875-bcb2-db7f4dac74e8)  |
