### PR TITLE
Add NFT instance details page

### DIFF
--- a/.changelog/909.feature.md
+++ b/.changelog/909.feature.md
@@ -1,0 +1,1 @@
+Add NFT feature

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -1,0 +1,95 @@
+import { FC } from 'react'
+import Card from '@mui/material/Card'
+import { useAccount } from '../AccountDetailsPage/hook'
+import { TextSkeleton } from '../../components/Skeleton'
+import { StyledDescriptionList } from '../../components/StyledDescriptionList'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { useTranslation } from 'react-i18next'
+import { AccountLink } from '../../components/Account/AccountLink'
+import { CopyToClipboard } from '../../components/CopyToClipboard'
+import { VerificationIcon } from '../../components/ContractVerificationIcon'
+import CardContent from '@mui/material/CardContent'
+import { TokenTypeTag } from '../../components/Tokens/TokenList'
+import { SearchScope } from '../../../types/searchScope'
+import { TokenLink } from '../../components/Tokens/TokenLink'
+import { EvmNft } from 'oasis-nexus/api'
+
+type InstanceDetailsCardProps = {
+  nft: EvmNft | undefined
+  isFetched: boolean
+  isLoading: boolean
+  scope: SearchScope
+  contractAddress: string
+}
+
+export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
+  contractAddress,
+  isFetched: isNftFetched,
+  isLoading: isNftLoading,
+  nft,
+  scope,
+}) => {
+  const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+  const {
+    account,
+    isFetched: isAccountFetched,
+    isLoading: accountIsLoading,
+  } = useAccount(scope, contractAddress)
+  const token = nft?.token
+  const isLoading = isNftLoading || accountIsLoading
+  const isFetched = isNftFetched || isAccountFetched
+  const owner = nft?.owner_eth ?? nft?.owner
+
+  return (
+    <Card>
+      <CardContent>
+        {isLoading && <TextSkeleton numberOfRows={7} />}
+        {isFetched && account && nft && (
+          <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
+            {nft.name && (
+              <>
+                <dt>{t('common.name')}</dt>
+                <dd>{nft.name}</dd>
+              </>
+            )}
+            <dt>{t('nft.instanceTokenId')}</dt>
+            <dd>{nft.id}</dd>
+            <dt>{t('nft.collection')} </dt>
+            <dd>
+              <TokenLink scope={scope} address={contractAddress} name={token?.name} />
+            </dd>
+            <dt>{t('common.type')} </dt>
+            <dd>
+              <TokenTypeTag tokenType={token?.type} />
+            </dd>
+            {owner && (
+              <>
+                <dt>{t('nft.owner')}</dt>
+                <dd>
+                  <AccountLink scope={scope} address={owner} />
+                  <CopyToClipboard value={owner} />
+                </dd>
+              </>
+            )}
+            {nft?.token?.num_transfers && (
+              <>
+                <dt>{t('nft.transfers')}</dt>
+                <dd>{nft.token.num_transfers!.toLocaleString()}</dd>
+              </>
+            )}
+            <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
+            <dd>
+              <AccountLink scope={account} address={account.address_eth || account.address} />
+              <CopyToClipboard value={account.address_eth || account.address} />
+            </dd>
+            <dt>{t('contract.verification.title')}</dt>
+            <dd>
+              <VerificationIcon address_eth={token?.eth_contract_addr!} verified={!!token?.is_verified} />
+            </dd>
+          </StyledDescriptionList>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
@@ -1,0 +1,145 @@
+import { FC, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import { Button } from '@mui/base/Button'
+import CardContent from '@mui/material/CardContent'
+import Card from '@mui/material/Card'
+import ContrastIcon from '@mui/icons-material/Contrast'
+import Link from '@mui/material/Link'
+import Skeleton from '@mui/material/Skeleton'
+import Tooltip from '@mui/material/Tooltip'
+import OpenInFullIcon from '@mui/icons-material/OpenInFull'
+import NotInterestedIcon from '@mui/icons-material/NotInterested'
+import { styled } from '@mui/material/styles'
+import { EvmNft } from 'oasis-nexus/api'
+import { isNftImageUrlValid, processNftImageUrl } from '../../utils/nft-images'
+import { COLORS } from '../../../styles/theme/colors'
+
+const maxImageSize = '350px'
+
+export const StyledImage = styled('img')({
+  maxWidth: maxImageSize,
+  maxHeight: maxImageSize,
+})
+
+const StyledButton = styled(Button, {
+  shouldForwardProp: prop => prop !== 'darkMode',
+})<{ darkMode: boolean }>(({ darkMode }) => ({
+  cursor: 'pointer',
+  border: 'none',
+  width: 36,
+  height: 36,
+  borderRadius: 18,
+  background: darkMode ? COLORS.white : COLORS.grayMedium,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  color: darkMode ? COLORS.grayMedium : COLORS.white,
+}))
+
+const DarkModeSwitch: FC<{ darkMode: boolean; onSetDarkMode: (darkMode: boolean) => void }> = ({
+  darkMode,
+  onSetDarkMode,
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Tooltip title={t('nft.switchBackgroundColor')}>
+      <StyledButton
+        darkMode={darkMode}
+        onClick={() => onSetDarkMode(!darkMode)}
+        aria-label={t('nft.switchBackgroundColor')}
+      >
+        <ContrastIcon />
+      </StyledButton>
+    </Tooltip>
+  )
+}
+
+// Temporary solution until we have a proper image modal viewer
+const FullScreenButton: FC<{ darkMode: boolean; imageUrl: string }> = ({ darkMode, imageUrl }) => {
+  const { t } = useTranslation()
+  return (
+    <Tooltip title={t('nft.openInFullscreen')}>
+      <StyledButton
+        darkMode={darkMode}
+        component={Link}
+        href={imageUrl}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <OpenInFullIcon />
+      </StyledButton>
+    </Tooltip>
+  )
+}
+
+type InstanceImageCardProps = {
+  nft: EvmNft | undefined
+  isFetched: boolean
+  isLoading: boolean
+}
+
+export const InstanceImageCard: FC<InstanceImageCardProps> = ({ isFetched, isLoading, nft }) => {
+  const { t } = useTranslation()
+  const [darkMode, setDarkMode] = useState(false)
+
+  return (
+    <Card
+      sx={{
+        background: darkMode ? COLORS.grayExtraDark : COLORS.white,
+      }}
+    >
+      <CardContent>
+        <Box
+          sx={{
+            background: darkMode ? COLORS.grayExtraDark : COLORS.white,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          {isLoading && <Skeleton variant="rectangular" width={maxImageSize} height={maxImageSize} />}
+          {isFetched && nft && !isNftImageUrlValid(nft.image) && (
+            <Box
+              paddingY={6}
+              gap={4}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                color: COLORS.grayMedium2,
+              }}
+            >
+              <NotInterestedIcon sx={{ fontSize: '72px' }} />
+              {t('nft.noPreview')}
+            </Box>
+          )}
+          {isFetched && nft && isNftImageUrlValid(nft.image) && (
+            <>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}
+              >
+                <StyledImage src={processNftImageUrl(nft.image)} alt={nft.name} />
+              </Box>
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'right',
+                  gap: 3,
+                }}
+              >
+                <FullScreenButton darkMode={darkMode} imageUrl={processNftImageUrl(nft.image)} />
+                <DarkModeSwitch darkMode={darkMode} onSetDarkMode={setDarkMode} />
+              </Box>
+            </>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceTitleCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceTitleCard.tsx
@@ -1,0 +1,77 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Skeleton from '@mui/material/Skeleton'
+import Typography from '@mui/material/Typography'
+import { EvmNft } from 'oasis-nexus/api'
+import { COLORS } from '../../../styles/theme/colors'
+import { VerificationIcon } from '../../components/ContractVerificationIcon'
+import { AccountLink } from '../../components/Account/AccountLink'
+import { CopyToClipboard } from '../../components/CopyToClipboard'
+import { SearchScope } from '../../../types/searchScope'
+import { getNftInstanceLabel } from '../../utils/nft'
+
+type InstanceTitleCardProps = {
+  isFetched: boolean
+  isLoading: boolean
+  nft: EvmNft | undefined
+  scope: SearchScope
+}
+
+export const InstanceTitleCard: FC<InstanceTitleCardProps> = ({ isFetched, isLoading, nft, scope }) => {
+  const { t } = useTranslation()
+  const token = nft?.token
+  const displayAddress = token ? token.eth_contract_addr || token.contract_addr : undefined
+
+  return (
+    <Card>
+      <CardContent>
+        {isLoading && <Skeleton variant="text" />}
+        {isFetched && token && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'space-between',
+              alignItems: 'bottom',
+            }}
+          >
+            <Typography
+              variant="h2"
+              sx={{
+                fontWeight: 600,
+                paddingBottom: 3,
+              }}
+            >
+              {getNftInstanceLabel(nft)}
+              &nbsp;
+              <Typography
+                component="span"
+                noWrap
+                sx={{
+                  color: COLORS.grayMedium,
+                  fontWeight: 400,
+                }}
+              >
+                {t('nft.instanceTitleSuffix')}
+              </Typography>
+            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <VerificationIcon address_eth={token.eth_contract_addr} verified={token.is_verified} noLink />
+              <AccountLink scope={scope} address={displayAddress!} />
+              <CopyToClipboard value={displayAddress!} />
+            </Box>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/NFTInstanceDashboardPage/index.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/index.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+import { useParams } from 'react-router-dom'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { PageLayout } from '../../components/PageLayout'
+import { Layer } from '../../../oasis-nexus/api'
+import { AppErrors } from '../../../types/errors'
+
+export const NFTInstanceDashboardPage: FC = () => {
+  const scope = useRequiredScopeParam()
+  const { address, instanceId } = useParams()
+  if (scope.layer === Layer.consensus) {
+    // There can be no ERC-20 or ERC-721 tokens on consensus
+    throw AppErrors.UnsupportedLayer
+  }
+
+  if (!address || !instanceId) {
+    throw AppErrors.InvalidUrl
+  }
+
+  return <PageLayout />
+}

--- a/src/app/pages/NFTInstanceDashboardPage/index.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/index.tsx
@@ -2,7 +2,10 @@ import { FC } from 'react'
 import { useParams } from 'react-router-dom'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { PageLayout } from '../../components/PageLayout'
-import { Layer } from '../../../oasis-nexus/api'
+import { InstanceTitleCard } from './InstanceTitleCard'
+import { InstanceDetailsCard } from './InstanceDetailsCard'
+import { InstanceImageCard } from './InstanceImageCard'
+import { Layer, Runtime, useGetRuntimeEvmTokensAddressNftsId } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 
 export const NFTInstanceDashboardPage: FC = () => {
@@ -17,5 +20,25 @@ export const NFTInstanceDashboardPage: FC = () => {
     throw AppErrors.InvalidUrl
   }
 
-  return <PageLayout />
+  const { data, isFetched, isLoading } = useGetRuntimeEvmTokensAddressNftsId(
+    scope.network,
+    scope.layer as Runtime,
+    address,
+    instanceId,
+  )
+  const nft = data?.data
+
+  return (
+    <PageLayout>
+      <InstanceTitleCard isFetched={isFetched} isLoading={isLoading} nft={nft} scope={scope} />
+      <InstanceImageCard isFetched={isFetched} isLoading={isLoading} nft={nft} />
+      <InstanceDetailsCard
+        isFetched={isFetched}
+        isLoading={isLoading}
+        nft={nft}
+        scope={scope}
+        contractAddress={address!}
+      />
+    </PageLayout>
+  )
 }

--- a/src/app/utils/__tests__/externalLinks.test.ts
+++ b/src/app/utils/__tests__/externalLinks.test.ts
@@ -31,6 +31,7 @@ onlyRunOnCI('externalLinks', () => {
         if (url.startsWith(externalLinksModule.referrals.coinGecko)) continue // CoinGecko has CloudFlare DDOS protection
         if (url.startsWith(externalLinksModule.github.commit)) continue // We store only partial url in constants
         if (url.startsWith(externalLinksModule.github.releaseTag)) continue // We store only partial url in constants
+        if (url.startsWith(externalLinksModule.ipfs.proxyPrefix)) continue // We store only partial url in constants
 
         it.concurrent(`${linksGroupName} ${linkName} ${url}`, async () => {
           const response = await nodeFetch(url, { method: 'GET' })

--- a/src/app/utils/__tests__/ipfs.test.ts
+++ b/src/app/utils/__tests__/ipfs.test.ts
@@ -1,0 +1,9 @@
+import { accessIpfsUrl } from '../ipfs'
+
+describe('accessIpfsUrl', () => {
+  it('should return valid https url', () => {
+    expect(
+      accessIpfsUrl('ipfs://QmbaHVxK6Ru8p4SL3cZuzNmPNH6kE9y5TDFHWuGmKtzpto/TRAILBLAZER_Stanford.png'),
+    ).toEqual('https://ipfs.io/ipfs/QmbaHVxK6Ru8p4SL3cZuzNmPNH6kE9y5TDFHWuGmKtzpto/TRAILBLAZER_Stanford.png')
+  })
+})

--- a/src/app/utils/externalLinks.ts
+++ b/src/app/utils/externalLinks.ts
@@ -41,3 +41,7 @@ export const testnet = {
 export const api = {
   spec: `${process.env.REACT_APP_API}spec/v1.html`,
 }
+
+export const ipfs = {
+  proxyPrefix: 'https://ipfs.io/ipfs/',
+}

--- a/src/app/utils/ipfs.ts
+++ b/src/app/utils/ipfs.ts
@@ -1,0 +1,14 @@
+import { ipfs } from './externalLinks'
+
+export const ipfsUrlPrefix = 'ipfs://'
+
+/**
+ * Return a URL for accessing an IPFS asset via ipfs.io
+ */
+export const accessIpfsUrl = (url: string): string => {
+  if (!url.toLowerCase().startsWith(ipfsUrlPrefix)) {
+    console.log('Looking for', ipfsUrlPrefix, 'found', url.toLowerCase())
+    throw new Error(`Invalid IPFS URL, doesn't start with ${ipfsUrlPrefix}: ${url}`)
+  }
+  return `${ipfs.proxyPrefix}${url.substring(ipfsUrlPrefix.length)}`
+}

--- a/src/app/utils/nft-images.ts
+++ b/src/app/utils/nft-images.ts
@@ -1,0 +1,29 @@
+import { AppError, AppErrors } from 'types/errors'
+import { accessIpfsUrl } from './ipfs'
+
+const validProtocols = ['http:', 'https:', 'ftp:', 'ipfs:']
+
+export const isNftImageUrlValid = (url: string | undefined): boolean => {
+  if (!url) {
+    return false
+  }
+
+  try {
+    const parsedUrl = new URL(url)
+    return validProtocols.includes(parsedUrl.protocol)
+  } catch (error) {
+    return false
+  }
+}
+
+export const processNftImageUrl = (url: string | undefined): string => {
+  if (!url || !isNftImageUrlValid(url)) {
+    throw new AppError(AppErrors.InvalidUrl)
+  }
+
+  if (url && url.startsWith('ipfs:')) {
+    return accessIpfsUrl(url)
+  }
+
+  return url
+}

--- a/src/app/utils/nft.ts
+++ b/src/app/utils/nft.ts
@@ -1,0 +1,4 @@
+import { EvmNft } from 'oasis-nexus/api'
+
+export const getNftInstanceLabel = (nft: EvmNft) =>
+  nft.token.name ? `${nft.token.name} #${nft.id}` : `#${nft.id}`

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -122,10 +122,14 @@
     }
   },
   "nft": {
+    "collection": "Collection",
+    "instanceTokenId": "Token ID",
     "instanceTitleSuffix": "(NFT Instance)",
     "noPreview": "No preview available",
     "openInFullscreen": "Open in fullscreen",
-    "switchBackgroundColor": "Switch between dark and light background"
+    "owner": "Owner",
+    "switchBackgroundColor": "Switch between dark and light background",
+    "transfers": "Transfers"
   },
   "nodes": {
     "title": "Active nodes",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -122,6 +122,7 @@
     }
   },
   "nft": {
+    "instanceTitleSuffix": "(NFT Instance)",
     "noPreview": "No preview available",
     "openInFullscreen": "Open in fullscreen",
     "switchBackgroundColor": "Switch between dark and light background"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -121,6 +121,11 @@
       "verifyInSourcify": "Verify through <SourcifyLink>Sourcify</SourcifyLink>"
     }
   },
+  "nft": {
+    "noPreview": "No preview available",
+    "openInFullscreen": "Open in fullscreen",
+    "switchBackgroundColor": "Switch between dark and light background"
+  },
   "nodes": {
     "title": "Active nodes",
     "unknown": "Consensus layer indexer is not caught up with the latest blocks. The number of active nodes is unknown.",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -25,6 +25,7 @@ import { TokenDashboardPage, useTokenDashboardProps } from './app/pages/TokenDas
 import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
 import { TokenTransfersCard } from './app/pages/TokenDashboardPage/TokenTransfersCard'
 import { TokenHoldersCard } from './app/pages/TokenDashboardPage/TokenHoldersCard'
+import { NFTInstanceDashboardPage } from './app/pages/NFTInstanceDashboardPage'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -115,6 +116,10 @@ export const routes: RouteObject[] = [
           {
             path: `token`,
             element: <TokensPage />,
+          },
+          {
+            path: 'token/:address/instance/:instanceId',
+            element: <NFTInstanceDashboardPage />,
           },
           {
             path: `token/:address`,


### PR DESCRIPTION
See the design [here](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?type=design&node-id=6092-212988&mode=design&t=IcBb5lsaTPunvu04-0) (Also move to the right)

![image](https://github.com/oasisprotocol/explorer/assets/2093792/4e835a0f-d428-4901-9f7d-18e5ef5a355b)


Currently powered by mock data. Obviously, the metadata and history tabs are not yet there, waiting for the backend on those. (Even the format is not yet known)

W.I.P.

Built on top of #893, in order to avoid syntax errors caused by importing the latest API definition.