### PR TITLE
Show different labels for ParaTime snapshot charts

### DIFF
--- a/.changelog/658.trivial.md
+++ b/.changelog/658.trivial.md
@@ -1,0 +1,1 @@
+Update charts in ParaTime Snapshot

--- a/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
+++ b/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
@@ -1,33 +1,20 @@
 import { FC } from 'react'
-import { TFunction } from 'i18next'
-import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
-import { ChartDuration } from '../../utils/chart-utils'
-
-const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
-  [ChartDuration.TODAY]: t('chartDuration.lastHour'),
-  [ChartDuration.WEEK]: t('chartDuration.lastDay'),
-  [ChartDuration.MONTH]: t('chartDuration.lastDay'),
-  [ChartDuration.ALL_TIME]: t('chartDuration.lastDay'),
-})
 
 type SnapshotCardLabelProps = {
-  duration: ChartDuration
+  label: string
   value: number | undefined
 }
-export const SnapshotCardDurationLabel: FC<SnapshotCardLabelProps> = ({ duration, value }) => {
-  const { t } = useTranslation()
-  const labels = getLabels(t)
-
+export const SnapshotCardDurationLabel: FC<SnapshotCardLabelProps> = ({ label, value }) => {
   if (!value) {
     return null
   }
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-      <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>{labels[duration]}</Typography>
+      <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>{label}</Typography>
       <Typography sx={{ fontSize: 'inherit' }}>{value.toLocaleString()}</Typography>
     </Box>
   )

--- a/src/app/pages/ParatimeDashboardPage/ActiveAccounts.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ActiveAccounts.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import startOfMonth from 'date-fns/startOfMonth'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
@@ -57,8 +58,16 @@ type ActiveAccountsProps = {
   chartDuration: ChartDuration
 }
 
+const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
+  [ChartDuration.TODAY]: t('chartDuration.lastHour'),
+  [ChartDuration.WEEK]: t('chartDuration.lastDay'),
+  [ChartDuration.MONTH]: t('chartDuration.lastDay'),
+  [ChartDuration.ALL_TIME]: t('chartDuration.lastMonth'),
+})
+
 export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
+  const labels = getLabels(t)
   const { limit, bucket_size_seconds } = durationToQueryParams[chartDuration]
   const scope = useRequiredScopeParam()
   const activeAccountsQuery = useGetLayerStatsActiveAccounts(
@@ -85,7 +94,7 @@ export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
       title={t('activeAccounts.title')}
       label={
         <SnapshotCardDurationLabel
-          duration={chartDuration}
+          label={labels[chartDuration]}
           value={windows?.length && windows[0].active_accounts}
         />
       }

--- a/src/app/pages/ParatimeDashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TransactionsChartCard.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { TFunction } from 'i18next'
 import { useGetLayerStatsTxVolume } from '../../../oasis-nexus/api'
 import {
   ChartDuration,
@@ -15,12 +16,20 @@ import { PercentageGain } from '../../components/PercentageGain'
 import startOfHour from 'date-fns/startOfHour'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 
+const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
+  [ChartDuration.TODAY]: t('chartDuration.lastHour'),
+  [ChartDuration.WEEK]: t('chartDuration.lastDay'),
+  [ChartDuration.MONTH]: t('chartDuration.lastDay'),
+  [ChartDuration.ALL_TIME]: t('chartDuration.lastDay'),
+})
+
 interface TransactionsChartCardProps {
   chartDuration: ChartDuration
 }
 
 const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
   const { t } = useTranslation()
+  const labels = getLabels(t)
   const { isMobile } = useScreenSize()
   const statsParams = durationToQueryParams[chartDuration]
   const scope = useRequiredScopeParam()
@@ -59,7 +68,7 @@ const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuratio
       }
       label={
         <SnapshotCardDurationLabel
-          duration={chartDuration}
+          label={labels[chartDuration]}
           value={lineChartData?.length && lineChartData[0].tx_volume}
         />
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -298,7 +298,8 @@
     "week": "Week",
     "month": "Month",
     "lastHour": "Last hour",
-    "lastDay": "Last day"
+    "lastDay": "Last day",
+    "lastMonth": "Last month"
   },
   "currentFiatValue": {
     "title": "Current fiat value",


### PR DESCRIPTION
Based on Don's feedback we want to keep current charts behaviour, but we need to show different label for ALL_TIME filter. 