### PR TITLE
Add "Token Holders" tab to Token Dashboard

### DIFF
--- a/.changelog/635.feature.md
+++ b/.changelog/635.feature.md
@@ -1,0 +1,1 @@
+Add "Token Holders" tab to Token Dashboard

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -13,7 +13,7 @@ type TableTokenHolder = BareTokenHolder & {
 type TokenHoldersProps = {
   holders: TableTokenHolder[] | undefined
   isLoading: boolean
-  decimals: number | undefined
+  decimals: number
   totalSupply: string | undefined
   limit: number
   pagination: false | TablePaginationProps
@@ -24,7 +24,7 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
   limit,
   pagination,
   holders,
-  decimals = 18,
+  decimals,
   totalSupply,
 }) => {
   const { t } = useTranslation()

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -1,0 +1,108 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Table, TableCellAlign, TableColProps } from '../Table'
+import { BareTokenHolder } from '../../../oasis-nexus/api'
+import { TablePaginationProps } from '../Table/TablePagination'
+import { AccountLink } from '../Account/AccountLink'
+import { fromBaseUnits } from '../../utils/helpers'
+import { TokenPriceInfo } from '../../../coin-gecko/api'
+
+type TableTokenHolder = BareTokenHolder & {
+  markAsNew?: boolean
+}
+
+type TokenHoldersProps = {
+  holders: TableTokenHolder[] | undefined
+  isLoading: boolean
+  decimals: number | undefined
+  totalSupply: string | undefined
+  limit: number
+  tokenPrice?: TokenPriceInfo
+  pagination: false | TablePaginationProps
+}
+
+export const TokenHolders: FC<TokenHoldersProps> = ({
+  isLoading,
+  limit,
+  pagination,
+  holders,
+  decimals = 18,
+  totalSupply,
+  tokenPrice,
+}) => {
+  const { t } = useTranslation()
+  const tableColumns: TableColProps[] = [
+    { key: 'rank', content: t('common.rank'), align: TableCellAlign.Center },
+    { key: 'address', content: t('common.address') },
+    { key: 'quantity', content: t('common.quantity'), align: TableCellAlign.Right },
+    { key: 'percentage', content: t('common.percentage'), align: TableCellAlign.Right },
+    ...(tokenPrice
+      ? [{ key: 'value', align: TableCellAlign.Right, content: t('common.value'), width: '250px' }]
+      : []),
+  ]
+
+  const calculateRatio = (balance: string): string => {
+    return totalSupply === undefined
+      ? t('common.missing')
+      : `${((100 * parseFloat(fromBaseUnits(balance, decimals))) / parseFloat(totalSupply)).toFixed(4)}%`
+  }
+
+  const tableRows = holders?.map((holder, index) => {
+    return {
+      key: holder.holder_address,
+      data: [
+        {
+          key: 'rank',
+          content: holder.rank.toLocaleString(),
+          align: TableCellAlign.Center,
+        },
+        {
+          key: 'address',
+          content: (
+            <AccountLink scope={holder} address={holder.eth_holder_address || holder.holder_address} />
+          ),
+        },
+        {
+          key: 'quantity',
+          content: t('tokens.totalSupplyValue', { value: fromBaseUnits(holder.balance, decimals) }),
+          align: TableCellAlign.Right,
+        },
+        {
+          key: 'percentage',
+          content: calculateRatio(holder.balance),
+          align: TableCellAlign.Right,
+        },
+        ...(tokenPrice?.price
+          ? [
+              {
+                key: 'value',
+                content: t('common.fiatValueInUSD', {
+                  value: parseFloat(fromBaseUnits(holder.balance, decimals)) * tokenPrice.price,
+                  formatParams: {
+                    value: {
+                      currency: 'USD',
+                    } satisfies Intl.NumberFormatOptions,
+                  },
+                }),
+
+                align: TableCellAlign.Right,
+              },
+            ]
+          : []),
+      ],
+      highlight: holder.markAsNew,
+    }
+  })
+
+  return (
+    <Table
+      columns={tableColumns}
+      rows={tableRows}
+      rowsNumber={limit}
+      name={t('transactions.latest')}
+      isLoading={isLoading}
+      pagination={pagination}
+      extraHorizontalSpaceOnMobile
+    />
+  )
+}

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -5,7 +5,6 @@ import { BareTokenHolder } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { AccountLink } from '../Account/AccountLink'
 import { fromBaseUnits } from '../../utils/helpers'
