### PR TITLE
TX details: always show raw data

### DIFF
--- a/.changelog/905.trivial.md
+++ b/.changelog/905.trivial.md
@@ -1,0 +1,1 @@
+TX details: always show raw data (Even for encrypted transactions)

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -336,7 +336,7 @@ export const TransactionDetailView: FC<{
           <dt>{t('common.gasLimit')}</dt>
           <dd>{transaction.gas_limit.toLocaleString()}</dd>
 
-          {!!transaction.body?.data && !transaction.encryption_envelope && (
+          {!!transaction.body?.data && (
             <>
               <dt>{t('transaction.rawData')}</dt>
               <dd>


### PR DESCRIPTION
Even for encrypted transactions, now we can show the raw data, like this:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/36f6a82b-f20f-44e5-b793-995002886cb7)

