### PR TITLE
Assemble changes for 0.2.0 release

### DIFF
--- a/.changelog/278.internal.md
+++ b/.changelog/278.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/473.internal.md
+++ b/.changelog/473.internal.md
@@ -1,1 +1,0 @@
-Refactor API bindings to support testnet using orval code generation

--- a/.changelog/477.internal.md
+++ b/.changelog/477.internal.md
@@ -1,1 +1,0 @@
-Add strict type-checks that most switch statements cover all cases

--- a/.changelog/482.feature.md
+++ b/.changelog/482.feature.md
@@ -1,1 +1,0 @@
-Mobile ParaTime picker

--- a/.changelog/510.bugfix.md
+++ b/.changelog/510.bugfix.md
@@ -1,1 +1,0 @@
-Abbreviate tables on dashboard mobile

--- a/.changelog/511.feature.md
+++ b/.changelog/511.feature.md
@@ -1,1 +1,0 @@
-Abbreviate numbers in transaction charts

--- a/.changelog/519.internal.md
+++ b/.changelog/519.internal.md
@@ -1,1 +1,0 @@
-Update dependency swiper to v9.4.1

--- a/.changelog/521.internal.md
+++ b/.changelog/521.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/522.bugfix.md
+++ b/.changelog/522.bugfix.md
@@ -1,1 +1,0 @@
-Show a nice error message when can't load account details.

--- a/.changelog/523.trivial.md
+++ b/.changelog/523.trivial.md
@@ -1,1 +1,0 @@
-Improve handling of nameless ERC-20 tokens

--- a/.changelog/524.bugfix.md
+++ b/.changelog/524.bugfix.md
@@ -1,1 +1,0 @@
-Improve/fix styling of search results on mobile

--- a/.changelog/525.bugfix.md
+++ b/.changelog/525.bugfix.md
@@ -1,1 +1,0 @@
-Fix description list paddings for mobile variant

--- a/.changelog/526.trivial.md
+++ b/.changelog/526.trivial.md
@@ -1,1 +1,0 @@
-Also indicate the unencrypted status of transactions

--- a/.changelog/527.feature.md
+++ b/.changelog/527.feature.md
@@ -1,1 +1,0 @@
-Use custom locale for formatting distance between dates

--- a/.changelog/529.bugfix.md
+++ b/.changelog/529.bugfix.md
@@ -1,1 +1,0 @@
-Fix paddings in table cell

--- a/.changelog/531.bugfix.md
+++ b/.changelog/531.bugfix.md
@@ -1,1 +1,0 @@
-Abbreviate block link on tablet

--- a/.changelog/532.bugfix.2.md
+++ b/.changelog/532.bugfix.2.md
@@ -1,1 +1,0 @@
-Adjust layout to new breakpoint

--- a/.changelog/532.bugfix.md
+++ b/.changelog/532.bugfix.md
@@ -1,1 +1,0 @@
-Set laptop breakpoint to handle more edge cases

--- a/.changelog/533.internal.md
+++ b/.changelog/533.internal.md
@@ -1,1 +1,0 @@
-Change release build artifact name to show version instead of commit hash

--- a/.changelog/534.breaking.md
+++ b/.changelog/534.breaking.md
@@ -1,3 +1,0 @@
-Update routes to conform to [EIP-3091]
-
-[EIP-3091]: https://eips.ethereum.org/EIPS/eip-3091

--- a/.changelog/535.feature.md
+++ b/.changelog/535.feature.md
@@ -1,1 +1,0 @@
-Create transaction icons

--- a/.changelog/536.trivial.md
+++ b/.changelog/536.trivial.md
@@ -1,1 +1,0 @@
-Update desktop footer

--- a/.changelog/537.bugfix.md
+++ b/.changelog/537.bugfix.md
@@ -1,1 +1,0 @@
-Fix dashboard links to latest blocks and transactions

--- a/.changelog/538.internal.md
+++ b/.changelog/538.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.7.0

