### PR TITLE
Show raw data for unencrypted transactions

### DIFF
--- a/.changelog/896.feature.md
+++ b/.changelog/896.feature.md
@@ -1,0 +1,1 @@
+Show raw data for unencrypted transactions

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -36,6 +36,7 @@ import { TransactionEncrypted } from '../../components/TransactionEncryptionStat
 import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
+import { base64ToHex } from '../../utils/helpers'
 
 type TransactionSelectionResult = {
   wantedTransaction?: RuntimeTransaction
@@ -334,6 +335,15 @@ export const TransactionDetailView: FC<{
 
           <dt>{t('common.gasLimit')}</dt>
           <dd>{transaction.gas_limit.toLocaleString()}</dd>
+
+          {transaction.body?.data !== undefined && !transaction.encryption_envelope && (
+            <>
+              <dt>{t('transaction.rawData')}</dt>
+              <dd>
+                <LongDataDisplay data={base64ToHex(transaction.body.data)} threshold={300} />
+              </dd>
+            </>
+          )}
 
           {transaction.encryption_envelope && (
             <>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -267,6 +267,7 @@
   "transaction": {
     "header": "Transaction",
     "warningMultipleTransactionsSameHash": "Please make sure you're looking at the right transaction. There is more than one transaction with this hash, which is extremely rare. We are showing the most recent successful one.",
+    "rawData": "Raw Data",
     "tooltips": {
       "txTooltipEth": "Ethereum hash for the transaction",
       "senderTooltipEth": "Ethereum address for the sender",


### PR DESCRIPTION
From slack:

> We currently parse the encrypted result data/nonce from encrypted evm.Call txs([example](https://explorer.dev.oasis.io/mainnet/sapphire/tx/0x641fd5ee9894496eac6dd11571e274124eb573ccff366e81f6190c9bdbc19e95)). 
> Do we want to do the same for unencrypted results ([example](https://explorer.dev.oasis.io/mainnet/sapphire/tx/0x290aa4660ebbf4560823c67569451100d936fce4674da1afd03ca373ae083e58))? 
> The result data/nonce don’t seem that useful for most users, but perhaps we should do it just to be consistent for all encrypted evm.Call txs

Also:

> could we add data field to the non-encrypted transaction page as well. [example](https://explorer.dev.oasis.io/testnet/sapphire/tx/0x86eb240b32bbd01698207a4c3ea705f272d84ad787d38124bd24b6dd15150ab2) ? I want to show how devs can check whether a transaction is encrypted or not and what's its content

Also:

> perhaps we should toggle between Hex and Base64 data (both for encrypted or plain eth transaction) with the Oasis<->ETH switch in the top-right corner? 

  * * *
  
As a first step, we are now showing:
 - The raw (hex-coded) data for unencrypted transactions

It turns out that the result data/nonce currently isn’t parsed for unencrypted results, which is tracked [here](https://app.clickup.com/t/8692tq704)

