### PR TITLE
Show number of token transfers in Token page details

### DIFF
--- a/.changelog/822.trivial.md
+++ b/.changelog/822.trivial.md
@@ -1,0 +1,1 @@
+Show number of token transfers in Token page details

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
 import Card from '@mui/material/Card'
+import Link from '@mui/material/Link'
 import { useTokenInfo } from './hook'
 import { useAccount } from '../AccountDetailsPage/hook'
 import { TextSkeleton } from '../../components/Skeleton'
@@ -15,6 +17,8 @@ import CardContent from '@mui/material/CardContent'
 import { TokenTypeTag } from '../../components/Tokens/TokenList'
 import { SearchScope } from '../../../types/searchScope'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
+import { RouteUtils } from '../../utils/route-utils'
+import { tokenTransfersContainerId } from '../../pages/TokenDashboardPage/TokenTransfersCard'
 
 export const TokenDetailsCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
@@ -70,6 +74,23 @@ export const TokenDetailsCard: FC<{ scope: SearchScope; address: string }> = ({ 
                 ? t('common.missing')
                 : t('common.valueInToken', { ...getPreciseNumberFormat(balance), ticker: tickerName })}
             </dd>
+
+            {token.num_transfers && (
+              <>
+                <dt>{t('tokens.transfers')}</dt>
+                <dd>
+                  <Link
+                    component={RouterLink}
+                    to={`${RouteUtils.getTokenRoute(
+                      scope,
+                      token.eth_contract_addr,
+                    )}#${tokenTransfersContainerId}`}
+                  >
+                    {token.num_transfers.toLocaleString()}
+                  </Link>
+                </dd>
+              </>
+            )}
           </StyledDescriptionList>
         )}
       </CardContent>

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -10,13 +10,18 @@ import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
 import { useAccount } from '../AccountDetailsPage/hook'
 import { useTokenInfo, useTokenTransfers } from './hook'
 import { TokenDashboardContext } from './index'
+import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
+
+export const tokenTransfersContainerId = 'tokenTransfers'
 
 export const TokenTransfersCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   return (
     <Card>
-      <CardHeader disableTypography component="h3" title={t('tokens.transfers')} />
+      <LinkableDiv id={tokenTransfersContainerId}>
+        <CardHeader disableTypography component="h3" title={t('tokens.transfers')} />
+      </LinkableDiv>
       <CardContent>
         <ErrorBoundary light={true}>
           <TokenTransfersView scope={scope} address={address} />

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -622,6 +622,9 @@ detected or is not supported, this field will be null/absent.
   type: EvmTokenType;
   /** The total number of base units available. */
   total_supply?: string;
+  /** The total number of transfers of this token.
+ */
+  num_transfers?: number;
   /** The number of addresses that have a nonzero balance of this token.
  */
   num_holders: number;


### PR DESCRIPTION
I am not entirely sure, but during one of a meeting we wanted to show total number of token transfers in tokens details page. It looks like a prop was added lately (not deployed yet).