### PR TITLE
Handle transaction evm.Call method that is likely a transfer

### DIFF
--- a/.changelog/723.trivial.md
+++ b/.changelog/723.trivial.md
@@ -1,0 +1,1 @@
+Handle transaction evm.Call method that is likely a transfer

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -125,6 +125,11 @@ export const useGetConsensusTransactions: typeof generated.useGetConsensusTransa
   })
 }
 
+const adjustRuntimeTransactionMethod = (
+  method: string | undefined,
+  isLikelyNativeTokenTransfer: boolean | undefined,
+) => (isLikelyNativeTokenTransfer ? 'accounts.Transfer' : method)
+
 export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactions = (
   network,
   runtime,
@@ -151,6 +156,7 @@ export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactio
                 layer: runtime,
                 network,
                 ticker,
+                method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),
               }
             }),
           }
@@ -221,6 +227,7 @@ export const useGetRuntimeTransactionsTxHash: typeof generated.useGetRuntimeTran
                 layer: runtime,
                 network,
                 ticker,
+                method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),
               }
             }),
           }


### PR DESCRIPTION
BE is adding an optional boolean when runtime tx method is evm.Call. In this case we want to swap type so it looks like transfer in UI.