### PR TITLE
Display TX format for unencrypted transactions

### DIFF
--- a/.changelog/898.trivial.md
+++ b/.changelog/898.trivial.md
@@ -1,0 +1,1 @@
+Display TX format for unencrypted transactions

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -32,7 +32,7 @@ import { CurrentFiatValue } from './CurrentFiatValue'
 import { AddressSwitch, AddressSwitchOption } from '../../components/AddressSwitch'
 import InfoIcon from '@mui/icons-material/Info'
 import Tooltip from '@mui/material/Tooltip'
-import { TransactionEncrypted } from '../../components/TransactionEncryptionStatus'
+import { TransactionEncrypted, TransactionNotEncrypted } from '../../components/TransactionEncryptionStatus'
 import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
@@ -245,6 +245,19 @@ export const TransactionDetailView: FC<{
             <RuntimeTransactionLabel method={transaction.method} />
           </dd>
 
+          <dt>{t('transactions.encryption.format')}</dt>
+          <dd>
+            {transaction.encryption_envelope ? (
+              <>
+                {transaction.encryption_envelope.format} &nbsp; <TransactionEncrypted />
+              </>
+            ) : (
+              <>
+                {t('transactions.encryption.plain')} &nbsp; <TransactionNotEncrypted />
+              </>
+            )}
+          </dd>
+
           <dt>{t('common.timestamp')}</dt>
           <dd>{formattedTimestamp}</dd>
 
@@ -347,11 +360,6 @@ export const TransactionDetailView: FC<{
 
           {transaction.encryption_envelope && (
             <>
-              <dt>{t('transactions.encryption.format')}</dt>
-              <dd>
-                {transaction.encryption_envelope.format} &nbsp; <TransactionEncrypted />
-              </dd>
-
               {transaction.encryption_envelope.public_key !== undefined && (
                 <>
                   <dt>{t('transactions.encryption.publicKey')}</dt>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -243,6 +243,7 @@
       "encryptedData": "Data (encrypted)",
       "encryptedResult": "Result (encrypted)",
       "format": "Format",
+      "plain": "Plain",
       "publicKey": "Public Key",
       "resultNonce": "Result Nonce"
     },


### PR DESCRIPTION
We have already been displaying format for encrypted transactions, but not for plain ones.
I moved the field (for encrypted TXs) higher, right next to type, and added the same field for plain transactions, too.

Encrypted TX:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/b86640c8-e9f6-410b-9d77-b07314bfa65c)

Plain TX:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/d33b221f-9779-4193-a0b6-78ca5a6d8761)
