### PR TITLE
Re-rerun PR checks after appending Change Log fragment

### DIFF
--- a/.changelog/777.internal.md
+++ b/.changelog/777.internal.md
@@ -1,0 +1,1 @@
+Re-run PR checks after appending Change Log fragment

--- a/.github/workflows/ci-renovate.yml
+++ b/.github/workflows/ci-renovate.yml
@@ -27,21 +27,22 @@ jobs:
           fetch-depth: 0
           # Checkout pull request HEAD commit instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
+          # Needed to enable checks re-run.
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
       - name: Set workflow variables
         # Id is needed to access output in a next step.
         id: vars
         run: |
           echo "FILE_NAME=.changelog/${{ github.event.pull_request.number }}.internal.md" >> $GITHUB_OUTPUT
-      - name: Create Change Log file
+      - name: Create and commit Change Log fragment if it does not exist
         run: |
-          echo "${{ github.event.pull_request.title }}" > ${{ steps.vars.outputs.FILE_NAME }}
-      - name: Commit Change Log file
-        run: |
-          # Set git user email and name to match author of the last commit.
-          git config --local user.email "$(git log --pretty='%ae' -1)"
-          git config --local user.name "$(git log --pretty=format:'%an' -1)"
-          git add ${{ steps.vars.outputs.FILE_NAME }}
-          git commit --amend --no-edit
-      - name: Push changes back to branch
-        run: |
-          git push --force-with-lease origin HEAD:refs/heads/${{ github.head_ref }}
+          if [[ ! -f "${{ steps.vars.outputs.FILE_NAME }}" ]]; then
+            echo "${{ github.event.pull_request.title }}" > ${{ steps.vars.outputs.FILE_NAME }}
+            # Set git user email and name to match author of the last commit.
+            git config --local user.email "$(git log --pretty='%ae' -1)"
+            git config --local user.name "$(git log --pretty=format:'%an' -1)"
+            git add ${{ steps.vars.outputs.FILE_NAME }}
+            git commit --amend --no-edit
+            git push --force-with-lease origin HEAD:refs/heads/${{ github.head_ref }}
+            echo "FILE_EXISTS=false" >> $GITHUB_OUTPUT
+          fi


### PR DESCRIPTION
Checks should re-run when push is made by not a temp/default Github token. Works when testing fork https://github.com/buberdds/explorer/pull/132, but I have no idea how PAT is configured in this repo.