--- a/.changelog/539.internal.md
+++ b/.changelog/539.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies to v7.0.21

--- a/.changelog/542.breaking.md
+++ b/.changelog/542.breaking.md
@@ -1,1 +1,0 @@
-Remove explorer support for token types dropped by indexer, incl. ERC721

--- a/.changelog/543.internal.md
+++ b/.changelog/543.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.7.1

--- a/.changelog/544.feature.md
+++ b/.changelog/544.feature.md
@@ -1,1 +1,0 @@
-At address page, recognize contracts, and use appropriate title

--- a/.changelog/546.feature.md
+++ b/.changelog/546.feature.md
@@ -1,1 +1,0 @@
-Add token overview page and dashboard component

--- a/.changelog/548.internal.md
+++ b/.changelog/548.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies to v4.29.14

--- a/.changelog/550.internal.md
+++ b/.changelog/550.internal.md
@@ -1,1 +1,0 @@
-Update dependency eslint to v8.43.0

--- a/.changelog/551.internal.md
+++ b/.changelog/551.internal.md
@@ -1,1 +1,0 @@
-Update dependency markdownlint-cli to v0.35.0

--- a/.changelog/552.internal.md
+++ b/.changelog/552.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies to v7.0.22

--- a/.changelog/554.bugfix.md
+++ b/.changelog/554.bugfix.md
@@ -1,1 +1,0 @@
-Prevent showing horizontal scrollbar on home page

--- a/.changelog/556.internal.md
+++ b/.changelog/556.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/557.bugfix.md
+++ b/.changelog/557.bugfix.md
@@ -1,1 +1,0 @@
-Fix error display when using invalid layers

--- a/.changelog/558.internal.md
+++ b/.changelog/558.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies to v5.60.0

--- a/.changelog/560.bugfix.md
+++ b/.changelog/560.bugfix.md
@@ -1,1 +1,0 @@
-Don't indicate problem with nodes while loading number

--- a/.changelog/562.internal.md
+++ b/.changelog/562.internal.md
@@ -1,1 +1,0 @@
-Table column content: support ReactNode besides string

--- a/.changelog/565.internal.md
+++ b/.changelog/565.internal.md
@@ -1,1 +1,0 @@
-Use intlFormatDistance instead of formatDistanceToNow

--- a/.changelog/566.internal.md
+++ b/.changelog/566.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/567.feature.md
+++ b/.changelog/567.feature.md
@@ -1,1 +1,0 @@
-Implement scroll restore and scroll to the top of the page on navigate

--- a/.changelog/568.trivial.md
+++ b/.changelog/568.trivial.md
@@ -1,1 +1,0 @@
-Test formatDistanceToNow

--- a/.changelog/569.internal.md
+++ b/.changelog/569.internal.md
@@ -1,1 +1,0 @@
-Update dependency @storybook/testing-library to v0.2.0

--- a/.changelog/570.trivial.md
+++ b/.changelog/570.trivial.md
@@ -1,1 +1,0 @@
-Fix token supply formatting

--- a/.changelog/571.bugfix.md
+++ b/.changelog/571.bugfix.md
@@ -1,1 +1,0 @@
-Wrap all long values in detail pages

--- a/.changelog/572.bugfix.md
+++ b/.changelog/572.bugfix.md
@@ -1,1 +1,0 @@
-Show proper icon for not encrypted transaction

--- a/.changelog/573.trivial.md
+++ b/.changelog/573.trivial.md
@@ -1,1 +1,0 @@
-Expand collapsed displays when clicking content too

--- a/.changelog/574.bugfix.md
+++ b/.changelog/574.bugfix.md
@@ -1,1 +1,0 @@
-Abbreviate tables on dashboard mobile

--- a/.changelog/575.trivial.md
+++ b/.changelog/575.trivial.md
@@ -1,1 +1,0 @@
-The Blocks and Txn should be clickable without ParaTime selected

