### PR TITLE
Filter token transfers consistently

### DIFF
--- a/.changelog/743.bugfix.md
+++ b/.changelog/743.bugfix.md
@@ -1,0 +1,1 @@
+Filter token transfers consistently

--- a/src/app/pages/AccountDetailsPage/hook.ts
+++ b/src/app/pages/AccountDetailsPage/hook.ts
@@ -56,7 +56,7 @@ export const useAccountTransactions = (scope: SearchScope, address: string) => {
   }
 }
 
-const WANTED_EVM_LOG_EVENTS: string[] = ['Transfer']
+export const WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS: string[] = ['Transfer']
 
 export const useAccountTokenTransfers = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
@@ -81,7 +81,7 @@ export const useAccountTokenTransfers = (scope: SearchScope, address: string) =>
   const { isFetched, isLoading, data } = query
 
   const transfers = data?.data.events.filter(
-    event => !!event.evm_log_name && WANTED_EVM_LOG_EVENTS.includes(event.evm_log_name),
+    event => !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
   )
 
   // TODO: fix pagination messed up by client-side filtering

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -8,6 +8,7 @@ import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS } from '../AccountDetailsPage/hook'
 
 export const useTokenInfo = (scope: SearchScope, address: string, enabled = true) => {
   const { network, layer } = scope
@@ -44,7 +45,7 @@ export const useTokenTransfers = (scope: SearchScope, address: string) => {
       limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       offset: offset,
       rel: address,
-      // type: 'evm.log',
+      type: 'evm.log',
       // TODO: maybe restrict this more later.
       // If the token is a payable account (usually they're not, AFAIK),
       // this will also return events where tokens were transferred to or from the token account itself.
@@ -55,7 +56,9 @@ export const useTokenTransfers = (scope: SearchScope, address: string) => {
 
   const { isFetched, isLoading, data } = query
 
-  const transfers = data?.data.events
+  const transfers = data?.data.events.filter(
+    event => !!event.evm_log_name && WANTED_EVM_LOG_EVENTS_FOR_LISTING_TRANSFERS.includes(event.evm_log_name),
+  )
 
   const totalCount = data?.data.total_count
   const isTotalCountClipped = data?.data.is_total_count_clipped


### PR DESCRIPTION
We want to do the same thing when looking at token transfers related to an account and token transfers related to a token.

(This has been separated from #738)