### PR TITLE
Pin Python version until Towncrier fork is updated

### DIFF
--- a/.changelog/979.internal.md
+++ b/.changelog/979.internal.md
@@ -1,0 +1,1 @@
+Pin Python version until Towncrier fork is updated

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          # Towncrier fork does not work with 3.12.
+          python-version: '3.11.6'
       - name: Set up Node.js 20
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Keep CI alive while we do not have Towncrier fork updated
sample issue from other repo https://github.com/oasisprotocol/oasis-wallet-web/actions/runs/6692075152/job/18180527014?pr=1747