### PR TITLE
Token dashboard: add "Token Transfers" and "Code" tabs

### DIFF
--- a/.changelog/634.feature.md
+++ b/.changelog/634.feature.md
@@ -1,0 +1,1 @@
+Token dashboard: add "Token Transfers" and "Code" tabs

--- a/src/app/components/NonScrollingRouterLink/index.tsx
+++ b/src/app/components/NonScrollingRouterLink/index.tsx
@@ -1,0 +1,6 @@
+import React, { ComponentPropsWithRef, FC } from 'react'
+import { Link } from 'react-router-dom'
+
+export const NonScrollingRouterLink: FC<ComponentPropsWithRef<typeof Link>> = React.forwardRef(
+  (props, ref) => <Link {...props} preventScrollReset ref={ref} />,
+)

--- a/src/app/components/RouterTabs/index.tsx
+++ b/src/app/components/RouterTabs/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
-import { useLocation, Link as RouterLink, Outlet } from 'react-router-dom'
+import { useLocation, Outlet } from 'react-router-dom'
+import { NonScrollingRouterLink } from '../NonScrollingRouterLink'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 
@@ -25,7 +26,13 @@ export const RouterTabs: FC<RouterTabsProps> = ({ tabs }) => {
         {tabs
           .filter(tab => tab === currentTab || tab.visible !== false)
           .map(tab => (
-            <Tab key={tab.to} component={RouterLink} value={tab.to} label={tab.label} to={tab.to} />
+            <Tab
+              key={tab.to}
+              component={NonScrollingRouterLink}
+              value={tab.to}
+              label={tab.label}
+              to={tab.to}
+            />
           ))}
       </Tabs>
       <Outlet />

--- a/src/app/components/ScrollableDataDisplay/index.tsx
+++ b/src/app/components/ScrollableDataDisplay/index.tsx
@@ -34,7 +34,7 @@ export const ScrollableDataDisplay: FC<{ data: string; fontWeight?: number }> = 
             fontWeight,
             overflowWrap: 'anywhere',
           }}
-          color={COLORS.grayMedium}
+          color={COLORS.brandExtraDark}
         >
           {data}
         </Typography>

--- a/src/app/components/ScrollableDataDisplay/index.tsx
+++ b/src/app/components/ScrollableDataDisplay/index.tsx
@@ -24,7 +24,7 @@ export const ScrollableDataDisplay: FC<{ data: string; fontWeight?: number }> = 
           border: `1px solid ${COLORS.grayMedium}`,
           height: '349px',
           overflowY: 'scroll',
-          p: 3,
+          p: 4,
         }}
       >
         <Typography