--- a/.changelog/576.feature.md
+++ b/.changelog/576.feature.md
@@ -1,1 +1,0 @@
-Save HelpScreen state on mobile

--- a/.changelog/577.feature.md
+++ b/.changelog/577.feature.md
@@ -1,1 +1,0 @@
-Add tooltip with error message to transaction status icons on lists

--- a/.changelog/578.bugfix.md
+++ b/.changelog/578.bugfix.md
@@ -1,1 +1,0 @@
-Fix offline indicators showing out-of-date 2 minutes after opening page

--- a/.changelog/579.bugfix.md
+++ b/.changelog/579.bugfix.md
@@ -1,1 +1,0 @@
-Differentiate user being offline and API being offline

--- a/.changelog/580.internal.md
+++ b/.changelog/580.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.7.2

--- a/.changelog/580.trivial.md
+++ b/.changelog/580.trivial.md
@@ -1,1 +1,0 @@
-Update ParaTime picker based on internal feedback

--- a/.changelog/581.internal.md
+++ b/.changelog/581.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies to v7.0.23

--- a/.changelog/583.bugfix.md
+++ b/.changelog/583.bugfix.md
@@ -1,1 +1,0 @@
-Prevent double click on graph

--- a/.changelog/584.trivial.md
+++ b/.changelog/584.trivial.md
@@ -1,1 +1,0 @@
-Update desktop footer

--- a/.changelog/585.bugfix.md
+++ b/.changelog/585.bugfix.md
@@ -1,1 +1,0 @@
-Differentiate user being offline and API being offline

--- a/.changelog/587.trivial.md
+++ b/.changelog/587.trivial.md
@@ -1,1 +1,0 @@
-Add buffer to bar chart and update chart styles

--- a/.changelog/588.internal.md
+++ b/.changelog/588.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/588.trivial.md
+++ b/.changelog/588.trivial.md
@@ -1,1 +1,0 @@
-Update sticky alert styles

--- a/.changelog/589.internal.md
+++ b/.changelog/589.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/590.internal.md
+++ b/.changelog/590.internal.md
@@ -1,1 +1,0 @@
-Update parcel monorepo to v2.9.3

--- a/.changelog/593.feature.md
+++ b/.changelog/593.feature.md
@@ -1,1 +1,0 @@
-Save HelpScreen state on mobile

--- a/.changelog/594.bugfix.md
+++ b/.changelog/594.bugfix.md
@@ -1,1 +1,0 @@
-Fix glitchy mobile onboarding steps

--- a/.changelog/595.internal.md
+++ b/.changelog/595.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies to v5.60.1

--- a/.changelog/596.internal.md
+++ b/.changelog/596.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies to v4.29.18

--- a/.changelog/597.trivial.md
+++ b/.changelog/597.trivial.md
@@ -1,1 +1,0 @@
-Fix zoom out link not visible on Testnet

--- a/.changelog/598.trivial.md
+++ b/.changelog/598.trivial.md
@@ -1,1 +1,0 @@
-Update learning materials for Sapphire testnet

--- a/.changelog/599.trivial.md
+++ b/.changelog/599.trivial.md
@@ -1,1 +1,0 @@
-Render pagination only when there is more than one page

--- a/.changelog/600.trivial.md
+++ b/.changelog/600.trivial.md
@@ -1,1 +1,0 @@
-Add Testnet Faucet to snapshot cards

--- a/.changelog/601.bugfix.md
+++ b/.changelog/601.bugfix.md
@@ -1,1 +1,0 @@
-Fix info icon missing on mobile

--- a/.changelog/602.trivial.md
+++ b/.changelog/602.trivial.md
@@ -1,1 +1,0 @@
-Add Docs and GitHub links in footer

--- a/.changelog/603.internal.md
+++ b/.changelog/603.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies to v4.29.19

--- a/.changelog/604.internal.md
+++ b/.changelog/604.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies to v7.0.24

--- a/.changelog/605.trivial.md
+++ b/.changelog/605.trivial.md
@@ -1,1 +1,0 @@
-Fix testnet help screen

