### PR TITLE
Fix issue with charts responsive container

### DIFF
--- a/.changelog/713.bugfix.md
+++ b/.changelog/713.bugfix.md
@@ -1,0 +1,1 @@
+Fix issue with charts responsive container

--- a/src/app/pages/SearchResultsPage/ResultListFrame.tsx
+++ b/src/app/pages/SearchResultsPage/ResultListFrame.tsx
@@ -27,6 +27,8 @@ export const ResultListFrame = styled(Box)(({ theme: wantedTheme }) => {
         background: COLORS.white,
         borderRadius: 12,
         boxShadow: '-20px 4px 40px rgba(34, 47, 63, 0.24)',
+        // Negative margins won't work with default Card overflow
+        [`&& .${cardClasses.root}`]: { overflow: 'initial' },
         [`&& .${cardClasses.root} > .${boxClasses.root}`]: {
           background: wantedTheme.palette.layout.networkBubbleBorder,
           marginLeft: -78,

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -366,7 +366,6 @@ export const defaultTheme = createTheme({
     MuiCard: {
       styleOverrides: {
         root: ({ theme }) => ({
-          overflow: 'initial',
           borderRadius: 12,
           boxShadow: 'none',
           [theme.breakpoints.down('sm')]: {


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/explorer/issues/702

Avoid recharts issues by moving Card css override directly to Search component. 