### PR TITLE
Update discord links

### DIFF
--- a/.changelog/698.trivial.md
+++ b/.changelog/698.trivial.md
@@ -1,0 +1,1 @@
+Update discord links

--- a/src/app/utils/externalLinks.ts
+++ b/src/app/utils/externalLinks.ts
@@ -1,9 +1,9 @@
 export const socialMedia = {
   telegram: 'https://t.me/oasisprotocolcommunity',
   twitter: 'https://twitter.com/oasisprotocol',
-  discord: 'https://discord.gg/oasisprotocol',
+  discord: 'https://discord.com/invite/BQCxwhT5wS',
   // This API link is for testing if invite is still valid (normal discord link is always 200 OK).
-  isDiscordStillValid: 'https://discord.com/api/v9/invites/oasisprotocol',
+  isDiscordStillValid: 'https://discord.com/api/v9/invites/BQCxwhT5wS',
   youtube: 'https://www.youtube.com/channel/UC35UFPcZ2F1wjPxhPrSsESQ',
   reddit: 'https://www.reddit.com/r/oasisnetwork/',
 }


### PR DESCRIPTION
We used to have a custom invide, with "oasisprotocol" in the URL,
but now it's gone, so we must use a regular one, with an
alphanumerical ID in the URL.