--- a/.changelog/607.trivial.md
+++ b/.changelog/607.trivial.md
@@ -1,1 +1,0 @@
-Ensure learning materials and search suggestions are specified for each layer

--- a/.changelog/608.trivial.md
+++ b/.changelog/608.trivial.md
@@ -1,1 +1,0 @@
-Update API bindings

--- a/.changelog/609.feature.md
+++ b/.changelog/609.feature.md
@@ -1,1 +1,0 @@
-Show contract verification and link to Sourcify

--- a/.changelog/610.internal.md
+++ b/.changelog/610.internal.md
@@ -1,1 +1,0 @@
-Update dependency typescript to v5.1.5

--- a/.changelog/611.bugfix.md
+++ b/.changelog/611.bugfix.md
@@ -1,1 +1,0 @@
-Freshness test: look at latest block time, not latest update

--- a/.changelog/612.internal.md
+++ b/.changelog/612.internal.md
@@ -1,1 +1,0 @@
-Remove desktop tooltips on Graph

--- a/.changelog/613.trivial.md
+++ b/.changelog/613.trivial.md
@@ -1,1 +1,0 @@
-Update labels in Account details

--- a/.changelog/614.trivial.md
+++ b/.changelog/614.trivial.md
@@ -1,1 +1,0 @@
-Add Docs and GitHub links in footer

--- a/.changelog/616.feature.md
+++ b/.changelog/616.feature.md
@@ -1,1 +1,0 @@
-For contracts, display bytecode

--- a/.changelog/617.bugfix.md
+++ b/.changelog/617.bugfix.md
@@ -1,1 +1,0 @@
-Specify search suggestions per layer

--- a/.changelog/617.trivial.md
+++ b/.changelog/617.trivial.md
@@ -1,1 +1,0 @@
-Hardcode values of active nodes

--- a/.changelog/620.trivial.md
+++ b/.changelog/620.trivial.md
@@ -1,1 +1,0 @@
-Various small cleanups

--- a/.changelog/621.trivial.md
+++ b/.changelog/621.trivial.md
@@ -1,1 +1,0 @@
-Switch back to production API

--- a/.changelog/622.internal.md
+++ b/.changelog/622.internal.md
@@ -1,1 +1,0 @@
-Update dependency typescript to v5.1.6

--- a/.changelog/623.2.feature.md
+++ b/.changelog/623.2.feature.md
@@ -1,1 +1,0 @@
-Properly display creator info for contracts.

--- a/.changelog/623.3.feature.md
+++ b/.changelog/623.3.feature.md
@@ -1,1 +1,0 @@
-When displaying a contract that describes a token, link to the token dashboard

--- a/.changelog/623.breaking.md
+++ b/.changelog/623.breaking.md
@@ -1,1 +1,0 @@
-Rename indexer to nexus

--- a/.changelog/623.feature.md
+++ b/.changelog/623.feature.md
@@ -1,1 +1,0 @@
-Add token dashboard

--- a/.changelog/624.feature.md
+++ b/.changelog/624.feature.md
@@ -1,1 +1,0 @@
-Account details: display token transfers

--- a/.changelog/626.trivial.md
+++ b/.changelog/626.trivial.md
@@ -1,1 +1,0 @@
-Update styles of search notifications

--- a/.changelog/627.feature.md
+++ b/.changelog/627.feature.md
@@ -1,1 +1,0 @@
-Update graph graphics

--- a/.changelog/629.trivial.md
+++ b/.changelog/629.trivial.md
@@ -1,1 +1,0 @@
-Imrove how tabs are displayed on small screens

--- a/.changelog/631.trivial.md
+++ b/.changelog/631.trivial.md
@@ -1,1 +1,0 @@
-Displaying contract code in hex, not base64

--- a/.changelog/633.internal.md
+++ b/.changelog/633.internal.md
@@ -1,1 +1,0 @@
-Update dependency ts-jest to v29.1.1

