### PR TITLE
Fix description alignment in description list

### DIFF
--- a/.changelog/668.internal.md
+++ b/.changelog/668.internal.md
@@ -1,0 +1,1 @@
+Fix description alignment in description list

--- a/src/app/components/StyledDescriptionList/index.tsx
+++ b/src/app/components/StyledDescriptionList/index.tsx
@@ -42,7 +42,6 @@ export const StyledDescriptionList = styled(InlineDescriptionList, {
 })<StyledDescriptionListProps>(({ theme, standalone, highlight }) => ({
   'dt, dd': {
     display: 'flex',
-    alignItems: 'start',
     boxShadow: `0px 1px 0px ${COLORS.grayLight}`,
     ':last-of-type': {
       boxShadow: 'none',
@@ -56,10 +55,12 @@ export const StyledDescriptionList = styled(InlineDescriptionList, {
   },
   dt: {
     color: COLORS.grayDark,
+    alignItems: 'start',
   },
   dd: {
     color: COLORS.brandExtraDark,
     overflowWrap: 'anywhere',
+    alignItems: 'center',
   },
   ...(standalone && {
     '&&': {


### PR DESCRIPTION
Reverts 1b1c63c2ca6158833bd7739757145ee3d9c2bea6 and re-fixes it by only aligning titles to top.

| Before | After |
| --- | --- |
| ![localhost_1234_testnet_sapphire_address_0x10FafE48F09CD304E26F704a7EE743c4CbDc61C1 (1)](https://github.com/oasisprotocol/explorer/assets/3758846/79a597c6-7dac-44ba-b905-5fcbaceff59c) | ![localhost_1234_testnet_sapphire_address_0x10FafE48F09CD304E26F704a7EE743c4CbDc61C1 (2)](https://github.com/oasisprotocol/explorer/assets/3758846/8f75b119-89d5-43b9-b114-a9061f168585)  | 