### PR TITLE
Fully bring back ERC-721 tokens

### DIFF
--- a/.changelog/681.feature.md
+++ b/.changelog/681.feature.md
@@ -1,0 +1,1 @@
+Fully bring back support for ERC-721 tokens

--- a/src/app/components/Account/ShowMoreTokensLink.tsx
+++ b/src/app/components/Account/ShowMoreTokensLink.tsx
@@ -29,6 +29,12 @@ export const ShowMoreTokensLink: FC<ShowMoreTokensLinkProps> = ({ account, token
     EvmTokenType.ERC20,
     accountTokenContainerId,
   )
+  const erc721Link = RouteUtils.getAccountTokensRoute(
+    account,
+    account.address_eth ?? account.address,
+    EvmTokenType.ERC721,
+    accountTokenContainerId,
+  )
 
   const additionalTokensCounter = tokens.length - pills.length
 
@@ -36,8 +42,14 @@ export const ShowMoreTokensLink: FC<ShowMoreTokensLinkProps> = ({ account, token
     return null
   }
 
+  // link to ERC20 tab otherwise if there are only ERC721 tokens not included in pills link to the ERC721
+  const pillsSymbols = new Set(pills.map(({ token_contract_addr }) => token_contract_addr))
+  const showMoreItems = tokens.filter(({ token_contract_addr }) => !pillsSymbols.has(token_contract_addr))
+  const hasERC20 = showMoreItems.some(item => item.token_type === EvmTokenType.ERC20)
+  const targetShowMoreLink = hasERC20 ? erc20link : erc721Link
+
   return (
-    <StyledLink to={erc20link} color="inherit">
+    <StyledLink to={targetShowMoreLink} color="inherit">
       {t('account.showMore', { counter: additionalTokensCounter })}
     </StyledLink>
   )

--- a/src/app/components/Account/__tests__/ShowMoreTokensLink.test.tsx
+++ b/src/app/components/Account/__tests__/ShowMoreTokensLink.test.tsx
@@ -28,6 +28,15 @@ const mockedToken2: Token = {
   token_decimals: 18,
 }
 
+const mockedToken3: Token = {
+  balance: '0.012345',
+  token_contract_addr: 'oasis1qrg90d4qlelg5zg4q4sd4y0z8j2lpjpvuspzjly3',
+  token_name: 'ERC721',
+  token_symbol: 'ERC721',
+  token_type: EvmTokenType.ERC721,
+  token_decimals: 18,
+}
+
 const mockedToken4: Token = {
   balance: '1123.5',
   token_contract_addr: 'oasis1qrg90d4qlelg5zg4q4sd4y0z8j2lpjpvuspzjly4',
@@ -52,15 +61,31 @@ describe('ShowMoreTokensLink', () => {
     renderWithProviders(
       <ShowMoreTokensLink
         account={mockedAccount}
-        tokens={[mockedToken1, mockedToken2, mockedToken4]}
+        tokens={[mockedToken1, mockedToken2, mockedToken3, mockedToken4]}
         pills={[mockedToken1]}
       />,
     )
 
-    expect(screen.getByText('+ 2 more')).toBeInTheDocument()
+    expect(screen.getByText('+ 3 more')).toBeInTheDocument()
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
       '/mainnet/emerald/address/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-20#tokens',
+    )
+  })
+
+  it('should render ERC721 link if there is no ERC20 token', () => {
+    renderWithProviders(
+      <ShowMoreTokensLink
+        account={mockedAccount}
+        tokens={[mockedToken1, mockedToken2, mockedToken3]}
+        pills={[mockedToken1, mockedToken2]}
+      />,
+    )
+
+    expect(screen.getByText('+ 1 more')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/mainnet/emerald/address/oasis1qrvha284gfztn7wwq6z50c86ceu28jp7csqhpx9t/tokens/erc-721#tokens',
     )
   })
 })

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -29,7 +29,7 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
   const { t } = useTranslation()
   const locationHash = useLocation().hash.replace('#', '')
   const tokenLabel = t(`account.${type}` as any)