--- a/.changelog/634.feature.md
+++ b/.changelog/634.feature.md
@@ -1,1 +1,0 @@
-Token dashboard: add "Token Transfers" and "Code" tabs

--- a/.changelog/635.feature.md
+++ b/.changelog/635.feature.md
@@ -1,1 +1,0 @@
-Add "Token Holders" tab to Token Dashboard

--- a/.changelog/636.internal.md
+++ b/.changelog/636.internal.md
@@ -1,1 +1,0 @@
-Update dependency react-router-dom to v6.14.1

--- a/.changelog/637.feature.md
+++ b/.changelog/637.feature.md
@@ -1,1 +1,0 @@
-Support searching for tokens by name

--- a/.changelog/638.feature.md
+++ b/.changelog/638.feature.md
@@ -1,1 +1,0 @@
-Include contract verification info in token lists

--- a/.changelog/639.internal.md
+++ b/.changelog/639.internal.md
@@ -1,1 +1,0 @@
-Update Nexus API bindings

--- a/.changelog/640.internal.md
+++ b/.changelog/640.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/node to v18.16.19

--- a/.changelog/641.internal.md
+++ b/.changelog/641.internal.md
@@ -1,1 +1,0 @@
-Update dependency eslint to v8.44.0

--- a/.changelog/643.trivial.md
+++ b/.changelog/643.trivial.md
@@ -1,1 +1,0 @@
-Show precise tooltip for "<0.00000" values too

--- a/.changelog/645.internal.md
+++ b/.changelog/645.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies to v7.0.25

--- a/.changelog/647.internal.md
+++ b/.changelog/647.internal.md
@@ -1,1 +1,0 @@
-Switch back to staging API

--- a/.changelog/648.internal.md
+++ b/.changelog/648.internal.md
@@ -1,1 +1,0 @@
-Remove feedback form from banner on staging

--- a/.changelog/649.internal.md
+++ b/.changelog/649.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies to v5.61.0

--- a/.changelog/650.trivial.md
+++ b/.changelog/650.trivial.md
@@ -1,1 +1,0 @@
-Account "Tokens" card: add missing links to tokens and contracts

--- a/.changelog/651.feature.md
+++ b/.changelog/651.feature.md
@@ -1,1 +1,0 @@
-Improve displaying events

--- a/.changelog/652.internal.md
+++ b/.changelog/652.internal.md
@@ -1,1 +1,0 @@
-Update fontsource monorepo to ^5.0.5

--- a/.changelog/653.internal.md
+++ b/.changelog/653.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/654.trivial.md
+++ b/.changelog/654.trivial.md
@@ -1,1 +1,0 @@
-Update charts in ParaTime Snapshot

--- a/.changelog/655.trivial.md
+++ b/.changelog/655.trivial.md
@@ -1,1 +1,0 @@
-Remove random async keyword

--- a/.changelog/657.internal.md
+++ b/.changelog/657.internal.md
@@ -1,1 +1,0 @@
-Update test dependencies to v29.6.0

--- a/.changelog/658.trivial.md
+++ b/.changelog/658.trivial.md
@@ -1,1 +1,0 @@
-Update charts in ParaTime Snapshot

--- a/.changelog/661.internal.md
+++ b/.changelog/661.internal.md
@@ -1,1 +1,0 @@
-Switch to production API

--- a/.changelog/662.internal.md
+++ b/.changelog/662.internal.md
@@ -1,1 +1,0 @@
-Fix changelog major and minor patterns

