### PR TITLE
Help to avoid sending over the mnemonic to nexus for search

### DIFF
--- a/.changelog/656.feature.md
+++ b/.changelog/656.feature.md
@@ -1,0 +1,1 @@
+Add check against sending menmonics to search

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tanstack/react-query-devtools": "4.29.19",
     "axios": "1.4.0",
     "bignumber.js": "9.1.1",
+    "bip39": "^3.1.0",
     "date-fns": "2.30.0",
     "i18next": "22.5.1",
     "react": "18.2.0",

--- a/src/app/utils/helpers.ts
+++ b/src/app/utils/helpers.ts
@@ -5,6 +5,7 @@ import * as oasisRT from '@oasisprotocol/client-rt'
 // eslint-disable-next-line no-restricted-imports
 import { AddressPreimage } from '../../oasis-nexus/generated/api'
 import BigNumber from 'bignumber.js'
+import { validateMnemonic } from 'bip39'
 
 export const isValidBlockHeight = (blockHeight: string): boolean => /^[0-9]+$/.test(blockHeight)
 export const isValidBlockHash = (hash: string): boolean => /^[0-9a-fA-F]{64}$/.test(hash)
@@ -79,3 +80,5 @@ export function fromBaseUnits(valueInBaseUnits: string, decimals: number): strin
   }
   return value.toFixed()
 }
+
+export const isValidMnemonic = (candidate: string): boolean => validateMnemonic(candidate)

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "appName": "Oasis Explorer",
   "account": {
     "cantLoadDetails": "Unfortunately we couldn't load the account details at this time. Please try again later.",
     "emptyTokenList": "This account holds no {{token}} tokens.",
@@ -375,7 +376,8 @@
   "search": {
     "placeholder": "Address, Block, Contract, Txn Hash, Transaction ID, Token name, etc",
     "error": {
-      "tooShort": "Please enter either at least 3 characters or a number in order to perform a search."
+      "tooShort": "Please enter either at least 3 characters or a number in order to perform a search.",
+      "privacy": "It seems like you might accidentally entered a keyphrase for a wallet. Please note that your mnemonic is a secret key that should never be shared, even not with our {{ pagetitle }}.\nExecuting this search is highly unlikely to return any results. If you want to proceed nonetheless, please add “{{ wordsOfPower }}” in front of your search query to perform the search at your own risk."
     },
     "mobilePlaceholder": "Search Address, Block, Txn, Token, etc",
     "noResults": {
@@ -412,6 +414,7 @@
     },
     "searchBtnText": "Search",
     "searchSuggestions": "Not sure what to look for? Try out a search: <OptionalBreak><BlockLink><BlockIcon/> Block</BlockLink>, <TransactionLink><TransactionIcon/> Transaction</TransactionLink>, <AccountLink><AccountIcon/> Address</AccountLink>, <TokenLink><TokenIcon/> Token</TokenLink> </OptionalBreak>",
-    "sectionHeader": "Results on {{ scope }}"
+    "sectionHeader": "Results on {{ scope }}",
+    "wordsOfPower": "I COMMAND THEE TO SEARCH FOR"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,7 +5227,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bip39@^3.0.4:
+bip39@^3.0.4, bip39@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"
   integrity sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==


### PR DESCRIPTION
Up to now, we could only search for strings in a few very strictly specified format. (Ie. block number, tx hash, etc.) But now that we can do free full-text search for token names, it has become a bit of a security vulnerability that it's possible to accidentally copy and send sensitive information, like your wallet private key mnemonics, if you are working with the wallet and the explorer at the same time, and accidentally copy the wrong string to the wrong field.

Although would probably not be an everyday event, it's worth to add a simple check to warn about this, before doing it.

If it happens, this is what we do:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/9ac429d0-5dc3-4bda-8b34-a117d2ed3bdb)
