### PR TITLE
Eliminate some useless token loading requests

### DIFF
--- a/.changelog/695.trivial.md
+++ b/.changelog/695.trivial.md
@@ -1,0 +1,1 @@
+Eliminate some useless token loading requests

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -25,11 +25,11 @@ export const AccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
-  const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address)
+  const isContract = !!account?.evm_contract
+  const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, isContract)
   const { totalCount: numberOfTokenTransfers } = useAccountTokenTransfers(scope, address)
 
   const tokenPriceInfo = useTokenPrice(account?.ticker || Ticker.ROSE)
-  const isContract = !!account?.evm_contract
 
   const showTokenTransfers = showEmptyAccountDetails || !!numberOfTokenTransfers
   const tokenTransfersLink = useHref(`token-transfers#${accountTokenTransfersContainerId}`)

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -9,16 +9,23 @@ import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 
-export const useTokenInfo = (scope: SearchScope, address: string) => {
+export const useTokenInfo = (scope: SearchScope, address: string, enabled = true) => {
   const { network, layer } = scope
   if (layer === Layer.consensus) {
     // There can be no ERC-20 or ERC-721 tokens on consensus
     throw AppErrors.UnsupportedLayer
   }
-  const query = useGetRuntimeEvmTokensAddress(network, layer, address!)
+  const query = useGetRuntimeEvmTokensAddress(network, layer, address!, {
+    query: { enabled },
+  })
   const token = query.data?.data
   const { isLoading, isError, isFetched } = query
-  return { token, isLoading, isError, isFetched }
+  return {
+    token,
+    isLoading: isLoading && enabled, // By default, we get true for isLoading on disabled queries. We don't want that.
+    isError,
+    isFetched,
+  }
 }
 
 export const useTokenTransfers = (scope: SearchScope, address: string) => {


### PR DESCRIPTION
When we are looking at account details, and the account is a token contract, then we also need to load the token data to get the name of the token, which we want to display.

Because of this, whenever looking at account details, we were always requesting token data at the same time.

This commit restricts sending this request to cases when we already know that we are looking at contract.