-import { TokenPriceInfo } from '../../../coin-gecko/api'
 
 type TableTokenHolder = BareTokenHolder & {
   markAsNew?: boolean
@@ -17,7 +16,6 @@ type TokenHoldersProps = {
   decimals: number | undefined
   totalSupply: string | undefined
   limit: number
-  tokenPrice?: TokenPriceInfo
   pagination: false | TablePaginationProps
 }
 
@@ -28,7 +26,6 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
   holders,
   decimals = 18,
   totalSupply,
-  tokenPrice,
 }) => {
   const { t } = useTranslation()
   const tableColumns: TableColProps[] = [
@@ -36,9 +33,6 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
     { key: 'address', content: t('common.address') },
     { key: 'quantity', content: t('common.quantity'), align: TableCellAlign.Right },
     { key: 'percentage', content: t('common.percentage'), align: TableCellAlign.Right },
-    ...(tokenPrice
-      ? [{ key: 'value', align: TableCellAlign.Right, content: t('common.value'), width: '250px' }]
-      : []),
   ]
 
   const calculateRatio = (balance: string): string => {
@@ -72,23 +66,6 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
           content: calculateRatio(holder.balance),
           align: TableCellAlign.Right,
         },
-        ...(tokenPrice?.price
-          ? [
-              {
-                key: 'value',
-                content: t('common.fiatValueInUSD', {
-                  value: parseFloat(fromBaseUnits(holder.balance, decimals)) * tokenPrice.price,
-                  formatParams: {
-                    value: {
-                      currency: 'USD',
-                    } satisfies Intl.NumberFormatOptions,
-                  },
-                }),
-
-                align: TableCellAlign.Right,
-              },
-            ]
-          : []),
       ],
       highlight: holder.markAsNew,
     }

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -5,6 +5,7 @@ import { BareTokenHolder } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { AccountLink } from '../Account/AccountLink'
 import { fromBaseUnits } from '../../utils/helpers'
