### PR TITLE
Disable automatically setting AddressSwitch based on URL

### DIFF
--- a/.changelog/727.feature.md
+++ b/.changelog/727.feature.md
@@ -1,0 +1,8 @@
+Disable automatically setting AddressSwitch based on URL
+
+Default to ETH instead. This shows more consistent information when seeing
+consensus withdrawals in transactions list (oasis tx hash, from eth, to
+oasis1) and then opening it:
+
+- before: oasis tx hash, from oasis1, to oasis1
+- after: oasis tx hash, from eth, to oasis1

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -32,7 +32,6 @@ import { CurrentFiatValue } from './CurrentFiatValue'
 import { AddressSwitch, AddressSwitchOption } from '../../components/AddressSwitch'
 import InfoIcon from '@mui/icons-material/Info'
 import Tooltip from '@mui/material/Tooltip'
-import { isValidTxOasisHash } from '../../utils/helpers'
 import { TransactionEncrypted } from '../../components/TransactionEncryptionStatus'
 import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
@@ -88,13 +87,7 @@ export const TransactionDetailPage: FC = () => {
 
   const [addressSwitchOption, setAddressSwitchOption] = useState<
     AddressSwitchOption.Oasis | AddressSwitchOption.ETH
-  >(() => {
-    if (isValidTxOasisHash(hash)) {
-      return AddressSwitchOption.Oasis
-    }
-
-    return AddressSwitchOption.ETH
-  })
+  >(AddressSwitchOption.ETH)
 
   const { isLoading, data } = useGetRuntimeTransactionsTxHash(
     scope.network,


### PR DESCRIPTION
Default to ETH instead. This shows more consistent information when seeing consensus withdrawals in transactions list (oasis tx hash, from eth, to oasis1) and then opening it:
- before: oasis tx hash, from oasis1, to oasis1
- after: oasis tx hash, from eth, to oasis1