### PR TITLE
Begin to fix ERC-271 tokens

### DIFF
--- a/.changelog/679.bugfix.md
+++ b/.changelog/679.bugfix.md
@@ -1,0 +1,1 @@
+Don't die on ERC-721 tokens

--- a/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
@@ -15,6 +15,8 @@ export const getTokenTypeName = (t: TFunction, type: EvmTokenType): string => {
   switch (type) {
     case 'ERC20':
       return t('account.ERC20')
+    case 'ERC721':
+      return t('account.ERC721')
     default:
       exhaustedTypeWarning('Unknown token type', type)
       return type

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -66,6 +66,7 @@ export abstract class RouteUtils {
   ) => {
     const map: Record<EvmTokenType, string | undefined> = {
       ERC20: `${this.getAccountRoute(scope, account)}/tokens/erc-20`,
+      ERC721: `${this.getAccountRoute(scope, account)}/tokens/erc-721`,
     }
     const tokenRoutes = map[tokenType]
     if (!tokenRoutes) throw new Error('Unexpected token type')

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "emptyTransactionList": "There are no transactions on record for this account.",
     "emptyTokenTransferList": "There are no token transfers on record for this account.",
     "ERC20": "ERC-20",
+    "ERC721": "ERC-721",
     "noTokens": "This account holds no tokens",
     "showMore": "+ {{counter}} more",
     "title": "Account",

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -75,6 +75,7 @@ export const isAccountNonEmpty = (account: RuntimeAccount) => !isAccountEmpty(ac
 export const groupAccountTokenBalances = (account: Omit<RuntimeAccount, 'tokenBalances'>): RuntimeAccount => {
   const tokenBalances: Record<generated.EvmTokenType, generated.RuntimeEvmBalance[]> = {
     ERC20: [],
+    ERC721: [],
   }
   account.evm_balances.forEach(balance => {
     if (balance.token_type) tokenBalances[balance.token_type].push(balance)


### PR DESCRIPTION
This PR builds on latest API changes from #677.

Afer this, we don't die on ERC-721 tokens.

It needs more work to actually display them properly,
but after this change, at least we are not throwing any more exceptions
when encountering them.