-  const tokenListLabel = t('common.tokens') // TODO: re-enable when we want multiple token types again t('account.tokensListTitle', { token: tokenLabel })
+  const tokenListLabel = t('account.tokensListTitle', { token: tokenLabel })
   const tableColumns: TableColProps[] = [
     { key: 'name', content: t('common.name') },
     { key: 'contract', content: t('common.smartContract') },

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -85,7 +85,7 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
       <LinkableDiv id={accountTokenContainerId}>
         <CardHeader disableTypography component="h3" title={tokenListLabel} />
         <CardContent>
-          {!isLoading && !account?.tokenBalances[type].length && (
+          {!isLoading && !account?.tokenBalances[type]?.length && (
             <CardEmptyState label={t('account.emptyTokenList', { token: tokenLabel })} />
           )}
 

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -34,6 +34,8 @@ export const AccountDetailsPage: FC = () => {
   const tokenTransfersLink = useHref(`token-transfers#${accountTokenTransfersContainerId}`)
   const showErc20 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC20].length
   const erc20Link = useHref(`tokens/erc-20#${accountTokenContainerId}`)
+  const showErc721 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC721].length
+  const erc721Link = useHref(`tokens/erc-721#${accountTokenContainerId}`)
   const showTxs = showEmptyAccountDetails || showErc20 || !!account?.stats.num_txns
   const txLink = useHref('')
   const showCode = isContract
@@ -62,7 +64,16 @@ export const AccountDetailsPage: FC = () => {
           tabs={[
             { label: t('common.transactions'), to: txLink, visible: showTxs },
             { label: t('tokens.transfers'), to: tokenTransfersLink, visible: showTokenTransfers },
-            { label: t('common.tokens'), to: erc20Link, visible: showErc20 },
+            {
+              label: t('account.tokensListTitle', { token: t(`account.ERC20`) }),
+              to: erc20Link,
+              visible: showErc20,
+            },
+            {
+              label: t('account.tokensListTitle', { token: t(`account.ERC721`) }),
+              to: erc721Link,
+              visible: showErc721,
+            },
             { label: t('contract.code'), to: codeLink, visible: showCode },
           ]}
         />

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -23,7 +23,7 @@ export const AccountDetailsPage: FC = () => {
 
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
-  const { account, isLoading: isAcccountLoading, isError } = useAccount(scope, address)
+  const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address)
   const { totalCount: numberOfTokenTransfers } = useAccountTokenTransfers(scope, address)
 
@@ -42,7 +42,7 @@ export const AccountDetailsPage: FC = () => {
   const codeLink = useHref(`code#${contractCodeContainerId}`)
 
   const showDetails = showTxs || showErc20
-  const isLoading = isAcccountLoading || isTokenLoading
+  const isLoading = isAccountLoading || isTokenLoading
 
   return (
     <PageLayout>

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -32,9 +32,9 @@ export const AccountDetailsPage: FC = () => {
 
   const showTokenTransfers = showEmptyAccountDetails || !!numberOfTokenTransfers
   const tokenTransfersLink = useHref(`token-transfers#${accountTokenTransfersContainerId}`)
-  const showErc20 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC20].length
+  const showErc20 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC20]?.length
   const erc20Link = useHref(`tokens/erc-20#${accountTokenContainerId}`)
-  const showErc721 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC721].length
+  const showErc721 = showEmptyAccountDetails || !!account?.tokenBalances[EvmTokenType.ERC721]?.length
   const erc721Link = useHref(`tokens/erc-721#${accountTokenContainerId}`)
   const showTxs = showEmptyAccountDetails || showErc20 || !!account?.stats.num_txns
   const txLink = useHref('')

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -44,7 +44,7 @@ declare module './generated/api' {
     layer: Layer
     address_eth?: string
     ticker: NativeTicker
-    tokenBalances: Record<EvmTokenType, generated.RuntimeEvmBalance[]>
+    tokenBalances: Partial<Record<EvmTokenType, generated.RuntimeEvmBalance[]>>
   }
   export interface RuntimeEvent {
     network: Network
@@ -73,12 +73,12 @@ export const isAccountEmpty = (account: RuntimeAccount) => {
 export const isAccountNonEmpty = (account: RuntimeAccount) => !isAccountEmpty(account)
 
 export const groupAccountTokenBalances = (account: Omit<RuntimeAccount, 'tokenBalances'>): RuntimeAccount => {
-  const tokenBalances: Record<generated.EvmTokenType, generated.RuntimeEvmBalance[]> = {
-    ERC20: [],
-    ERC721: [],
-  }
+  const tokenBalances: Partial<Record<generated.EvmTokenType, generated.RuntimeEvmBalance[]>> = {}
   account.evm_balances.forEach(balance => {
-    if (balance.token_type) tokenBalances[balance.token_type].push(balance)
+    if (balance.token_type) {
+      tokenBalances[balance.token_type] ??= []
+      tokenBalances[balance.token_type]!.push(balance)
+    }
   })
 
   return {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -97,6 +97,11 @@ export const routes: RouteObject[] = [
                 loader: addressParamLoader,
               },
               {
+                path: 'tokens/erc-721',
+                element: <AccountTokensCard type="ERC721" />,
+                loader: addressParamLoader,
+              },
+              {
                 path: 'code',
                 element: <ContractCodeCard />,
                 loader: addressParamLoader,


### PR DESCRIPTION
This PR basically just restores what we had before we have removed the ERC-721 support before in https://github.com/oasisprotocol/explorer/pull/542/commits/3a3b71f2add61d7a7e193ff1f2b4a89fdd104d9f, following the indexer (now nexus) API changes.

Now that nexus brings them back, we need to do that, too.

The previous PR (#679) fixed the type safety issues and exceptions; this PR adds back the missing UI.