### PR TITLE
 Move all router access to page-level components

### DIFF
--- a/.changelog/712.internal.md
+++ b/.changelog/712.internal.md
@@ -1,0 +1,1 @@
+Move all router access to page-level components

--- a/src/app/components/RouterTabs/index.tsx
+++ b/src/app/components/RouterTabs/index.tsx
@@ -1,22 +1,22 @@
-import { FC } from 'react'
 import { useLocation, Outlet } from 'react-router-dom'
 import { NonScrollingRouterLink } from '../NonScrollingRouterLink'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 
-type RouterTabsProps = {
+type RouterTabsProps<Context> = {
   tabs: {
     label: string
     to: string
     visible?: boolean
   }[]
+  context?: Context
 }
 
 function getPathname(tab: { to: string }) {
   return new URL(tab.to, 'https://a.b').pathname
 }
 
-export const RouterTabs: FC<RouterTabsProps> = ({ tabs }) => {
+export function RouterTabs<Context>({ tabs, context }: RouterTabsProps<Context>) {
   const { pathname } = useLocation()
   const currentTab = tabs.find(tab => getPathname(tab) === pathname)
 
@@ -35,7 +35,7 @@ export const RouterTabs: FC<RouterTabsProps> = ({ tabs }) => {
             />
           ))}
       </Tabs>
-      <Outlet />
+      <Outlet context={context} />
     </>
   )
 }

--- a/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -9,14 +9,12 @@ import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from './CardEmptyState'
 import { useAccount, useAccountTokenTransfers } from './hook'
 import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
-import { useOutletContext } from 'react-router-dom'
 import { AccountDetailsContext } from './index'
 
 export const accountTokenTransfersContainerId = 'transfers'
 
-export const AccountTokenTransfersCard: FC = () => {
+export const AccountTokenTransfersCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const { scope, address } = useOutletContext<AccountDetailsContext>()
 
   const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } =
     useAccountTokenTransfers(scope, address)

--- a/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -8,16 +8,15 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from './CardEmptyState'
 import { useAccount, useAccountTokenTransfers } from './hook'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
 import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
+import { useOutletContext } from 'react-router-dom'
+import { AccountDetailsContext } from './index'
 
 export const accountTokenTransfersContainerId = 'transfers'
 
 export const AccountTokenTransfersCard: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
+  const { scope, address } = useOutletContext<AccountDetailsContext>()
 
   const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } =
     useAccountTokenTransfers(scope, address)

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLoaderData, useLocation } from 'react-router-dom'
+import { useLocation, useOutletContext } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
@@ -12,7 +12,6 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { EvmTokenType, Layer } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useAccount } from './hook'
 import { TokenLink } from '../../components/Tokens/TokenLink'
 import { AccountLink } from '../../components/Account/AccountLink'
@@ -23,6 +22,7 @@ import {
 } from '../../../types/tokens'
 import { SearchScope } from '../../../types/searchScope'
 import Skeleton from '@mui/material/Skeleton'
+import { AccountDetailsContext } from './index'
 
 type AccountTokensCardProps = {
   type: EvmTokenType
@@ -50,8 +50,7 @@ export const DelayedContractLink: FC<{ scope: SearchScope; oasisAddress: string 
 }
 
 export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
+  const { scope, address } = useOutletContext<AccountDetailsContext>()
   const { t } = useTranslation()
   const locationHash = useLocation().hash.replace('#', '')
   const tokenListLabel = getTokenTypePluralName(t, type)
@@ -61,7 +60,7 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
     { key: 'balance', align: TableCellAlign.Right, content: t('common.balance') },
     { key: 'ticker', align: TableCellAlign.Right, content: t('common.ticker') },
   ]
-  const { layer } = useRequiredScopeParam()
+  const { layer } = scope
   if (layer === Layer.consensus) {
     // There can be no ERC-20 or ERC-721 tokens on consensus
     throw AppErrors.UnsupportedLayer

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, useOutletContext } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
@@ -24,7 +24,7 @@ import { SearchScope } from '../../../types/searchScope'
 import Skeleton from '@mui/material/Skeleton'
 import { AccountDetailsContext } from './index'
 
