### PR TITLE
Update towncrier to ignore package.json

### DIFF
--- a/.changelog/665.internal.md
+++ b/.changelog/665.internal.md
@@ -1,0 +1,1 @@
+Update towncrier to ignore package.json

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -5,6 +5,11 @@
 [tool.towncrier]
 filename = "CHANGELOG.md"
 directory = ".changelog"
+# Ignore certain files when running towncrier check.
+check_ignore_files = [
+  # File where we store app version.
+  "package.json",
+]
 issue_format = "[#{issue}](https://github.com/oasisprotocol/explorer/issues/{issue})"
 start_string = "<!-- TOWNCRIER -->\n"
 # Custom Jinja2 template for preparing a new section of the Change Log.


### PR DESCRIPTION
We don't want append Change Log fragment when we bump app version (when we are assembling changes via towncrier). 