### PR TITLE
Improve token transfer listing for tokens

### DIFF
--- a/.changelog/738.bugfix.md
+++ b/.changelog/738.bugfix.md
@@ -1,0 +1,1 @@
+Implement client-side pagination for token transfers

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -4,3 +4,8 @@ export interface SimplePaginationEngine {
   selectedPage: number
   linkToPage: (pageNumber: number) => To
 }
+
+export interface ComprehensivePaginationEngine {
+  selectedPage: number
+  linkToPage: (pageNumber: number) => To
+}

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -1,0 +1,6 @@
+import { To } from 'react-router-dom'
+
+export interface SimplePaginationEngine {
+  selectedPage: number
+  linkToPage: (pageNumber: number) => To
+}

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -1,11 +1,20 @@
 import { To } from 'react-router-dom'
+import { TablePaginationProps } from './TablePagination'
+import { List } from '../../../oasis-nexus/api'
 
 export interface SimplePaginationEngine {
   selectedPage: number
   linkToPage: (pageNumber: number) => To
 }
 
-export interface ComprehensivePaginationEngine {
-  selectedPage: number
-  linkToPage: (pageNumber: number) => To
+export interface PaginatedResults<Item> {
+  tablePaginationProps: TablePaginationProps
+  data: Item[] | undefined
+}
+
+export interface ComprehensivePaginationEngine<Item, QueryResult extends List> {
+  offsetForQuery: number
+  limitForQuery: number
+  paramsForQuery: { offset: number; limit: number }
+  getResults: (queryResult: QueryResult | undefined, key?: keyof QueryResult) => PaginatedResults<Item>
 }

--- a/src/app/components/Table/useClientSidePagination.ts
+++ b/src/app/components/Table/useClientSidePagination.ts
@@ -83,7 +83,12 @@ export function useClientSizePagination<Item, QueryResult extends List>({
       const tableProps: TablePaginationProps = {
         selectedPage: selectedClientPage,
         linkToPage,
-        totalCount: filteredData?.length,
+        totalCount: filteredData
+          ? // This correction is here to simulate the bogus behavior of server-side pagination
+            // Remove this when server-side pagination is fixed,
+            // and so the work-around in the pagination widget is fixed.
+            filteredData.length - clientPageSize * (selectedClientPage - 1)
+          : undefined,
         isTotalCountClipped: queryResult?.is_total_count_clipped, // TODO
         rowsPerPage: clientPageSize,
       }

--- a/src/app/components/Table/useClientSidePagination.ts
+++ b/src/app/components/Table/useClientSidePagination.ts
@@ -1,0 +1,91 @@
+import { To, useSearchParams } from 'react-router-dom'
+import { AppErrors } from '../../../types/errors'
+import { ComprehensivePaginationEngine } from './PaginationEngine'
+import { List } from '../../../oasis-nexus/api'
+import { TablePaginationProps } from './TablePagination'
+
+type ClientSizePaginationParams<Item> = {
+  paramName: string
+  pageSize: number
+  /**
+   * @deprecated this will mess up page size.
+   *
+   * Consider using client-side pagination instead.
+   */
+  filter?: (item: Item) => boolean
+}
+
+const knownListKeys: string[] = ['total_count', 'is_total_count_clipped']
+
+function findListIn<T extends List, Item>(data: T): Item[] {
+  const candidates = Object.keys(data).filter(
+    key => !knownListKeys.includes(key) && Array.isArray(data[key as keyof T]),
+  ) as (keyof T)[]
+  switch (candidates.length) {
+    case 0:
+      throw new Error('Data not found!')
+    case 1:
+      return data[candidates[0]] as Item[]
+    default:
+      throw new Error('Data not found!')
+  }
+}
+
+export function useClientSizePagination<Item, QueryResult extends List>({
+  paramName,
+  pageSize,
+  filter,
+}: ClientSizePaginationParams<Item>): ComprehensivePaginationEngine<Item, QueryResult> {
+  const [searchParams] = useSearchParams()
+  const selectedPageString = searchParams.get(paramName)
+  const selectedPage = parseInt(selectedPageString ?? '1', 10)
+  if (isNaN(selectedPage) || (!!selectedPageString && selectedPage.toString() !== selectedPageString)) {
+    // This would be nicer, but this would also trigger react-error-overlay (besides our error boundary).
+    // We don't want that, so now, we are stuck with throwing a string, instead of a proper error.
+    // throw new AppError(AppErrors.InvalidPageNumber)
+    throw AppErrors.InvalidPageNumber
+  }
+
+  function linkToPage(page: number): To {
+    const newSearchParams = new URLSearchParams(searchParams)
+    if (page > 1) {
+      newSearchParams.set(paramName, page.toString())
+    } else {
+      newSearchParams.delete(paramName)
+    }
+    return { search: newSearchParams.toString() }
+  }
+
+  const limit = pageSize
+  const offset = (selectedPage - 1) * pageSize
+  const paramsForQuery = {
+    offset,
+    limit,
+  }
+
+  return {
+    offsetForQuery: offset,
+    limitForQuery: limit,
+    paramsForQuery,
+    getResults: (queryResult, key) => {
+      const data = queryResult
+        ? key
+          ? (queryResult[key] as Item[])
+          : findListIn<QueryResult, Item>(queryResult)
+        : undefined
+      const filteredData = !!data && !!filter ? data.filter(filter) : data
+      const tableProps: TablePaginationProps = {
+        selectedPage,
+        linkToPage,
+        totalCount: queryResult?.total_count,
+        isTotalCountClipped: queryResult?.is_total_count_clipped,
+        rowsPerPage: pageSize,
+      }
+      return {
+        tablePaginationProps: tableProps,
+        data: filteredData,
+      }
+    },
+    // tableProps,
+  }
+}

--- a/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
+++ b/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
@@ -1,0 +1,27 @@
+import { To, useSearchParams } from 'react-router-dom'
+import { AppErrors } from '../../../types/errors'
+import { ComprehensivePaginationEngine } from './PaginationEngine'
+
+export function useComprehensiveSearchParamsPagination(paramName: string): ComprehensivePaginationEngine {
+  const [searchParams] = useSearchParams()
+  const selectedPageString = searchParams.get(paramName)
+  const selectedPage = parseInt(selectedPageString ?? '1', 10)
+  if (isNaN(selectedPage) || (!!selectedPageString && selectedPage.toString() !== selectedPageString)) {
+    // This would be nicer, but this would also trigger react-error-overlay (besides our error boundary).
+    // We don't want that, so now, we are stuck with throwing a string, instead of a proper error.
+    // throw new AppError(AppErrors.InvalidPageNumber)
+    throw AppErrors.InvalidPageNumber
+  }
+
+  function linkToPage(page: number): To {
+    const newSearchParams = new URLSearchParams(searchParams)
+    if (page > 1) {
+      newSearchParams.set(paramName, page.toString())
+    } else {
+      newSearchParams.delete(paramName)
+    }
+    return { search: newSearchParams.toString() }
+  }
+
+  return { selectedPage, linkToPage }
+}

--- a/src/app/components/Table/useSearchParamsPagination.ts
+++ b/src/app/components/Table/useSearchParamsPagination.ts
@@ -1,7 +1,8 @@
 import { To, useSearchParams } from 'react-router-dom'
 import { AppErrors } from '../../../types/errors'
+import { SimplePaginationEngine } from './PaginationEngine'
 
-export function useSearchParamsPagination(paramName: string) {
+export function useSearchParamsPagination(paramName: string): SimplePaginationEngine {
   const [searchParams] = useSearchParams()
   const selectedPageString = searchParams.get(paramName)
   const selectedPage = parseInt(selectedPageString ?? '1', 10)

--- a/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -7,7 +7,8 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from './CardEmptyState'
-import { useAccount, useAccountTokenTransfers } from './hook'
+import { useAccount } from './hook'
+import { useTokenTransfers } from '../TokenDashboardPage/hook'
 import { TokenTransfers } from '../../components/Tokens/TokenTransfers'
 import { AccountDetailsContext } from './index'
 
@@ -16,7 +17,7 @@ export const accountTokenTransfersContainerId = 'transfers'
 export const AccountTokenTransfersCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
-  const { isLoading, isFetched, results } = useAccountTokenTransfers(scope, address)
+  const { isLoading, isFetched, results } = useTokenTransfers(scope, address)
 
   const { account } = useAccount(scope, address)
   const transfers = results.data

--- a/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -16,10 +16,10 @@ export const accountTokenTransfersContainerId = 'transfers'
 export const AccountTokenTransfersCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
-  const { isLoading, isFetched, transfers, pagination, totalCount, isTotalCountClipped } =
-    useAccountTokenTransfers(scope, address)
+  const { isLoading, isFetched, results } = useAccountTokenTransfers(scope, address)
 
   const { account } = useAccount(scope, address)
+  const transfers = results.data
 
   return (
     <Card>
@@ -34,13 +34,7 @@ export const AccountTokenTransfersCard: FC<AccountDetailsContext> = ({ scope, ad
             ownAddress={account?.address_eth}
             isLoading={isLoading}
             limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-            pagination={{
-              selectedPage: pagination.selectedPage,
-              linkToPage: pagination.linkToPage,
-              totalCount,
-              isTotalCountClipped,
-              rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-            }}
+            pagination={results.tablePaginationProps}
             differentTokens
           />
         </ErrorBoundary>

--- a/src/app/pages/AccountDetailsPage/hook.ts
+++ b/src/app/pages/AccountDetailsPage/hook.ts
@@ -1,15 +1,8 @@
-import {
-  Layer,
-  RuntimeEvent,
-  useGetRuntimeAccountsAddress,
-  useGetRuntimeEvents,
-  useGetRuntimeTransactions,
-} from '../../../oasis-nexus/api'
+import { Layer, useGetRuntimeAccountsAddress, useGetRuntimeTransactions } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { SearchScope } from '../../../types/searchScope'
-import { useClientSizePagination } from '../../components/Table/useClientSidePagination'
 
 export const useAccount = (scope: SearchScope, oasisAddress: string) => {
   const { network, layer } = scope
@@ -55,41 +48,5 @@ export const useAccountTransactions = (scope: SearchScope, address: string) => {
     pagination,
     totalCount,
     isTotalCountClipped,
-  }
-}
-
-export const WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS: string[] = ['Transfer']
-
-export const useAccountTokenTransfers = (scope: SearchScope, address: string) => {
-  const { network, layer } = scope
-  const pagination = useClientSizePagination({
-    paramName: 'page',
-    clientPageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-    serverPageSize: 1000,
-    filter: (event: RuntimeEvent) =>
-      !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
-  })
-
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Loading transactions on the consensus layer is not supported yet.
-    // We should use useGetConsensusTransactions()
-  }
-  const query = useGetRuntimeEvents(
-    network,
-    layer, // This is OK since consensus has been handled separately
-    {
-      ...pagination.paramsForQuery,
-      rel: address,
-      type: 'evm.log',
-    },
-  )
-
-  const { isFetched, isLoading, data } = query
-
-  return {
-    isLoading,
-    isFetched,
-    results: pagination.getResults(data?.data),
   }
 }

--- a/src/app/pages/AccountDetailsPage/hook.ts
+++ b/src/app/pages/AccountDetailsPage/hook.ts
@@ -1,5 +1,6 @@
 import {
   Layer,
+  RuntimeEvent,
   useGetRuntimeAccountsAddress,
   useGetRuntimeEvents,
   useGetRuntimeTransactions,
@@ -8,6 +9,7 @@ import { AppErrors } from '../../../types/errors'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { SearchScope } from '../../../types/searchScope'
+import { useClientSizePagination } from '../../components/Table/useClientSidePagination'
 
 export const useAccount = (scope: SearchScope, oasisAddress: string) => {
   const { network, layer } = scope
@@ -60,8 +62,14 @@ export const WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS: string[] = ['Transfer'
 
 export const useAccountTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
-  const pagination = useSearchParamsPagination('page')
-  const offset = (pagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+  const pagination = useClientSizePagination({
+    paramName: 'page',
+    clientPageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+    serverPageSize: 1000,
+    filter: (event: RuntimeEvent) =>
+      !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
+  })
+
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
     // Loading transactions on the consensus layer is not supported yet.
@@ -71,8 +79,7 @@ export const useAccountTokenTransfers = (scope: SearchScope, address: string) =>
     network,
     layer, // This is OK since consensus has been handled separately
     {
-      limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-      offset: offset,
+      ...pagination.paramsForQuery,
       rel: address,
       type: 'evm.log',
     },
@@ -80,21 +87,9 @@ export const useAccountTokenTransfers = (scope: SearchScope, address: string) =>
 
   const { isFetched, isLoading, data } = query
 
-  const transfers = data?.data.events.filter(
-    event => !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
-  )
-
-  // TODO: fix pagination messed up by client-side filtering
-
-  const totalCount = data?.data.total_count
-  const isTotalCountClipped = data?.data.is_total_count_clipped
-
   return {
     isLoading,
     isFetched,
-    transfers,
-    pagination,
-    totalCount,
-    isTotalCountClipped,
+    results: pagination.getResults(data?.data),
   }
 }

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -35,7 +35,8 @@ export const AccountDetailsPage: FC = () => {
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, isContract)
-  const { totalCount: numberOfTokenTransfers } = useAccountTokenTransfers(scope, address)
+  const { results: tokenResults } = useAccountTokenTransfers(scope, address)
+  const numberOfTokenTransfers = tokenResults.tablePaginationProps.totalCount
 
   const tokenPriceInfo = useTokenPrice(account?.ticker || Ticker.ROSE)
 

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -10,12 +10,12 @@ import { Ticker } from '../../../types/ticker'
 
 import { EvmToken, EvmTokenType, RuntimeAccount } from '../../../oasis-nexus/api'
 import { accountTokenContainerId } from './AccountTokensCard'
-import { useAccount, useAccountTokenTransfers } from './hook'
+import { useAccount } from './hook'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { showEmptyAccountDetails } from '../../../config'
 import { CardEmptyState } from './CardEmptyState'
 import { contractCodeContainerId } from './ContractCodeCard'
-import { useTokenInfo } from '../TokenDashboardPage/hook'
+import { useTokenInfo, useTokenTransfers } from '../TokenDashboardPage/hook'
 import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
 import { getTokenTypePluralName } from '../../../types/tokens'
 import { SearchScope } from '../../../types/searchScope'
@@ -35,7 +35,7 @@ export const AccountDetailsPage: FC = () => {
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, isContract)
-  const { results: tokenResults } = useAccountTokenTransfers(scope, address)
+  const { results: tokenResults } = useTokenTransfers(scope, address)
   const numberOfTokenTransfers = tokenResults.tablePaginationProps.totalCount
 
   const tokenPriceInfo = useTokenPrice(account?.ticker || Ticker.ROSE)

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -16,20 +16,14 @@ export const tokenTransfersContainerId = 'transfers'
 export const TokenTransfersCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
-  const {
-    isLoading: areTransfersLoading,
-    isFetched,
-    transfers,
-    pagination,
-    totalCount,
-    isTotalCountClipped,
-  } = useTokenTransfers(scope, address)
+  const { isLoading: areTransfersLoading, isFetched, results } = useTokenTransfers(scope, address)
 
   const { isLoading: isTokenLoading } = useTokenInfo(scope, address)
 
   const { isLoading: isAccountLoading, account } = useAccount(scope, address)
 
   const isLoading = isTokenLoading || isAccountLoading || areTransfersLoading
+  const transfers = results.data
 
   return (
     <Card>
@@ -42,13 +36,7 @@ export const TokenTransfersCard: FC<TokenDashboardContext> = ({ scope, address }
             ownAddress={account?.address_eth}
             isLoading={isLoading}
             limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-            pagination={{
-              selectedPage: pagination.selectedPage,
-              linkToPage: pagination.linkToPage,
-              totalCount,
-              isTotalCountClipped,
-              rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-            }}
+            pagination={results.tablePaginationProps}
           />
         </ErrorBoundary>
       </CardContent>

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -9,7 +9,6 @@ import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
-import { WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS } from '../AccountDetailsPage/hook'
 import { useClientSizePagination } from '../../components/Table/useClientSidePagination'
 
 export const useTokenInfo = (scope: SearchScope, address: string, enabled = true) => {
@@ -31,6 +30,8 @@ export const useTokenInfo = (scope: SearchScope, address: string, enabled = true
   }
 }
 
+export const WANTED_EVM_LOG_EVENTS_FOR_LISTING_TOKEN_TRANSFERS: string[] = ['Transfer']
+
 export const useTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
   const pagination = useClientSizePagination({
@@ -38,7 +39,7 @@ export const useTokenTransfers = (scope: SearchScope, address: string) => {
     clientPageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
     serverPageSize: 1000,
     filter: (event: RuntimeEvent) =>
-      !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
+      !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TOKEN_TRANSFERS.includes(event.evm_log_name),
   })
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -35,7 +35,8 @@ export const useTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
   const pagination = useClientSizePagination({
     paramName: 'page',
-    pageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+    clientPageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+    serverPageSize: 1000,
     filter: (event: RuntimeEvent) =>
       !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
   })

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -8,9 +8,9 @@ import {
 import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
-import { useComprehensiveSearchParamsPagination } from '../../components/Table/useComprehensiveSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS } from '../AccountDetailsPage/hook'
+import { useClientSizePagination } from '../../components/Table/useClientSidePagination'
 
 export const useTokenInfo = (scope: SearchScope, address: string, enabled = true) => {
   const { network, layer } = scope
@@ -33,7 +33,7 @@ export const useTokenInfo = (scope: SearchScope, address: string, enabled = true
 
 export const useTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
-  const pagination = useComprehensiveSearchParamsPagination({
+  const pagination = useClientSizePagination({
     paramName: 'page',
     pageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
     filter: (event: RuntimeEvent) =>

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -7,6 +7,7 @@ import {
 import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { useComprehensiveSearchParamsPagination } from '../../components/Table/useComprehensiveSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
 import { WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS } from '../AccountDetailsPage/hook'
 
@@ -31,7 +32,7 @@ export const useTokenInfo = (scope: SearchScope, address: string, enabled = true
 
 export const useTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
-  const pagination = useSearchParamsPagination('page')
+  const pagination = useComprehensiveSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   if (layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer


### PR DESCRIPTION
~**This depends on #743.**~

Improve pagination experience by proving rudimentary client-side pagination (limitation: looking only at the first 1000 records)

This impacts two pages:
- Tokens's token transfer listing (for example  `/mainnet/sapphire/token/0x998633BDF6eE32A9CcA6c9A247F428596e8e65d8` )
- Account's token transfer listing (for example `/mainnet/sapphire/address/0x998633BDF6eE32A9CcA6c9A247F428596e8e65d8/token-transfers#transfers`

~I think there is some problem with the pagination widget sometimes displaying the wrong number of total pages, but that is totally unrelated.~ **Update:** workaround added for anomalous behavior.

Technical note: great emphasis has been placed in developing this in separate commits so that it's easier to follow what is going on, so I suggest reviewing commit by commit.