--- a/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
@@ -59,19 +59,19 @@ export const ContractCodeCard: FC = () => {
   const noCode = isFetched && !contract?.creation_bytecode && !contract?.runtime_bytecode
   return (
     <Card>
-      <LinkableDiv id={contractCodeContainerId}>
-        {noCode && <CardEmptyState label={t('contract.noCode')} />}
-        {contract && (contract.creation_bytecode || contract.runtime_bytecode) && (
-          <CardContent>
+      {noCode && <CardEmptyState label={t('contract.noCode')} />}
+      {contract && (contract.creation_bytecode || contract.runtime_bytecode) && (
+        <CardContent>
+          <LinkableDiv id={contractCodeContainerId}>
             <CodeDisplay rawData={contract.creation_bytecode} label={t('contract.creationByteCode')} />
             <CodeDisplay
               rawData={contract.runtime_bytecode}
               label={t('contract.runtimeByteCode')}
               extraTopPadding={!!contract.creation_bytecode}
             />
-          </CardContent>
-        )}
-      </LinkableDiv>
+          </LinkableDiv>
+        </CardContent>
+      )}
     </Card>
   )
 }

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -41,6 +41,12 @@ export const TokenDetailsCard: FC = () => {
             <dt>{t('common.token')}</dt>
             <dd>{token.name}</dd>
 
+            {isMobile && (
+              <>
+                <dt>{t('common.ticker')}</dt>
+                <dd>{token.symbol}</dd>
+              </>
+            )}
             <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
             <dd>
               <AccountLink scope={account} address={account.address_eth || account.address} />

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useLoaderData } from 'react-router-dom'
+import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
+import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
+import { useAccount } from '../AccountDetailsPage/hook'
+import { useTokenTransfers } from './hook'
+
+export const tokenTransfersContainerId = 'transfers'
+
+export const TokenTransfersCard: FC = () => {
+  const { t } = useTranslation()
+  const scope = useRequiredScopeParam()
+  const address = useLoaderData() as string
+
+  const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } = useTokenTransfers(
+    scope,
+    address,
+  )
+
+  const { account } = useAccount(scope, address)
+
+  return (
+    <Card>
+      <CardHeader disableTypography component="h3" title={t('tokens.transfers')} />
+      <CardContent>
+        <ErrorBoundary light={true}>
+          {isFetched && !transfers?.length && <CardEmptyState label={t('account.emptyTokenTransferList')} />}
+          <TokenTransfers
+            transfers={transfers}
+            ownAddress={account?.address_eth}
+            isLoading={isLoading}
+            limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+            pagination={{
+              selectedPage: pagination.selectedPage,
+              linkToPage: pagination.linkToPage,
+              totalCount,
+              isTotalCountClipped,
+              rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+            }}
+          />
+        </ErrorBoundary>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -1,6 +1,8 @@
-import { Layer, useGetRuntimeEvmTokensAddress } from '../../../oasis-nexus/api'
+import { Layer, useGetRuntimeEvents, useGetRuntimeEvmTokensAddress } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
+import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 
 export const useTokenInfo = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
@@ -12,4 +14,46 @@ export const useTokenInfo = (scope: SearchScope, address: string) => {
   const token = query.data?.data
   const { isLoading, isError, isFetched } = query
   return { token, isLoading, isError, isFetched }
+}
+
+export const useTokenTransfers = (scope: SearchScope, address: string) => {
+  const { network, layer } = scope
+  const pagination = useSearchParamsPagination('page')
+  const offset = (pagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+  if (layer === Layer.consensus) {
+    throw AppErrors.UnsupportedLayer
+    // Loading transactions on the consensus layer is not supported yet.
+    // We should use useGetConsensusTransactions()
+  }
+  const query = useGetRuntimeEvents(
+    network,
+    layer, // This is OK since consensus has been handled separately
+    {
+      limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+      offset: offset,
+      rel: address,
+      // type: 'evm.log',
+      // TODO: maybe restrict this more later.
+      // If the token is a payable account (usually they're not, AFAIK),
+      // this will also return events where tokens were transferred to or from the token account itself.
+      // I think let's ignore this possibility for now.
+      // We can limit these unwanted (?) results further by adding &type=evm.log
+    },
+  )
+
+  const { isFetched, isLoading, data } = query
+
+  const transfers = data?.data.events
+
+  const totalCount = data?.data.total_count
+  const isTotalCountClipped = data?.data.is_total_count_clipped
+
+  return {
+    isLoading,
+    isFetched,
+    transfers,
+    pagination,
+    totalCount,
+    isTotalCountClipped,
+  }
 }

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -6,11 +6,15 @@ import { TokenTitleCard } from './TokenTitleCard'
 import { TokenSnapshot } from './TokenSnapshot'
 import { TokenDetailsCard } from './TokenDetailsCard'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
+import { useHref, useLoaderData } from 'react-router-dom'
 import { useTokenInfo } from './hook'
 import { AppErrors } from '../../../types/errors'
+import { RouterTabs } from '../../components/RouterTabs'
+import { useTranslation } from 'react-i18next'
+import { contractCodeContainerId } from '../AccountDetailsPage/ContractCodeCard'
 
 export const TokenDashboardPage: FC = () => {
+  const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
@@ -21,12 +25,21 @@ export const TokenDashboardPage: FC = () => {
     throw AppErrors.InvalidAddress
   }
 
+  const tokenTransfersLink = useHref(``)
+  const codeLink = useHref(`code#${contractCodeContainerId}`)
+
   return (
     <PageLayout>
       <TokenTitleCard />
       <TokenSnapshot />
       {!isMobile && <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />}
       <TokenDetailsCard />
+      <RouterTabs
+        tabs={[
+          { label: t('tokens.transfers'), to: tokenTransfersLink },
+          { label: t('contract.code'), to: codeLink },
+        ]}
+      />
     </PageLayout>
   )
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -23,6 +23,7 @@ import { TokensPage } from './app/pages/TokensOverviewPage'
 import { ContractCodeCard } from './app/pages/AccountDetailsPage/ContractCodeCard'
 import { TokenDashboardPage } from './app/pages/TokenDashboardPage'
 import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
+import { TokenTransfersCard } from './app/pages/TokenDashboardPage/TokenTransfersCard'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -118,6 +119,18 @@ export const routes: RouteObject[] = [
             path: `token/:address`, // This is a temporal workaround, until we have the required dedicated functionality for tokens
             element: <TokenDashboardPage />,
             loader: addressParamLoader,
+            children: [
+              {
+                path: '',
+                element: <TokenTransfersCard />,
+                loader: addressParamLoader,
+              },
+              {
+                path: 'code',
+                element: <ContractCodeCard />,
+                loader: addressParamLoader,
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
This PR adds 2 of the 3 tabs required for the token dashboard:
 - Token transfers
 - Code

Designs: 
 - [Token transfers](https://www.figma.com/file/ifCrok8cP5ymEYjMa2PIi9/Block-Explorer?type=design&node-id=5840-215517)
 - [Code](https://www.figma.com/file/ifCrok8cP5ymEYjMa2PIi9/Block-Explorer?type=design&node-id=5967-211710)

The last tab, token holders, comes later.