+import { RoundedBalance } from '../RoundedBalance'
 
 type TableTokenHolder = BareTokenHolder & {
   markAsNew?: boolean
@@ -58,7 +59,7 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
         },
         {
           key: 'quantity',
-          content: t('tokens.totalSupplyValue', { value: fromBaseUnits(holder.balance, decimals) }),
+          content: <RoundedBalance value={fromBaseUnits(holder.balance, decimals)} />,
           align: TableCellAlign.Right,
         },
         {

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -1,0 +1,55 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useLoaderData } from 'react-router-dom'
+import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
+import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
+import { useAccount } from '../AccountDetailsPage/hook'
+import { useTokenTransfers } from './hook'
+
+export const tokenHoldersContainerId = 'holders'
+
+export const TokenHoldersCard: FC = () => {
+  const { t } = useTranslation()
+  const scope = useRequiredScopeParam()
+  const address = useLoaderData() as string
+
+  const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } = useTokenTransfers(
+    scope,
+    address,
+  )
+
+  const { account } = useAccount(scope, address)
+
+  return (
+    <Card>
+      <LinkableDiv id={tokenHoldersContainerId}>
+        <CardHeader disableTypography component="h3" title={t('tokens.holders')} />
+      </LinkableDiv>
+      <CardContent>
+        <ErrorBoundary light={true}>
+          {isFetched && !transfers?.length && <CardEmptyState label={t('account.emptyTokenTransferList')} />}
+          <TokenTransfers
+            transfers={transfers}
+            ownAddress={account?.address_eth}
+            isLoading={isLoading}
+            limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+            pagination={{
+              selectedPage: pagination.selectedPage,
+              linkToPage: pagination.linkToPage,
+              totalCount,
+              isTotalCountClipped,
+              rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+            }}
+          />
+        </ErrorBoundary>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -19,12 +19,18 @@ export const TokenHoldersCard: FC = () => {
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
 
-  const { token } = useTokenInfo(scope, address)
+  const { isLoading: isTokenLoading, token } = useTokenInfo(scope, address)
 
-  const { isLoading, isFetched, holders, pagination, totalCount, isTotalCountClipped } = useTokenHolders(
-    scope,
-    address,
-  )
+  const {
+    isLoading: areHoldersLoading,
+    isFetched,
+    holders,
+    pagination,
+    totalCount,
+    isTotalCountClipped,
+  } = useTokenHolders(scope, address)
+
+  const isLoading = isTokenLoading || areHoldersLoading
 
   return (
     <Card>
@@ -36,7 +42,7 @@ export const TokenHoldersCard: FC = () => {
           {isFetched && !totalCount && <CardEmptyState label={t('tokens.emptyTokenHolderList')} />}
           <TokenHolders
             holders={holders}
-            decimals={token?.decimals}
+            decimals={token?.decimals ?? 0}
             totalSupply={token?.total_supply}
             isLoading={isLoading}
             limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -26,10 +26,6 @@ export const TokenHoldersCard: FC = () => {
     address,
   )
 
-  const tokenPrice = undefined
-  // TODO: add token price when available
-  // const tokenPrice = useTokenPrice('ROSE')
-
   return (
     <Card>
       <LinkableDiv id={tokenHoldersContainerId}>
@@ -44,7 +40,6 @@ export const TokenHoldersCard: FC = () => {
             totalSupply={token?.total_supply}
             isLoading={isLoading}
             limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-            tokenPrice={tokenPrice}
             pagination={{
               selectedPage: pagination.selectedPage,
               linkToPage: pagination.linkToPage,

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -8,10 +8,9 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useLoaderData } from 'react-router-dom'
-import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
-import { useAccount } from '../AccountDetailsPage/hook'
-import { useTokenTransfers } from './hook'
+import { useTokenHolders, useTokenInfo } from './hook'
+import { TokenHolders } from '../../components/Tokens/TokenHolders'
 
 export const tokenHoldersContainerId = 'holders'
 
@@ -20,12 +19,16 @@ export const TokenHoldersCard: FC = () => {
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
 
-  const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } = useTokenTransfers(
+  const { token } = useTokenInfo(scope, address)
+
+  const { isLoading, isFetched, holders, pagination, totalCount, isTotalCountClipped } = useTokenHolders(
     scope,
     address,
   )
 
-  const { account } = useAccount(scope, address)
+  const tokenPrice = undefined
+  // TODO: add token price when available
+  // const tokenPrice = useTokenPrice('ROSE')
 
   return (
     <Card>
@@ -34,12 +37,14 @@ export const TokenHoldersCard: FC = () => {
       </LinkableDiv>
       <CardContent>
         <ErrorBoundary light={true}>
-          {isFetched && !transfers?.length && <CardEmptyState label={t('account.emptyTokenTransferList')} />}
-          <TokenTransfers
-            transfers={transfers}
-            ownAddress={account?.address_eth}
+          {isFetched && !totalCount && <CardEmptyState label={t('tokens.emptyTokenHolderList')} />}
+          <TokenHolders
+            holders={holders}
+            decimals={token?.decimals}
+            totalSupply={token?.total_supply}
             isLoading={isLoading}
             limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+            tokenPrice={tokenPrice}
             pagination={{
               selectedPage: pagination.selectedPage,
               linkToPage: pagination.linkToPage,

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
@@ -8,7 +8,7 @@ import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useTokenInfo } from './hook'
 import { useLoaderData } from 'react-router-dom'
 
-export const TokenHoldersCard: FC = () => {
+export const TokenHoldersCountCard: FC = () => {
   const { t } = useTranslation()
   const scope = useRequiredScopeParam()
 

--- a/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { AppendMobileSearch } from '../../components/AppendMobileSearch'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { TokenSupplyCard } from './TokenSupplyCard'
-import { TokenHoldersCard } from './TokenHoldersCard'
+import { TokenHoldersCountCard } from './TokenHoldersCountCard'
 import { TokenTypeCard } from './TokenTypeCard'
 import { TokenTotalTransactionsCard } from './TokenTotalTransactionsCard'
 
@@ -49,7 +49,7 @@ export const TokenSnapshot: FC = () => {
           <TokenSupplyCard />
         </StyledGrid>
         <StyledGrid item xs={22} md={5}>
-          <TokenHoldersCard />
+          <TokenHoldersCountCard />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
           <TokenTypeCard />

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -1,4 +1,9 @@
-import { Layer, useGetRuntimeEvents, useGetRuntimeEvmTokensAddress } from '../../../oasis-nexus/api'
+import {
+  Layer,
+  useGetRuntimeEvents,
+  useGetRuntimeEvmTokensAddress,
+  useGetRuntimeEvmTokensAddressHolders,
+} from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
@@ -52,6 +57,36 @@ export const useTokenTransfers = (scope: SearchScope, address: string) => {
     isLoading,
     isFetched,
     transfers,
+    pagination,
+    totalCount,
+    isTotalCountClipped,
+  }
+}
+
+export const useTokenHolders = (scope: SearchScope, address: string) => {
+  const { network, layer } = scope
+  const pagination = useSearchParamsPagination('page')
+  const offset = (pagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+  if (layer === Layer.consensus) {
+    throw AppErrors.UnsupportedLayer
+    // There are no token holders on the consensus layer.
+  }
+  const query = useGetRuntimeEvmTokensAddressHolders(network, layer, address, {
+    limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+    offset: offset,
+  })
+
+  const { isFetched, isLoading, data } = query
+
+  const holders = data?.data.holders
+
+  const totalCount = data?.data.total_count
+  const isTotalCountClipped = data?.data.is_total_count_clipped
+
+  return {
+    isLoading,
+    isFetched,
+    holders,
     pagination,
     totalCount,
     isTotalCountClipped,

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -12,6 +12,7 @@ import { AppErrors } from '../../../types/errors'
 import { RouterTabs } from '../../components/RouterTabs'
 import { useTranslation } from 'react-i18next'
 import { contractCodeContainerId } from '../AccountDetailsPage/ContractCodeCard'
+import { tokenHoldersContainerId } from './TokenHoldersCard'
 
 export const TokenDashboardPage: FC = () => {
   const { t } = useTranslation()
@@ -26,6 +27,7 @@ export const TokenDashboardPage: FC = () => {
   }
 
   const tokenTransfersLink = useHref(``)
+  const tokenHoldersLink = useHref(`holders#${tokenHoldersContainerId}`)
   const codeLink = useHref(`code#${contractCodeContainerId}`)
 
   return (
@@ -37,6 +39,7 @@ export const TokenDashboardPage: FC = () => {
       <RouterTabs
         tabs={[
           { label: t('tokens.transfers'), to: tokenTransfersLink },
+          { label: t('tokens.holders'), to: tokenHoldersLink },
           { label: t('contract.code'), to: codeLink },
         ]}
       />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -197,7 +197,7 @@
     "request": "Request test tokens"
   },
   "tokens": {
-    "holders": "Holders",
+    "holders": "Token Holders",
     "holdersValue": "{{ value, number }}",
     "holdersCount": "Holders count",
     "holdersCount_short": "Holders",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -33,6 +33,7 @@
   },
   "coinGeckoReferral": "Data from <CoinGeckoLink>CoinGecko</CoinGeckoLink>",
   "common": {
+    "address": "Address",
     "age": "Age",
     "balance": "Balance",
     "block": "Block",
@@ -64,6 +65,8 @@
     "name": "Name",
     "oasis": "Oasis",
     "paratime": "Paratime",
+    "percentage": "Percentage",
+    "rank": "Rank",
     "select": "Select",
     "size": "Size",
     "sapphire": "Sapphire",
@@ -82,6 +85,7 @@
     "transactionAbbreviation": "Txs",
     "txnFee": "Txn Fee",
     "type": "Type",
+    "quantity": "Quantity",
     "unknown": "Unknown",
     "value": "Value",
     "valueInToken": "{{value}} {{ticker}}",
@@ -197,6 +201,7 @@
     "request": "Request test tokens"
   },
   "tokens": {
+    "emptyTokenHolderList": "There are no token holders on record for this token.",
     "holders": "Token Holders",
     "holdersValue": "{{ value, number }}",
     "holdersCount": "Holders count",

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -58,6 +58,7 @@ declare module './generated/api' {
   export interface BareTokenHolder {
     network: Network
     layer: Layer
+    rank: number
   }
 }
 
@@ -554,9 +555,10 @@ export const useGetRuntimeEvmTokensAddressHolders: typeof generated.useGetRuntim
           if (status !== 200) return data
           return {
             ...data,
-            holders: data.holders.map(holder => {
+            holders: data.holders.map((holder, index) => {
               return {
                 ...holder,
+                rank: index + (params?.offset ?? 0) + 1,
                 layer: runtime,
                 network,
               }

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -55,6 +55,10 @@ declare module './generated/api' {
     network: Network
     layer: Layer
   }
+  export interface BareTokenHolder {
+    network: Network
+    layer: Layer
+  }
 }
 
 export const isAccountEmpty = (account: RuntimeAccount) => {
@@ -521,6 +525,38 @@ export const useGetRuntimeEvents: typeof generated.useGetRuntimeEvents = (
             events: data.events.map(event => {
               return {
                 ...event,
+                layer: runtime,
+                network,
+              }
+            }),
+          }
+        },
+        ...arrayify(options?.request?.transformResponse),
+      ],
+    },
+  })
+}
+
+export const useGetRuntimeEvmTokensAddressHolders: typeof generated.useGetRuntimeEvmTokensAddressHolders = (
+  network,
+  runtime,
+  address,
+  params,
+  options,
+) => {
+  return generated.useGetRuntimeEvmTokensAddressHolders(network, runtime, address, params, {
+    ...options,
+    request: {
+      ...options?.request,
+      transformResponse: [
+        ...arrayify(axios.defaults.transformResponse),
+        (data: generated.TokenHolderList, headers, status) => {
+          if (status !== 200) return data
+          return {
+            ...data,
+            holders: data.holders.map(holder => {
+              return {
+                ...holder,
                 layer: runtime,
                 network,
               }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -24,6 +24,7 @@ import { ContractCodeCard } from './app/pages/AccountDetailsPage/ContractCodeCar
 import { TokenDashboardPage } from './app/pages/TokenDashboardPage'
 import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
 import { TokenTransfersCard } from './app/pages/TokenDashboardPage/TokenTransfersCard'
+import { TokenHoldersCard } from './app/pages/TokenDashboardPage/TokenHoldersCard'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -123,6 +124,11 @@ export const routes: RouteObject[] = [
               {
                 path: '',
                 element: <TokenTransfersCard />,
+                loader: addressParamLoader,
+              },
+              {
+                path: 'holders',
+                element: <TokenHoldersCard />,
                 loader: addressParamLoader,
               },
               {


### PR DESCRIPTION
This ~is built on top of #634, and~ implements the last missing tab, "Token Holders".

Design is [here](https://www.figma.com/file/ifCrok8cP5ymEYjMa2PIi9/Block-Explorer?type=design&node-id=5967-211045).
