### PR TITLE
Pull the API specs directly from GitHub

### DIFF
--- a/.changelog/678.internal.md
+++ b/.changelog/678.internal.md
@@ -1,0 +1,1 @@
+Pull the API specs directly from GitHub

--- a/src/oasis-nexus/orval.config.js
+++ b/src/oasis-nexus/orval.config.js
@@ -6,9 +6,9 @@ const config = {
   nexus: {
     input: {
       // target: './v1.yaml',
-      // target: 'https://raw.githubusercontent.com/oasisprotocol/nexus/main/api/spec/v1.yaml',
+      target: 'https://raw.githubusercontent.com/oasisprotocol/nexus/main/api/spec/v1.yaml',
       // target: 'https://index-staging.oasislabs.com/v1/spec/v1.yaml',
-      target: 'https://index.oasislabs.com/v1/spec/v1.yaml',
+      // target: 'https://index.oasislabs.com/v1/spec/v1.yaml',
       override: {
         // We want:
         // - network as a parameter for controlling API baseURL


### PR DESCRIPTION
https://github.com/oasisprotocol/nexus/pull/478 has been recently merged to nexus code. We need this change to accurately describe the data that is already being returned by the API at the production deployment. It's not realistic to get a new deployment (with the updated specs) right away, but we _do_ need the new specs, so we need to pull it directly from GitHub. 
Hence, this change.