### PR TITLE
Add missing 0x prefix to eth hashes in runtime events

### DIFF
--- a/.changelog/728.bugfix.md
+++ b/.changelog/728.bugfix.md
@@ -1,0 +1,1 @@
+Add missing 0x prefix to eth hashes in runtime events

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -532,6 +532,7 @@ export const useGetRuntimeEvents: typeof generated.useGetRuntimeEvents = (
           return {
             ...data,
             events: data.events.map(event => {
+              const adjustedHash = event.eth_tx_hash ? `0x${event.eth_tx_hash}` : undefined
               if (
                 event.type === 'accounts.transfer' ||
                 event.type === 'accounts.mint' ||
@@ -541,6 +542,7 @@ export const useGetRuntimeEvents: typeof generated.useGetRuntimeEvents = (
               ) {
                 return {
                   ...event,
+                  eth_tx_hash: adjustedHash,
                   body: {
                     ...event.body,
                     amount:
@@ -562,6 +564,7 @@ export const useGetRuntimeEvents: typeof generated.useGetRuntimeEvents = (
               }
               return {
                 ...event,
+                eth_tx_hash: adjustedHash,
                 layer: runtime,
                 network,
               }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|  ![image](https://github.com/oasisprotocol/explorer/assets/2093792/745c8719-bb8e-4e21-af29-d4644cf59bef)   |  ![image](https://github.com/oasisprotocol/explorer/assets/2093792/345a1b9c-ac94-4730-a6ea-063093307acd) |
