### PR TITLE
Format large numbers in token total supply

### DIFF
--- a/.changelog/732.bugfix.md
+++ b/.changelog/732.bugfix.md
@@ -1,0 +1,3 @@
+Compact large numbers in token total supply
+
+Enable formatting of large numbers in token snapshot card and token list

--- a/src/app/components/RoundedBalance/__tests__/index.test.tsx
+++ b/src/app/components/RoundedBalance/__tests__/index.test.tsx
@@ -69,4 +69,26 @@ describe('RoundedBalance', () => {
       ).toBeInTheDocument()
     })
   })
+
+  describe('should format large numbers with i18next when compactLargeNumbers prop is true', () => {
+    it('should format large number', () => {
+      render(<RoundedBalance compactLargeNumbers value="15000000" />)
+      expect(screen.getByText('15M')).toBeInTheDocument()
+    })
+
+    it('should format large number and include ticker', () => {
+      render(<RoundedBalance compactLargeNumbers value="15000000" ticker="ROSE" />)
+      expect(screen.getByText('15M ROSE')).toBeInTheDocument()
+    })
+
+    it('should format large number with decimals', () => {
+      render(<RoundedBalance compactLargeNumbers value="100000.00000000000002231" />)
+      expect(screen.getByText('100K')).toBeInTheDocument()
+    })
+
+    it('should not format if number is too small', () => {
+      render(<RoundedBalance compactLargeNumbers value="99999.00000000000002231" />)
+      expect(screen.getByText('99,999.00000…')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/app/components/RoundedBalance/index.tsx
+++ b/src/app/components/RoundedBalance/index.tsx
@@ -14,6 +14,7 @@ type RoundedBalanceProps = {
   scope?: SearchScope
   tokenAddress?: string
   tickerAsLink?: boolean | undefined
+  compactLargeNumbers?: boolean
 }
 
 const numberOfDecimals = 5
@@ -24,6 +25,7 @@ export const RoundedBalance: FC<RoundedBalanceProps> = ({
   scope,
   tokenAddress,
   tickerAsLink,
+  compactLargeNumbers,
 }) => {
   const { t } = useTranslation()
 
@@ -42,6 +44,31 @@ export const RoundedBalance: FC<RoundedBalanceProps> = ({
     ) : (
       <PlaceholderLabel label={tickerName} />
     )
+
+  if (number.isGreaterThan(100_000) && compactLargeNumbers) {
+    return (
+      <Tooltip
+        arrow
+        placement="top"
+        title={t('common.valueInToken', { value: number.toFormat(), ticker: tickerName })}
+        enterDelay={tooltipDelay}
+        enterNextDelay={tooltipDelay}
+      >
+        <span>
+          {t('common.valuePair', {
+            value: number.toFixed(),
+            formatParams: {
+              value: {
+                notation: 'compact',
+              } satisfies Intl.NumberFormatOptions,
+            },
+          })}
+          &nbsp;
+          {ticker}
+        </span>
+      </Tooltip>
+    )
+  }
 
   if (number.isEqualTo(truncatedNumber)) {
     return (

--- a/src/app/components/Tokens/TokenList.tsx
+++ b/src/app/components/Tokens/TokenList.tsx
@@ -130,7 +130,7 @@ export const TokenList = (props: TokensProps) => {
           align: TableCellAlign.Right,
         },
         {
-          content: <RoundedBalance value={token.total_supply} ticker={token.symbol} />,
+          content: <RoundedBalance compactLargeNumbers value={token.total_supply} ticker={token.symbol} />,
           key: 'supply',
           align: TableCellAlign.Right,
         },

--- a/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
@@ -7,6 +7,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import { useTokenInfo } from './hook'
 import Skeleton from '@mui/material/Skeleton'
 import { SearchScope } from '../../../types/searchScope'
+import { RoundedBalance } from '../../components/RoundedBalance'
 
 export const TokenSupplyCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
@@ -34,9 +35,11 @@ export const TokenSupplyCard: FC<{ scope: SearchScope; address: string }> = ({ s
                 width: '100%',
               }}
             >
-              {token.total_supply
-                ? t('tokens.totalSupplyValue', { value: token.total_supply })
-                : t('common.undefined')}
+              {token.total_supply ? (
+                <RoundedBalance value={token.total_supply} compactLargeNumbers />
+              ) : (
+                t('common.undefined')
+              )}
             </Typography>
           )
         )}


### PR DESCRIPTION
Based on https://github.com/oasisprotocol/explorer/pull/715#discussion_r1260005955 it's not clear how/where/what we want to round. I added optional `roundLargeNumbers` prop so for now only two places are affected. 