### PR TITLE
Use eth addresses in account token balances

### DIFF
--- a/.changelog/695.trivial.md
+++ b/.changelog/695.trivial.md
@@ -1,1 +1,1 @@
-Eliminate some useless token loading requests
+Use eth addresses in account token balances

--- a/.changelog/696.trivial.md
+++ b/.changelog/696.trivial.md
@@ -1,0 +1,1 @@
+Eliminate some useless token loading requests

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -21,12 +21,33 @@ import {
   getTokenTypePluralName,
   getTokenTypeStrictName,
 } from '../../../types/tokens'
+import { SearchScope } from '../../../types/searchScope'
+import Skeleton from '@mui/material/Skeleton'
 
 type AccountTokensCardProps = {
   type: EvmTokenType
 }
 
 export const accountTokenContainerId = 'tokens'
+
+export const DelayedContractLink: FC<{ scope: SearchScope; oasisAddress: string }> = ({
+  scope,
+  oasisAddress,
+}) => {
+  const { isLoading, account: contract } = useAccount(scope, oasisAddress)
+
+  if (isLoading) {
+    return <Skeleton variant={'text'} />
+  }
+
+  const address = contract?.address_eth ?? oasisAddress
+  return (
+    <Box sx={{ display: 'flex', alignContent: 'center' }}>
+      <AccountLink scope={scope} address={address} />
+      <CopyToClipboard value={address} />
+    </Box>
+  )
+}
 
 export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
   const scope = useRequiredScopeParam()
@@ -62,10 +83,8 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
       {
         content: (
           <LinkableDiv id={item.token_contract_addr}>
-            <Box sx={{ display: 'flex', alignContent: 'center' }}>
-              <AccountLink scope={scope} address={item.token_contract_addr} />
-              <CopyToClipboard value={item.token_contract_addr} />
-            </Box>
+            {/* TODO remove temporal workaround when token_contract_addr_eth becomes available as part of RuntimeEvmBalance */}
+            <DelayedContractLink scope={scope} oasisAddress={item.token_contract_addr} />
           </LinkableDiv>
         ),
         key: 'hash',


### PR DESCRIPTION
Since the required ETH address data is currently not present in the balances provided by the API, this requires pulling up the contracts for each balance.

Before:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/29e24b39-aad2-4370-ab43-7a9bd7927d8f)

After:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/46540f28-f698-47fa-af7b-0f5a45b0f28f)