-type AccountTokensCardProps = {
+type AccountTokensCardProps = AccountDetailsContext & {
   type: EvmTokenType
 }
 
@@ -49,8 +49,7 @@ export const DelayedContractLink: FC<{ scope: SearchScope; oasisAddress: string 
   )
 }
 
-export const AccountTokensCard: FC<AccountTokensCardProps> = ({ type }) => {
-  const { scope, address } = useOutletContext<AccountDetailsContext>()
+export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, address, type }) => {
   const { t } = useTranslation()
   const locationHash = useLocation().hash.replace('#', '')
   const tokenListLabel = getTokenTypePluralName(t, type)

--- a/src/app/pages/AccountDetailsPage/AccountTransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTransactionsCard.tsx
@@ -10,12 +10,10 @@ import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from './CardEmptyState'
 import { useAccountTransactions } from './hook'
 import { AccountDetailsContext } from './index'
-import { useOutletContext } from 'react-router-dom'
 
 export const accountTransactionsContainerId = 'transactions'
 
-export const AccountTransactionsCard: FC = () => {
-  const { scope, address } = useOutletContext<AccountDetailsContext>()
+export const AccountTransactionsCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const { isLoading, isFetched, transactions, pagination, totalCount, isTotalCountClipped } =

--- a/src/app/pages/AccountDetailsPage/AccountTransactionsCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTransactionsCard.tsx
@@ -9,15 +9,14 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from './CardEmptyState'
 import { useAccountTransactions } from './hook'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
+import { AccountDetailsContext } from './index'
+import { useOutletContext } from 'react-router-dom'
 
 export const accountTransactionsContainerId = 'transactions'
 
 export const AccountTransactionsCard: FC = () => {
+  const { scope, address } = useOutletContext<AccountDetailsContext>()
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
 
   const { isLoading, isFetched, transactions, pagination, totalCount, isTotalCountClipped } =
     useAccountTransactions(scope, address)

--- a/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
@@ -4,8 +4,7 @@ import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { useAccount } from './hook'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import { CardEmptyState } from './CardEmptyState'
 import Typography from '@mui/material/Typography'
 import { ScrollableDataDisplay } from '../../components/ScrollableDataDisplay'
@@ -13,6 +12,7 @@ import Box from '@mui/material/Box'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { base64ToHex } from '../../utils/helpers'
+import { AccountDetailsContext } from './index'
 
 export const contractCodeContainerId = 'code'
 
@@ -51,8 +51,7 @@ const CodeDisplay: FC<{ rawData: string | undefined; label: string; extraTopPadd
 
 export const ContractCodeCard: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
+  const { scope, address } = useOutletContext<AccountDetailsContext>()
 
   const { isFetched, account } = useAccount(scope, address)
   const contract = account?.evm_contract

--- a/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/AccountDetailsPage/ContractCodeCard.tsx
@@ -4,7 +4,6 @@ import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { useAccount } from './hook'
-import { useOutletContext } from 'react-router-dom'
 import { CardEmptyState } from './CardEmptyState'
 import Typography from '@mui/material/Typography'
 import { ScrollableDataDisplay } from '../../components/ScrollableDataDisplay'
@@ -12,7 +11,7 @@ import Box from '@mui/material/Box'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { base64ToHex } from '../../utils/helpers'
-import { AccountDetailsContext } from './index'
+import { TokenDashboardContext } from '../TokenDashboardPage'
 
 export const contractCodeContainerId = 'code'
 
@@ -49,9 +48,8 @@ const CodeDisplay: FC<{ rawData: string | undefined; label: string; extraTopPadd
   )
 }
 
-export const ContractCodeCard: FC = () => {
+export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const { scope, address } = useOutletContext<AccountDetailsContext>()
 
   const { isFetched, account } = useAccount(scope, address)
   const contract = account?.evm_contract

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useHref, useLoaderData } from 'react-router-dom'
+import { useHref, useLoaderData, useOutletContext } from 'react-router-dom'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { Account } from '../../components/Account'
@@ -24,6 +24,8 @@ export type AccountDetailsContext = {
   scope: SearchScope
   address: string
 }
+
+export const useAccountDetailsProps = () => useOutletContext<AccountDetailsContext>()
 
 export const AccountDetailsPage: FC = () => {
   const { t } = useTranslation()

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -18,6 +18,12 @@ import { contractCodeContainerId } from './ContractCodeCard'
 import { useTokenInfo } from '../TokenDashboardPage/hook'
 import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
 import { getTokenTypePluralName } from '../../../types/tokens'
+import { SearchScope } from '../../../types/searchScope'
+
+export type AccountDetailsContext = {
+  scope: SearchScope
+  address: string
+}
 
 export const AccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -44,6 +50,8 @@ export const AccountDetailsPage: FC = () => {
 
   const showDetails = showTxs || showErc20
   const isLoading = isAccountLoading || isTokenLoading
+
+  const context: AccountDetailsContext = { scope, address }
 
   return (
     <PageLayout>
@@ -77,6 +85,7 @@ export const AccountDetailsPage: FC = () => {
             },
             { label: t('contract.code'), to: codeLink, visible: showCode },
           ]}
+          context={context}
         />
       )}
     </PageLayout>

--- a/src/app/pages/ParatimeDashboardPage/ActiveAccounts.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ActiveAccounts.tsx
@@ -18,7 +18,7 @@ import {
   filterHourlyActiveAccounts,
   sumBucketsByStartDuration,
 } from '../../utils/chart-utils'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { SearchScope } from '../../../types/searchScope'
 
 export const getActiveAccountsWindows = (duration: ChartDuration, windows: Windows[]) => {
   switch (duration) {
@@ -56,6 +56,7 @@ export const getChartLabelFormatParams = (duration: ChartDuration) => {
 }
 
 type ActiveAccountsProps = {
+  scope: SearchScope
   chartDuration: ChartDuration
 }
 
@@ -66,7 +67,7 @@ const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
   [ChartDuration.ALL_TIME]: t('chartDuration.lastMonth'),
 })
 
-export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
+export const ActiveAccounts: FC<ActiveAccountsProps> = ({ scope, chartDuration }) => {
   const { t } = useTranslation()
   const labels = getLabels(t)
   const { limit, bucket_size_seconds } = {
@@ -78,7 +79,6 @@ export const ActiveAccounts: FC<ActiveAccountsProps> = ({ chartDuration }) => {
         ? dailyLimitWithoutBuffer
         : durationToQueryParams[chartDuration].limit,
   }
-  const scope = useRequiredScopeParam()
   const activeAccountsQuery = useGetLayerStatsActiveAccounts(
     scope.network,
     scope.layer,

--- a/src/app/pages/ParatimeDashboardPage/LatestBlocks.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestBlocks.tsx
@@ -10,16 +10,15 @@ import { Blocks, BlocksTableType } from '../../components/Blocks'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../config'
 import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { SearchScope } from '../../../types/searchScope'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const LatestBlocks: FC = () => {
+export const LatestBlocks: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
   const { network, layer } = scope
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer

--- a/src/app/pages/ParatimeDashboardPage/LatestTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestTransactions.tsx
@@ -10,16 +10,15 @@ import { Transactions } from '../../components/Transactions'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../config'
 import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { SearchScope } from '../../../types/searchScope'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const LatestTransactions: FC = () => {
+export const LatestTransactions: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { isTablet } = useScreenSize()
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
   const { network, layer } = scope
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -13,10 +13,10 @@ import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 import { docs } from '../../utils/externalLinks'
 import { Layer } from '../../../oasis-nexus/api'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { getLayerLabels } from '../../utils/content'
 import { Network } from '../../../types/network'
 import { SpecifiedPerEnabledLayer } from '../../utils/route-utils'
+import { SearchScope } from '../../../types/searchScope'
 
 const StyledLink = styled(Link)(() => ({
   width: '44px',
@@ -130,9 +130,9 @@ const LearningSection: FC<LearningSectionProps> = ({ description, title, url, ..
   )
 }
 
-export const LearningMaterials = () => {
+export const LearningMaterials: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
-  const { layer, network } = useRequiredScopeParam()
+  const { layer, network } = scope
   const content = getContent(t)[network][layer]
 
   if (!content) {

--- a/src/app/pages/ParatimeDashboardPage/Nodes.tsx
+++ b/src/app/pages/ParatimeDashboardPage/Nodes.tsx
@@ -8,14 +8,13 @@ import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
 import { Layer, useGetRuntimeStatus } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
 import { paraTimesConfig } from '../../../config'
+import { SearchScope } from '../../../types/searchScope'
 
-export const Nodes: FC = () => {
+export const Nodes: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
   if (scope.layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
   }

--- a/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
@@ -14,20 +14,19 @@ import { ChartDuration } from '../../utils/chart-utils'
 import { useTranslation } from 'react-i18next'
 import { useConstant } from '../../hooks/useConstant'
 import { AppendMobileSearch } from '../../components/AppendMobileSearch'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { Network } from '../../../types/network'
 import { getLayerNames } from '../../../types/layers'
 import { TestnetFaucet } from './TestnetFaucet'
+import { SearchScope } from '../../../types/searchScope'
 
 const StyledGrid = styled(Grid)(() => ({
   display: 'flex',
 }))
 
-export const ParaTimeSnapshot: FC = () => {
+export const ParaTimeSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const defaultChartDurationValue = useConstant<ChartDuration>(() => ChartDuration.TODAY)
   const [chartDuration, setChartDuration] = useState<ChartDuration>(defaultChartDurationValue)
-  const scope = useRequiredScopeParam()
   const paratime = getLayerNames(t)[scope.layer]
   const theme = useTheme()
   const { isMobile } = useScreenSize()
@@ -62,13 +61,13 @@ export const ParaTimeSnapshot: FC = () => {
 
       <Grid container rowSpacing={1} columnSpacing={4} columns={22}>
         <StyledGrid item xs={22} md={6}>
-          <TransactionsChartCard chartDuration={chartDuration} />
+          <TransactionsChartCard scope={scope} chartDuration={chartDuration} />
         </StyledGrid>
         <StyledGrid item xs={22} md={5}>
-          <ActiveAccounts chartDuration={chartDuration} />
+          <ActiveAccounts scope={scope} chartDuration={chartDuration} />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
-          <Nodes />
+          <Nodes scope={scope} />
         </StyledGrid>
         <StyledGrid item xs={22} md={5}>
           {scope.network === Network.mainnet && <RosePriceCard />}

--- a/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
@@ -9,15 +9,14 @@ import { Layer, useGetRuntimeEvmTokens } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../config'
 import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { RouteUtils } from '../../utils/route-utils'
 import { TokenList } from '../../components/Tokens/TokenList'
+import { SearchScope } from '../../../types/searchScope'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const TopTokens: FC = () => {
+export const TopTokens: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
   const { network, layer } = scope
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer

--- a/src/app/pages/ParatimeDashboardPage/TotalTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TotalTransactions.tsx
@@ -8,10 +8,10 @@ import { chartUseQueryStaleTimeMs, durationToQueryParams } from '../../utils/cha
 import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration, cumulativeSum } from '../../utils/chart-utils'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TotalTransactions: FC = () => {
+export const TotalTransactions: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
@@ -20,7 +20,6 @@ export const TotalTransactions: FC = () => {
     // We want to start from the beginning of offset as cumulative sum generates a line chart that always goes up
     offset: 0,
   }
-  const scope = useRequiredScopeParam()
   const dailyVolumeQuery = useGetLayerStatsTxVolume(scope.network, scope.layer, statsParams, {
     query: {
       keepPreviousData: true,

--- a/src/app/pages/ParatimeDashboardPage/TransactionsChartCard.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TransactionsChartCard.tsx
@@ -14,7 +14,7 @@ import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { SnapshotCardDurationLabel } from '../../components/Snapshots/SnapshotCardDurationLabel'
 import { PercentageGain } from '../../components/PercentageGain'
 import startOfHour from 'date-fns/startOfHour'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { SearchScope } from '../../../types/searchScope'
 
 const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
   [ChartDuration.TODAY]: t('chartDuration.lastHour'),
@@ -24,15 +24,15 @@ const getLabels = (t: TFunction): Record<ChartDuration, string> => ({
 })
 
 interface TransactionsChartCardProps {
+  scope: SearchScope
   chartDuration: ChartDuration
 }
 
-const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ chartDuration }) => {
+const TransactionsChartCardCmp: FC<TransactionsChartCardProps> = ({ scope, chartDuration }) => {
   const { t } = useTranslation()
   const labels = getLabels(t)
   const { isMobile } = useScreenSize()
   const statsParams = durationToQueryParams[chartDuration]
-  const scope = useRequiredScopeParam()
   const { data, isFetched } = useGetLayerStatsTxVolume(scope.network, scope.layer, statsParams, {
     query: { staleTime: chartUseQueryStaleTimeMs },
   })

--- a/src/app/pages/ParatimeDashboardPage/TransactionsStats.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TransactionsStats.tsx
@@ -12,16 +12,14 @@ import {
 import { DurationPills } from './DurationPills'
 import { CardHeaderWithResponsiveActions } from './CardHeaderWithResponsiveActions'
 import { ChartDuration } from '../../utils/chart-utils'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TransactionsStats: FC = () => {
+export const TransactionsStats: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
-
-  const scope = useRequiredScopeParam()
 
   const dailyVolumeQuery = useGetLayerStatsTxVolume(scope.network, scope.layer, statsParams, {
     query: {

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -11,31 +11,33 @@ import { TotalTransactions } from './TotalTransactions'
 import { PageLayout } from '../../components/PageLayout'
 import { ParaTimeSnapshot } from './ParaTimeSnapshot'
 import { TopTokens } from './TopTokens'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 
 export const ParatimeDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
+  const scope = useRequiredScopeParam()
 
   return (
     <PageLayout>
-      <ParaTimeSnapshot />
+      <ParaTimeSnapshot scope={scope} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <LatestTransactions />
+      <LatestTransactions scope={scope} />
       <Grid container spacing={4}>
         <Grid item xs={12} md={6} sx={{ display: 'flex', order: isMobile ? 1 : 0 }}>
-          <LearningMaterials />
+          <LearningMaterials scope={scope} />
         </Grid>
         <Grid item xs={12} md={6}>
-          <LatestBlocks />
+          <LatestBlocks scope={scope} />
         </Grid>
         {isMobile && (
           <Grid item xs={12}>
-            <TopTokens />
+            <TopTokens scope={scope} />
           </Grid>
         )}
       </Grid>
-      {!isMobile && <TopTokens />}
-      <TransactionsStats />
-      <TotalTransactions />
+      {!isMobile && <TopTokens scope={scope} />}
+      <TransactionsStats scope={scope} />
+      <TotalTransactions scope={scope} />
       <Social />
     </PageLayout>
   )

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -1,7 +1,5 @@
 import { FC } from 'react'
 import Card from '@mui/material/Card'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
 import { useTokenInfo } from './hook'
 import { useAccount } from '../AccountDetailsPage/hook'
 import { TextSkeleton } from '../../components/Skeleton'
@@ -15,11 +13,10 @@ import { getNameForTicker, Ticker } from '../../../types/ticker'
 import { DelayedContractCreatorInfo } from '../../components/Account/ContractCreatorInfo'
 import CardContent from '@mui/material/CardContent'
 import { TokenTypeTag } from '../../components/Tokens/TokenList'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenDetailsCard: FC = () => {
+export const TokenDetailsCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
   const { isMobile } = useScreenSize()
 
   const { token, isLoading: tokenIsLoading } = useTokenInfo(scope, address)

--- a/src/app/pages/TokenDashboardPage/TokenGasUsedCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenGasUsedCard.tsx
@@ -4,15 +4,11 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
 import { useAccount } from '../AccountDetailsPage/hook'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenGasUsedCard: FC = () => {
+export const TokenGasUsedCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-
-  const address = useLoaderData() as string
 
   const { account, isFetched } = useAccount(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -6,18 +6,17 @@ import CardContent from '@mui/material/CardContent'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
 import { useTokenHolders, useTokenInfo } from './hook'
 import { TokenHolders } from '../../components/Tokens/TokenHolders'
+import { TokenDashboardContext } from './index'
 
 export const tokenHoldersContainerId = 'holders'
 
 export const TokenHoldersCard: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
+  const { scope, address } = useOutletContext<TokenDashboardContext>()
 
   const { isLoading: isTokenLoading, token } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCard.tsx
@@ -6,7 +6,6 @@ import CardContent from '@mui/material/CardContent'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
-import { useOutletContext } from 'react-router-dom'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
 import { useTokenHolders, useTokenInfo } from './hook'
 import { TokenHolders } from '../../components/Tokens/TokenHolders'
@@ -14,9 +13,8 @@ import { TokenDashboardContext } from './index'
 
 export const tokenHoldersContainerId = 'holders'
 
-export const TokenHoldersCard: FC = () => {
+export const TokenHoldersCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const { scope, address } = useOutletContext<TokenDashboardContext>()
 
   const { isLoading: isTokenLoading, token } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
@@ -4,16 +4,12 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useTokenInfo } from './hook'
-import { useLoaderData } from 'react-router-dom'
 import Skeleton from '@mui/material/Skeleton'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenHoldersCountCard: FC = () => {
+export const TokenHoldersCountCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-
-  const address = useLoaderData() as string
 
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
@@ -7,20 +7,19 @@ import { useTheme } from '@mui/material/styles'
 import { styled } from '@mui/material/styles'
 import { useTranslation } from 'react-i18next'
 import { AppendMobileSearch } from '../../components/AppendMobileSearch'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { TokenSupplyCard } from './TokenSupplyCard'
 import { TokenHoldersCountCard } from './TokenHoldersCountCard'
 import { TokenTypeCard } from './TokenTypeCard'
 import { TokenTotalTransactionsCard } from './TokenTotalTransactionsCard'
+import { SearchScope } from '../../../types/searchScope'
 
 const StyledGrid = styled(Grid)(() => ({
   display: 'flex',
 }))
 
-export const TokenSnapshot: FC = () => {
+export const TokenSnapshot: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
-  const scope = useRequiredScopeParam()
   const theme = useTheme()
   const { isMobile } = useScreenSize()
 
@@ -43,16 +42,16 @@ export const TokenSnapshot: FC = () => {
 
       <Grid container rowSpacing={1} columnSpacing={4} columns={22}>
         <StyledGrid item xs={22} md={5}>
-          <TokenTotalTransactionsCard />
+          <TokenTotalTransactionsCard scope={scope} address={address} />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
-          <TokenSupplyCard />
+          <TokenSupplyCard scope={scope} address={address} />
         </StyledGrid>
         <StyledGrid item xs={22} md={5}>
-          <TokenHoldersCountCard />
+          <TokenHoldersCountCard scope={scope} address={address} />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
-          <TokenTypeCard />
+          <TokenTypeCard scope={scope} address={address} />
           {/*<TokenGasUsedCard /> TODO: use this when gas used becomes available */}
         </StyledGrid>
       </Grid>

--- a/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
@@ -4,16 +4,12 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useTokenInfo } from './hook'
-import { useLoaderData } from 'react-router-dom'
 import Skeleton from '@mui/material/Skeleton'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenSupplyCard: FC = () => {
+export const TokenSupplyCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-
-  const address = useLoaderData() as string
 
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -1,6 +1,4 @@
 import { FC } from 'react'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
@@ -12,13 +10,12 @@ import { AccountLink } from '../../components/Account/AccountLink'
 import Box from '@mui/material/Box'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useTranslation } from 'react-i18next'
+import { SearchScope } from '../../../types/searchScope'
 
 const TitleSkeleton: FC = () => <Skeleton variant="text" sx={{ display: 'inline-block', width: '100%' }} />
 
-export const TokenTitleCard: FC = () => {
+export const TokenTitleCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
 
   const { isLoading, token } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenTotalTransactionsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTotalTransactionsCard.tsx
@@ -4,17 +4,16 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
 import { useAccount } from '../AccountDetailsPage/hook'
 import Skeleton from '@mui/material/Skeleton'
 import { useTokenInfo } from './hook'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenTotalTransactionsCard: FC = () => {
+export const TokenTotalTransactionsCard: FC<{ scope: SearchScope; address: string }> = ({
+  scope,
+  address,
+}) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-
-  const address = useLoaderData() as string
 
   const { isLoading: isAccountLoading, isFetched, account } = useAccount(scope, address)
   const { isLoading: isTokenLoading } = useTokenInfo(scope, address)

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -5,7 +5,6 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
-import { useOutletContext } from 'react-router-dom'
 import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
 import { useAccount } from '../AccountDetailsPage/hook'
@@ -14,9 +13,8 @@ import { TokenDashboardContext } from './index'
 
 export const tokenTransfersContainerId = 'transfers'
 
-export const TokenTransfersCard: FC = () => {
+export const TokenTransfersCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const { scope, address } = useOutletContext<TokenDashboardContext>()
 
   const {
     isLoading: areTransfersLoading,

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -5,19 +5,18 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useLoaderData } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
 import { useAccount } from '../AccountDetailsPage/hook'
 import { useTokenInfo, useTokenTransfers } from './hook'
+import { TokenDashboardContext } from './index'
 
 export const tokenTransfersContainerId = 'transfers'
 
 export const TokenTransfersCard: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  const address = useLoaderData() as string
+  const { scope, address } = useOutletContext<TokenDashboardContext>()
 
   const {
     isLoading: areTransfersLoading,

--- a/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
@@ -4,17 +4,13 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { useTokenInfo } from './hook'
-import { useLoaderData } from 'react-router-dom'
 import Skeleton from '@mui/material/Skeleton'
 import { getTokenTypeDescription, getTokenTypeStrictName } from '../../../types/tokens'
+import { SearchScope } from '../../../types/searchScope'
 
-export const TokenTypeCard: FC = () => {
+export const TokenTypeCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-
-  const address = useLoaderData() as string
 
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -6,7 +6,7 @@ import { TokenTitleCard } from './TokenTitleCard'
 import { TokenSnapshot } from './TokenSnapshot'
 import { TokenDetailsCard } from './TokenDetailsCard'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useHref, useLoaderData } from 'react-router-dom'
+import { useHref, useLoaderData, useOutletContext } from 'react-router-dom'
 import { useTokenInfo } from './hook'
 import { AppErrors } from '../../../types/errors'
 import { RouterTabs } from '../../components/RouterTabs'
@@ -19,6 +19,8 @@ export type TokenDashboardContext = {
   scope: SearchScope
   address: string
 }
+
+export const useTokenDashboardProps = () => useOutletContext<TokenDashboardContext>()
 
 export const TokenDashboardPage: FC = () => {
   const { t } = useTranslation()

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -13,6 +13,12 @@ import { RouterTabs } from '../../components/RouterTabs'
 import { useTranslation } from 'react-i18next'
 import { contractCodeContainerId } from '../AccountDetailsPage/ContractCodeCard'
 import { tokenHoldersContainerId } from './TokenHoldersCard'
+import { SearchScope } from '../../../types/searchScope'
+
+export type TokenDashboardContext = {
+  scope: SearchScope
+  address: string
+}
 
 export const TokenDashboardPage: FC = () => {
   const { t } = useTranslation()
@@ -30,18 +36,24 @@ export const TokenDashboardPage: FC = () => {
   const tokenHoldersLink = useHref(`holders#${tokenHoldersContainerId}`)
   const codeLink = useHref(`code#${contractCodeContainerId}`)
 
+  const context: TokenDashboardContext = {
+    scope,
+    address,
+  }
+
   return (
     <PageLayout>
-      <TokenTitleCard />
-      <TokenSnapshot />
+      <TokenTitleCard scope={scope} address={address} />
+      <TokenSnapshot scope={scope} address={address} />
       {!isMobile && <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />}
-      <TokenDetailsCard />
+      <TokenDetailsCard scope={scope} address={address} />
       <RouterTabs
         tabs={[
           { label: t('tokens.transfers'), to: tokenTransfersLink },
           { label: t('tokens.holders'), to: tokenHoldersLink },
           { label: t('contract.code'), to: codeLink },
         ]}
+        context={context}
       />
     </PageLayout>
   )

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -129,17 +129,14 @@ export const routes: RouteObject[] = [
               {
                 path: '',
                 element: <TokenTransfersCard />,
-                loader: addressParamLoader,
               },
               {
                 path: 'holders',
                 element: <TokenHoldersCard />,
-                loader: addressParamLoader,
               },
               {
                 path: 'code',
                 element: <ContractCodeCard />,
-                loader: addressParamLoader,
               },
             ],
           },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -84,27 +84,22 @@ export const routes: RouteObject[] = [
               {
                 path: '',
                 element: <AccountTransactionsCard />,
-                loader: addressParamLoader,
               },
               {
                 path: 'token-transfers',
                 element: <AccountTokenTransfersCard />,
-                loader: addressParamLoader,
               },
               {
                 path: 'tokens/erc-20',
                 element: <AccountTokensCard type="ERC20" />,
-                loader: addressParamLoader,
               },
               {
                 path: 'tokens/erc-721',
                 element: <AccountTokensCard type="ERC721" />,
-                loader: addressParamLoader,
               },
               {
                 path: 'code',
                 element: <ContractCodeCard />,
-                loader: addressParamLoader,
               },
             ],
           },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,7 +5,7 @@ import { TransactionsPage } from './app/pages/TransactionsPage'
 import { TransactionDetailPage } from './app/pages/TransactionDetailPage'
 import { ParatimeDashboardPage } from './app/pages/ParatimeDashboardPage'
 import { BlockDetailPage } from './app/pages/BlockDetailPage'
-import { AccountDetailsPage } from './app/pages/AccountDetailsPage'
+import { AccountDetailsPage, useAccountDetailsProps } from './app/pages/AccountDetailsPage'
 import { AccountTransactionsCard } from './app/pages/AccountDetailsPage/AccountTransactionsCard'
 import { AccountTokensCard } from './app/pages/AccountDetailsPage/AccountTokensCard'
 import { SearchResultsPage } from './app/pages/SearchResultsPage'
@@ -21,7 +21,7 @@ import { ThemeByNetwork, withDefaultTheme } from './app/components/ThemeByNetwor
 import { useRequiredScopeParam } from './app/hooks/useScopeParam'
 import { TokensPage } from './app/pages/TokensOverviewPage'
 import { ContractCodeCard } from './app/pages/AccountDetailsPage/ContractCodeCard'
-import { TokenDashboardPage } from './app/pages/TokenDashboardPage'
+import { TokenDashboardPage, useTokenDashboardProps } from './app/pages/TokenDashboardPage'
 import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
 import { TokenTransfersCard } from './app/pages/TokenDashboardPage/TokenTransfersCard'
 import { TokenHoldersCard } from './app/pages/TokenDashboardPage/TokenHoldersCard'
@@ -83,23 +83,23 @@ export const routes: RouteObject[] = [
             children: [
               {
                 path: '',
-                element: <AccountTransactionsCard />,
+                Component: () => <AccountTransactionsCard {...useAccountDetailsProps()} />,
               },
               {
                 path: 'token-transfers',
-                element: <AccountTokenTransfersCard />,
+                Component: () => <AccountTokenTransfersCard {...useAccountDetailsProps()} />,
               },
               {
                 path: 'tokens/erc-20',
-                element: <AccountTokensCard type="ERC20" />,
+                Component: () => <AccountTokensCard {...useAccountDetailsProps()} type="ERC20" />,
               },
               {
                 path: 'tokens/erc-721',
-                element: <AccountTokensCard type="ERC721" />,
+                Component: () => <AccountTokensCard {...useAccountDetailsProps()} type="ERC721" />,
               },
               {
                 path: 'code',
-                element: <ContractCodeCard />,
+                Component: () => <ContractCodeCard {...useAccountDetailsProps()} />,
               },
             ],
           },
@@ -123,15 +123,15 @@ export const routes: RouteObject[] = [
             children: [
               {
                 path: '',
-                element: <TokenTransfersCard />,
+                Component: () => <TokenTransfersCard {...useTokenDashboardProps()} />,
               },
               {
                 path: 'holders',
-                element: <TokenHoldersCard />,
+                Component: () => <TokenHoldersCard {...useTokenDashboardProps()} />,
               },
               {
                 path: 'code',
-                element: <ContractCodeCard />,
+                Component: () => <ContractCodeCard {...useTokenDashboardProps()} />,
               },
             ],
           },


### PR DESCRIPTION
We should only be accessing the URL (via the router) from page-level components, not individual components.
This improves the composability of the app.

Cleanup progress:

- [x] Paratime Dashboard
- [x] Token Dashboard
- [x] Account details
- [x] Other places