### PR TITLE
Install setuptools to make Towncrier fork work with Python 3.12

### DIFF
--- a/.changelog/980.internal.md
+++ b/.changelog/980.internal.md
@@ -1,0 +1,1 @@
+Install setuptools to make Towncrier fork work with Python 3.12

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Install gitlint
         run: |
           python -m pip install gitlint
+        # Needed for Towncrier fork to work with 3.12 and above
+      - name: Install setuptools
+        run: |
+          python -m pip install setuptools
       - name: Install towncrier
         run: |
           python -m pip install https://github.com/oasisprotocol/towncrier/archive/oasis-master.tar.gz


### PR DESCRIPTION
See https://github.com/oasisprotocol/oasis-core/pull/5421.