### PR TITLE
Handle new event types (placeholders)

### DIFF
--- a/.changelog/893.internal.md
+++ b/.changelog/893.internal.md
@@ -1,0 +1,1 @@
+Add basic handling of new event types

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -25,6 +25,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import StreamIcon from '@mui/icons-material/Stream'
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
+import { UnknownIcon } from '../CustomIcons/Unknown'
 
 export const EventTypeIcon: FC<{
   eventType: RuntimeEventType
@@ -36,6 +37,9 @@ export const EventTypeIcon: FC<{
     [RuntimeEventType.coregas_used]: <></>,
     [RuntimeEventType.consensus_accountswithdraw]: <WithdrawIcon fontSize="inherit" />,
     [RuntimeEventType.consensus_accountsdeposit]: <DepositIcon fontSize="inherit" />,
+    [RuntimeEventType.consensus_accountsdelegate]: <UnknownIcon fontSize="inherit" />, // TODO: use correct icon
+    [RuntimeEventType.consensus_accountsundelegate_start]: <UnknownIcon fontSize="inherit" />, // TODO: use correct icon
+    [RuntimeEventType.consensus_accountsundelegate_done]: <UnknownIcon fontSize="inherit" />, // TODO: use correct icon
     [RuntimeEventType.accountsmint]: <StreamIcon fontSize="inherit" htmlColor={COLORS.eucalyptus} />,
     [RuntimeEventType.accountsburn]: (
       <LocalFireDepartmentIcon fontSize="inherit" htmlColor={COLORS.eucalyptus} />
@@ -137,6 +141,9 @@ export const RuntimeEventDetails: FC<{
     [RuntimeEventType.coregas_used]: t('runtimeEvent.gasUsed'),
     [RuntimeEventType.consensus_accountswithdraw]: t('runtimeEvent.consensusWithdrawal'),
     [RuntimeEventType.consensus_accountsdeposit]: t('runtimeEvent.consensusDeposit'),
+    [RuntimeEventType.consensus_accountsdelegate]: t('runtimeEvent.consensusDelegate'),
+    [RuntimeEventType.consensus_accountsundelegate_start]: t('runtimeEvent.consensusUndelegateStart'),
+    [RuntimeEventType.consensus_accountsundelegate_done]: t('runtimeEvent.consensusUndelegateDone'),
     [RuntimeEventType.accountsmint]: t('runtimeEvent.accountsmint'),
     [RuntimeEventType.accountsburn]: t('runtimeEvent.accountsburn'),
   }
@@ -230,6 +237,9 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.accountstransfer:
     case RuntimeEventType.consensus_accountsdeposit:
     case RuntimeEventType.consensus_accountswithdraw:
+    case RuntimeEventType.consensus_accountsdelegate: // TODO show this properly
+    case RuntimeEventType.consensus_accountsundelegate_start: // TODO show this properly
+    case RuntimeEventType.consensus_accountsundelegate_done: // TODO show this properly
       return (
         <div>
           <EventTypeIcon eventType={event.type} eventName={eventName} />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -293,6 +293,9 @@
     "accountstransfer": "Transfer",
     "consensusDeposit": "Deposit from consensus",
     "consensusWithdrawal": "Withdrawal to consensus",
+    "consensusDelegate": "Delegate to consensus",
+    "consensusUndelegateStart": "Start to undelegate from consensus",
+    "consensusUndelegateDone": "Undelegate from consensus finished",
     "evmLog": "EVM log message",
     "filter": {
       "all": "All events",

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -979,6 +979,9 @@ export const RuntimeEventType = {
   accountsmint: 'accounts.mint',
   consensus_accountsdeposit: 'consensus_accounts.deposit',
   consensus_accountswithdraw: 'consensus_accounts.withdraw',
+  consensus_accountsdelegate: 'consensus_accounts.delegate',
+  consensus_accountsundelegate_start: 'consensus_accounts.undelegate_start',
+  consensus_accountsundelegate_done: 'consensus_accounts.undelegate_done',
   coregas_used: 'core.gas_used',
   evmlog: 'evm.log',
 } as const;


### PR DESCRIPTION
The goal of this PR is to remove syntax errors introduced by the latest auto-generated API wrapper code in #888.

So this incorporated the new API code from that PR, and also the required fixes in other related code.

Please note that [Handle new event types “consensus.Delegate”,  “consensus.Undelegate”](https://app.clickup.com/t/8692qqm49) is still required; this code only adds placeholders, marked with TODO comments, where the actual new stuff will have to go. (Icons, data fields, etc.)