--- a/.changelog/665.internal.md
+++ b/.changelog/665.internal.md
@@ -1,1 +1,0 @@
-Update towncrier to ignore package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,284 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 0.2.0 (2023-07-05)
+
+### Removals and Breaking Changes
+
+- Update routes to conform to [EIP-3091]
+  ([#534](https://github.com/oasisprotocol/explorer/issues/534))
+
+  [EIP-3091]: https://eips.ethereum.org/EIPS/eip-3091
+
+- Remove explorer support for token types dropped by indexer, incl. ERC721
+  ([#542](https://github.com/oasisprotocol/explorer/issues/542))
+
+- Rename indexer to nexus
+  ([#623](https://github.com/oasisprotocol/explorer/issues/623))
+
+### Features
+
+- Properly display creator info for contracts.
+  ([#2](https://github.com/oasisprotocol/explorer/issues/2))
+
+- When displaying a contract that describes a token, link to the token dashboard
+  ([#3](https://github.com/oasisprotocol/explorer/issues/3))
+
+- Mobile ParaTime picker
+  ([#482](https://github.com/oasisprotocol/explorer/issues/482))
+
+- Abbreviate numbers in transaction charts
+  ([#511](https://github.com/oasisprotocol/explorer/issues/511))
+
+- Use custom locale for formatting distance between dates
+  ([#527](https://github.com/oasisprotocol/explorer/issues/527))
+
+- Create transaction icons
+  ([#535](https://github.com/oasisprotocol/explorer/issues/535))
+
+- At address page, recognize contracts, and use appropriate title
+  ([#544](https://github.com/oasisprotocol/explorer/issues/544))
+
+- Add token overview page and dashboard component
+  ([#546](https://github.com/oasisprotocol/explorer/issues/546))
+
+- Implement scroll restore and scroll to the top of the page on navigate
+  ([#567](https://github.com/oasisprotocol/explorer/issues/567))
+
+- Save HelpScreen state on mobile
+  ([#576](https://github.com/oasisprotocol/explorer/issues/576),
+  [#593](https://github.com/oasisprotocol/explorer/issues/593))
+
+- Add tooltip with error message to transaction status icons on lists
+  ([#577](https://github.com/oasisprotocol/explorer/issues/577))
+
+- Show contract verification and link to Sourcify
+  ([#609](https://github.com/oasisprotocol/explorer/issues/609))
+
+- For contracts, display bytecode
+  ([#616](https://github.com/oasisprotocol/explorer/issues/616))
+
+- Add token dashboard
+  ([#623](https://github.com/oasisprotocol/explorer/issues/623))
+
+- Account details: display token transfers
+  ([#624](https://github.com/oasisprotocol/explorer/issues/624))
+
+- Update graph graphics
+  ([#627](https://github.com/oasisprotocol/explorer/issues/627))
+
+- Token dashboard: add "Token Transfers" and "Code" tabs
+  ([#634](https://github.com/oasisprotocol/explorer/issues/634))
+
+- Add "Token Holders" tab to Token Dashboard
+  ([#635](https://github.com/oasisprotocol/explorer/issues/635))
+
+- Support searching for tokens by name
+  ([#637](https://github.com/oasisprotocol/explorer/issues/637))
+
+- Include contract verification info in token lists
+  ([#638](https://github.com/oasisprotocol/explorer/issues/638))
+
+- Improve displaying events
+  ([#651](https://github.com/oasisprotocol/explorer/issues/651))
+
+### Bug Fixes and Improvements
+
+- Abbreviate tables on dashboard mobile
+  ([#510](https://github.com/oasisprotocol/explorer/issues/510),
+  [#574](https://github.com/oasisprotocol/explorer/issues/574))
+
+- Show a nice error message when can't load account details.
+  ([#522](https://github.com/oasisprotocol/explorer/issues/522))
+
+- Improve/fix styling of search results on mobile
+  ([#524](https://github.com/oasisprotocol/explorer/issues/524))
+
+- Fix description list paddings for mobile variant
+  ([#525](https://github.com/oasisprotocol/explorer/issues/525))
+
+- Fix paddings in table cell
+  ([#529](https://github.com/oasisprotocol/explorer/issues/529))
+
+- Abbreviate block link on tablet
+  ([#531](https://github.com/oasisprotocol/explorer/issues/531))
+
+- Set laptop breakpoint to handle more edge cases
+  ([#532](https://github.com/oasisprotocol/explorer/issues/532))
+
+- Adjust layout to new breakpoint
+  ([#532](https://github.com/oasisprotocol/explorer/issues/532))
+
+- Fix dashboard links to latest blocks and transactions
+  ([#537](https://github.com/oasisprotocol/explorer/issues/537))
+
+- Prevent showing horizontal scrollbar on home page
+  ([#554](https://github.com/oasisprotocol/explorer/issues/554))
+
+- Fix error display when using invalid layers
+  ([#557](https://github.com/oasisprotocol/explorer/issues/557))
+
+- Don't indicate problem with nodes while loading number
+  ([#560](https://github.com/oasisprotocol/explorer/issues/560))
+
+- Wrap all long values in detail pages
+  ([#571](https://github.com/oasisprotocol/explorer/issues/571))
+
+- Show proper icon for not encrypted transaction
+  ([#572](https://github.com/oasisprotocol/explorer/issues/572))
+
+- Fix offline indicators showing out-of-date 2 minutes after opening page
+  ([#578](https://github.com/oasisprotocol/explorer/issues/578))
+
+- Differentiate user being offline and API being offline
+  ([#579](https://github.com/oasisprotocol/explorer/issues/579),
+  [#585](https://github.com/oasisprotocol/explorer/issues/585))
+
+- Prevent double click on graph
+  ([#583](https://github.com/oasisprotocol/explorer/issues/583))
+
+- Fix glitchy mobile onboarding steps
+  ([#594](https://github.com/oasisprotocol/explorer/issues/594))
+
+- Fix info icon missing on mobile
+  ([#601](https://github.com/oasisprotocol/explorer/issues/601))
+
+- Freshness test: look at latest block time, not latest update
+  ([#611](https://github.com/oasisprotocol/explorer/issues/611))
+
+- Specify search suggestions per layer
+  ([#617](https://github.com/oasisprotocol/explorer/issues/617))
+
+### Internal Changes
+
+- Update material-ui monorepo
+  ([#278](https://github.com/oasisprotocol/explorer/issues/278),
+  [#588](https://github.com/oasisprotocol/explorer/issues/588),
+  [#653](https://github.com/oasisprotocol/explorer/issues/653))
+
+- Refactor API bindings to support testnet using orval code generation
+  ([#473](https://github.com/oasisprotocol/explorer/issues/473))
+
+- Add strict type-checks that most switch statements cover all cases
+  ([#477](https://github.com/oasisprotocol/explorer/issues/477))
+
+- Update dependency swiper to v9.4.1
+  ([#519](https://github.com/oasisprotocol/explorer/issues/519))
+
+- Update react dependencies
+  ([#521](https://github.com/oasisprotocol/explorer/issues/521),
+  [#556](https://github.com/oasisprotocol/explorer/issues/556),
+  [#566](https://github.com/oasisprotocol/explorer/issues/566),
+  [#589](https://github.com/oasisprotocol/explorer/issues/589))
+
+- Change release build artifact name to show version instead of commit hash
+  ([#533](https://github.com/oasisprotocol/explorer/issues/533))
+
+- Update dependency recharts to v2.7.0
+  ([#538](https://github.com/oasisprotocol/explorer/issues/538))
+
+- Update storybook dependencies to v7.0.21
+  ([#539](https://github.com/oasisprotocol/explorer/issues/539))
+
+- Update dependency recharts to v2.7.1
+  ([#543](https://github.com/oasisprotocol/explorer/issues/543))
+
+- Update react dependencies to v4.29.14
+  ([#548](https://github.com/oasisprotocol/explorer/issues/548))
+
+- Update dependency eslint to v8.43.0
+  ([#550](https://github.com/oasisprotocol/explorer/issues/550))
+
+- Update dependency markdownlint-cli to v0.35.0
+  ([#551](https://github.com/oasisprotocol/explorer/issues/551))
+
+- Update storybook dependencies to v7.0.22
+  ([#552](https://github.com/oasisprotocol/explorer/issues/552))
+
+- Update lint dependencies to v5.60.0
+  ([#558](https://github.com/oasisprotocol/explorer/issues/558))
+
+- Table column content: support ReactNode besides string
+  ([#562](https://github.com/oasisprotocol/explorer/issues/562))
+
+- Use intlFormatDistance instead of formatDistanceToNow
+  ([#565](https://github.com/oasisprotocol/explorer/issues/565))
+
+- Update dependency @storybook/testing-library to v0.2.0
+  ([#569](https://github.com/oasisprotocol/explorer/issues/569))
+
+- Update dependency recharts to v2.7.2
+  ([#580](https://github.com/oasisprotocol/explorer/issues/580))
+
+- Update storybook dependencies to v7.0.23
+  ([#581](https://github.com/oasisprotocol/explorer/issues/581))
+
+- Update parcel monorepo to v2.9.3
+  ([#590](https://github.com/oasisprotocol/explorer/issues/590))
+
+- Update lint dependencies to v5.60.1
+  ([#595](https://github.com/oasisprotocol/explorer/issues/595))
+
+- Update react dependencies to v4.29.18
+  ([#596](https://github.com/oasisprotocol/explorer/issues/596))
+
+- Update react dependencies to v4.29.19
+  ([#603](https://github.com/oasisprotocol/explorer/issues/603))
+
+- Update storybook dependencies to v7.0.24
+  ([#604](https://github.com/oasisprotocol/explorer/issues/604))
+
+- Update dependency typescript to v5.1.5
+  ([#610](https://github.com/oasisprotocol/explorer/issues/610))
+
+- Remove desktop tooltips on Graph
+  ([#612](https://github.com/oasisprotocol/explorer/issues/612))
+
+- Update dependency typescript to v5.1.6
+  ([#622](https://github.com/oasisprotocol/explorer/issues/622))
+
+- Update dependency ts-jest to v29.1.1
+  ([#633](https://github.com/oasisprotocol/explorer/issues/633))
+
+- Update dependency react-router-dom to v6.14.1
+  ([#636](https://github.com/oasisprotocol/explorer/issues/636))
+
+- Update Nexus API bindings
+  ([#639](https://github.com/oasisprotocol/explorer/issues/639))
+
+- Update dependency @types/node to v18.16.19
+  ([#640](https://github.com/oasisprotocol/explorer/issues/640))
+
+- Update dependency eslint to v8.44.0
+  ([#641](https://github.com/oasisprotocol/explorer/issues/641))
+
+- Update storybook dependencies to v7.0.25
+  ([#645](https://github.com/oasisprotocol/explorer/issues/645))
+
+- Switch back to staging API
+  ([#647](https://github.com/oasisprotocol/explorer/issues/647))
+
+- Remove feedback form from banner on staging
+  ([#648](https://github.com/oasisprotocol/explorer/issues/648))
+
+- Update lint dependencies to v5.61.0
+  ([#649](https://github.com/oasisprotocol/explorer/issues/649))
+
+- Update fontsource monorepo to ^5.0.5
+  ([#652](https://github.com/oasisprotocol/explorer/issues/652))
+
+- Update test dependencies to v29.6.0
+  ([#657](https://github.com/oasisprotocol/explorer/issues/657))
+
+- Switch to production API
+  ([#661](https://github.com/oasisprotocol/explorer/issues/661))
+
+- Fix changelog major and minor patterns
+  ([#662](https://github.com/oasisprotocol/explorer/issues/662))
+
+- Update towncrier to ignore package.json
+  ([#665](https://github.com/oasisprotocol/explorer/issues/665))
+
 ## 0.1.0 (2023-06-13)
 
 ### Process Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lukaw3d/parcel-bundler-json-schemas/main/package_schema.json",
   "name": "@oasisprotocol/explorer-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Manually downgraded from `1.0.0` to `0.2.0` as we want to keep `1.0.0` for a public launch.