### PR TITLE
Fix "undefined" token supply card

### DIFF
--- a/.changelog/742.trivial.md
+++ b/.changelog/742.trivial.md
@@ -1,0 +1,1 @@
+Fix "undefined" token supply card

--- a/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
@@ -38,7 +38,7 @@ export const TokenSupplyCard: FC<{ scope: SearchScope; address: string }> = ({ s
               {token.total_supply ? (
                 <RoundedBalance value={token.total_supply} compactLargeNumbers />
               ) : (
-                t('common.undefined')
+                t('common.not_defined')
               )}
             </Typography>
           )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -66,6 +66,7 @@
     "name": "Name",
     "nft": "NFT",
     "nfts": "NFTs",
+    "not_defined": "Not defined",
     "oasis": "Oasis",
     "paratime": "Paratime",
     "parentheses":"({{subject}})",


### PR DESCRIPTION
Updated the wording on token supply card when token supply is not given.

See #739 for context.

Now it will look like this: 
![image](https://github.com/oasisprotocol/explorer/assets/2093792/a2f6f0a0-8e65-4759-bc62-1b3f2c1ac057)
