### PR TITLE
TX details: don't show raw data when it's empty

### DIFF
--- a/.changelog/903.trivial.md
+++ b/.changelog/903.trivial.md
@@ -1,0 +1,1 @@
+TX details: don't show raw data when it's empty

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -336,7 +336,7 @@ export const TransactionDetailView: FC<{
           <dt>{t('common.gasLimit')}</dt>
           <dd>{transaction.gas_limit.toLocaleString()}</dd>
 
-          {transaction.body?.data !== undefined && !transaction.encryption_envelope && (
+          {!!transaction.body?.data && !transaction.encryption_envelope && (
             <>
               <dt>{t('transaction.rawData')}</dt>
               <dd>


### PR DESCRIPTION
Follow up to #896 

In the original implementation, we have only hidden this field when it was undefined, but later I found out that sometimes it's an empty string, which should also be hidden.