### PR TITLE
Account ERC721 collection

### DIFF
--- a/.changelog/1052.feature.md
+++ b/.changelog/1052.feature.md
@@ -1,0 +1,1 @@
+Add NFT feature

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -1,21 +1,63 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams, Link as RouterLink } from 'react-router-dom'
+import Box from '@mui/material/Box'
+import Breadcrumbs from '@mui/material/Breadcrumbs'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { AccountDetailsContext } from './index'
 import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
+import { AccountLink } from 'app/components/Account/AccountLink'
+import { CopyToClipboard } from 'app/components/CopyToClipboard'
+import { AppErrors } from 'types/errors'
+import { RouteUtils } from 'app/utils/route-utils'
+import { COLORS } from 'styles/theme/colors'
 
 export const accountTokenContainerId = 'nftCollection'
 
 export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
+  const { contractAddress } = useParams()
+
+  if (!contractAddress) {
+    throw AppErrors.InvalidAddress
+  }
+
   return (
     <Card>
       <LinkableDiv id={accountTokenTransfersContainerId}>
-        <CardHeader disableTypography component="h3" title={t('nft.accountCollection')} />
+        <CardHeader
+          action={
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', paddingY: 3 }}>
+              <AccountLink scope={scope} address={contractAddress} />
+              <CopyToClipboard value={contractAddress} />
+            </Box>
+          }
+          disableTypography
+          title={
+            <Breadcrumbs separator="›" aria-label="breadcrumb">
+              <Typography fontSize={24}>
+                <Link
+                  component={RouterLink}
+                  to={RouteUtils.getAccountTokensRoute(scope, address, 'ERC721', contractAddress)}
+                >
+                  {t('nft.accountCollection')}
+                </Link>
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'baseline' }} gap={2}>
+                <Typography color={COLORS.brandExtraDark} fontSize={24}>
+                  {t('common.collection')}
+                </Typography>
+                <Typography>(3)</Typography>
+              </Box>
+            </Breadcrumbs>
+          }
+        />
       </LinkableDiv>
       <CardContent>
         <ErrorBoundary light={true}>

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -15,7 +15,6 @@ import Skeleton from '@mui/material/Skeleton'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { AccountDetailsContext } from './index'
-import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
 import { AccountLink } from 'app/components/Account/AccountLink'
 import { CopyToClipboard } from 'app/components/CopyToClipboard'
 import { RouteUtils } from 'app/utils/route-utils'
@@ -28,7 +27,7 @@ import { EvmNft } from 'oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { NFTCollectionLink, NFTInstanceLink } from '../TokenDashboardPage/NFTLinks'
 
-export const accountTokenContainerId = 'nftCollection'
+export const accountNFTCollectionContainerId = 'nftCollection'
 
 export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
@@ -41,7 +40,7 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
 
   return (
     <Card>
-      <LinkableDiv id={accountTokenTransfersContainerId}>
+      <LinkableDiv id={accountNFTCollectionContainerId}>
         <CardHeader
           action={
             <Box sx={{ display: 'flex', alignItems: 'flex-start', paddingY: 3 }}>
@@ -55,8 +54,9 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
               <Breadcrumbs separator="›" aria-label="breadcrumb">
                 <Typography fontSize={24}>
                   <Link
+                    preventScrollReset={true}
                     component={RouterLink}
-                    to={RouteUtils.getAccountTokensRoute(scope, address, 'ERC721', ethContractAddress)}
+                    to={RouteUtils.getAccountTokensRoute(scope, address, 'ERC721', '')}
                   >
                     {t('nft.accountCollection')}
                   </Link>

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -26,6 +26,7 @@ import { TablePagination } from '../../components/Table/TablePagination'
 import { useAccountTokenInventory } from '../TokenDashboardPage/hook'
 import { EvmNft } from 'oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
+import { NFTInstanceLink } from '../TokenDashboardPage/NFTLinks'
 
 export const accountTokenContainerId = 'nftCollection'
 
@@ -126,7 +127,11 @@ const AccountNFTCollection: FC<AccountNFTCollectionProps> = ({
               return (
                 <ImageListItem key={instance.id}>
                   <ImageListItemImage instance={instance} to={to} />
-                  <ImageListItemBar title={'TODO'} subtitle={'TODO'} position="below" />
+                  <ImageListItemBar
+                    title={'TODO'}
+                    subtitle={<NFTInstanceLink instance={instance} scope={scope} />}
+                    position="below"
+                  />
                 </ImageListItem>
               )
             })}

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -26,7 +26,7 @@ import { TablePagination } from '../../components/Table/TablePagination'
 import { useAccountTokenInventory } from '../TokenDashboardPage/hook'
 import { EvmNft } from 'oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
-import { NFTInstanceLink } from '../TokenDashboardPage/NFTLinks'
+import { NFTCollectionLink, NFTInstanceLink } from '../TokenDashboardPage/NFTLinks'
 
 export const accountTokenContainerId = 'nftCollection'
 
@@ -128,7 +128,7 @@ const AccountNFTCollection: FC<AccountNFTCollectionProps> = ({
                 <ImageListItem key={instance.id}>
                   <ImageListItemImage instance={instance} to={to} />
                   <ImageListItemBar
-                    title={'TODO'}
+                    title={<NFTCollectionLink instance={instance} scope={scope} />}
                     subtitle={<NFTInstanceLink instance={instance} scope={scope} />}
                     position="below"
                   />

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -31,22 +31,23 @@ export const accountNFTCollectionContainerId = 'nftCollection'
 
 export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, address }) => {
   const { t } = useTranslation()
-  const { ethContractAddress, oasisContractAddress } = useLoaderData() as {
-    ethContractAddress: string
-    oasisContractAddress: string
-  }
+  const oasisContractAddress = useLoaderData() as string
   const { inventory, isFetched, isLoading, isTotalCountClipped, pagination, totalCount } =
     useAccountTokenInventory(scope, address, oasisContractAddress)
+  const firstToken = inventory?.length ? inventory?.[0].token : undefined
 
   return (
     <Card>
       <LinkableDiv id={accountNFTCollectionContainerId}>
         <CardHeader
           action={
-            <Box sx={{ display: 'flex', alignItems: 'flex-start', paddingY: 3 }}>
-              <AccountLink scope={scope} address={ethContractAddress} />
-              <CopyToClipboard value={ethContractAddress} />
-            </Box>
+            isFetched &&
+            firstToken && (
+              <Box sx={{ display: 'flex', alignItems: 'flex-start', paddingY: 3 }}>
+                <AccountLink scope={scope} address={firstToken?.eth_contract_addr} />
+                <CopyToClipboard value={firstToken?.eth_contract_addr} />
+              </Box>
+            )
           }
           disableTypography
           title={
@@ -64,9 +65,7 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
                 {isFetched && (
                   <Box sx={{ display: 'flex', alignItems: 'baseline' }} gap={2}>
                     <Typography color={COLORS.brandExtraDark} fontSize={24}>
-                      {inventory?.length && inventory?.[0].token.name
-                        ? inventory?.[0].token.name
-                        : t('common.collection')}
+                      {firstToken?.name ? inventory?.[0].token.name : t('common.collection')}
                     </Typography>
                     {!!totalCount && (
                       <Typography>({`${isTotalCountClipped ? ' > ' : ''}${totalCount}`})</Typography>

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -84,6 +84,7 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
           <AccountNFTCollection
             inventory={inventory}
             isFetched={isFetched}
+            isLoading={isLoading}
             totalCount={totalCount}
             isTotalCountClipped={isTotalCountClipped}
             pagination={pagination}
@@ -97,6 +98,7 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
 
 type AccountNFTCollectionProps = {
   inventory: EvmNft[] | undefined
+  isLoading: boolean
   isFetched: boolean
   isTotalCountClipped: boolean | undefined
   totalCount: number | undefined
@@ -110,6 +112,7 @@ type AccountNFTCollectionProps = {
 
 const AccountNFTCollection: FC<AccountNFTCollectionProps> = ({
   inventory,
+  isLoading,
   isFetched,
   isTotalCountClipped,
   pagination,
@@ -120,6 +123,7 @@ const AccountNFTCollection: FC<AccountNFTCollectionProps> = ({
 
   return (
     <>
+      {isLoading && <Skeleton variant="rectangular" sx={{ height: 200 }} />}
       {isFetched && !totalCount && <CardEmptyState label={t('tokens.emptyInventory')} />}
       {!!inventory?.length && (
         <>

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -64,9 +64,11 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
                 {isFetched && (
                   <Box sx={{ display: 'flex', alignItems: 'baseline' }} gap={2}>
                     <Typography color={COLORS.brandExtraDark} fontSize={24}>
-                      {inventory?.[0].token.name ? inventory?.[0].token.name : t('common.collection')}
+                      {inventory?.length && inventory?.[0].token.name
+                        ? inventory?.[0].token.name
+                        : t('common.collection')}
                     </Typography>
-                    {totalCount && (
+                    {!!totalCount && (
                       <Typography>({`${isTotalCountClipped ? ' > ' : ''}${totalCount}`})</Typography>
                     )}
                   </Box>

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
+import { AccountDetailsContext } from './index'
+import { accountTokenTransfersContainerId } from './AccountTokenTransfersCard'
+
+export const accountTokenContainerId = 'nftCollection'
+
+export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, address }) => {
+  const { t } = useTranslation()
+  return (
+    <Card>
+      <LinkableDiv id={accountTokenTransfersContainerId}>
+        <CardHeader disableTypography component="h3" title={t('nft.accountCollection')} />
+      </LinkableDiv>
+      <CardContent>
+        <ErrorBoundary light={true}>
+          <AccountNFTCollection scope={scope} address={address} />
+        </ErrorBoundary>
+      </CardContent>
+    </Card>
+  )
+}
+
+const AccountNFTCollection: FC<AccountDetailsContext> = ({ scope, address }) => {
+  return <>sub view</>
+}

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
+import { useLocation, Link as RouterLink } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
+import Link from '@mui/material/Link'
 import { CardEmptyState } from './CardEmptyState'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
@@ -43,11 +44,20 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, address, 
   const { t } = useTranslation()
   const locationHash = useLocation().hash.replace('#', '')
   const tokenListLabel = getTokenTypePluralName(t, type)
+  const isERC721 = type === EvmTokenType.ERC721
   const tableColumns: TableColProps[] = [
-    { key: 'name', content: t('common.name') },
+    { key: 'name', content: t(isERC721 ? 'common.collection' : 'common.name') },
     { key: 'contract', content: t('common.smartContract') },
-    { key: 'balance', align: TableCellAlign.Right, content: t('common.balance') },
+    { key: 'balance', align: TableCellAlign.Right, content: t(isERC721 ? 'common.owned' : 'common.balance') },
     { key: 'ticker', align: TableCellAlign.Right, content: t('common.ticker') },
+    ...(isERC721
+      ? [
+          {
+            key: 'link',
+            content: '',
+          },
+        ]
+      : []),
   ]
   const { layer } = scope
   if (layer === Layer.consensus) {
@@ -85,6 +95,15 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, address, 
         align: TableCellAlign.Right,
         content: item.token_symbol || t('common.missing'),
         key: 'ticker',
+      },
+      {
+        align: TableCellAlign.Right,
+        key: 'link',
+        content: (
+          <Link component={RouterLink} to={item.token_contract_addr_eth}>
+            {t('common.viewAll')}
+          </Link>
+        ),
       },
     ],
     highlight: item.token_contract_addr_eth === locationHash || item.token_contract_addr === locationHash,

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -100,7 +100,7 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, address, 
         align: TableCellAlign.Right,
         key: 'link',
         content: (
-          <Link component={RouterLink} to={item.token_contract_addr_eth}>
+          <Link component={RouterLink} to={item.token_contract_addr_eth} preventScrollReset={true}>
             {t('common.viewAll')}
           </Link>
         ),

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -55,7 +55,7 @@ export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
             )}
             <dt>{t('nft.instanceTokenId')}</dt>
             <dd>{nft.id}</dd>
-            <dt>{t('nft.collection')} </dt>
+            <dt>{t('common.collection')} </dt>
             <dd>
               <TokenLink scope={scope} address={contractAddress} name={token?.name} />
             </dd>

--- a/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
+++ b/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
@@ -12,6 +12,7 @@ const imageSize = '210px'
 const StyledImage = styled('img')({
   width: imageSize,
   height: imageSize,
+  objectFit: 'cover',
 })
 
 type ImageListItemImageProps = {

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -1,18 +1,40 @@
 import { FC } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
+import { EvmNft } from 'oasis-nexus/api'
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import { RouteUtils } from '../../utils/route-utils'
-import { EvmNft } from 'oasis-nexus/api'
-import { SearchScope } from 'types/searchScope'
+import { SearchScope } from '../../../types/searchScope'
+import { trimLongString } from '../../utils/trimLongString'
 
-type NFTInstanceLinkProps = {
+type NFTLinkProps = {
   scope: SearchScope
   instance: EvmNft
 }
 
-export const NFTInstanceLink: FC<NFTInstanceLinkProps> = ({ scope, instance }) => {
+export const NFTCollectionLink: FC<NFTLinkProps> = ({ scope, instance }) => {
+  const { t } = useTranslation()
+  const to = RouteUtils.getTokenRoute(scope, instance.token?.contract_addr)
+
+  return (
+    <Typography>
+      <Trans
+        i18nKey="nft.collectionLink"
+        t={t}
+        components={{
+          CollectionLink: (
+            <Link component={RouterLink} to={to}>
+              {instance.token?.name ?? trimLongString(instance.token?.eth_contract_addr, 5, 5)}
+            </Link>
+          ),
+        }}
+      />
+    </Typography>
+  )
+}
+
+export const NFTInstanceLink: FC<NFTLinkProps> = ({ scope, instance }) => {
   const { t } = useTranslation()
   const to = RouteUtils.getNFTInstanceRoute(scope, instance.token?.contract_addr, instance.id)
 

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { Link as RouterLink } from 'react-router-dom'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import { RouteUtils } from '../../utils/route-utils'
+import { EvmNft } from 'oasis-nexus/api'
+import { SearchScope } from 'types/searchScope'
+
+type NFTInstanceLinkProps = {
+  scope: SearchScope
+  instance: EvmNft
+}
+
+export const NFTInstanceLink: FC<NFTInstanceLinkProps> = ({ scope, instance }) => {
+  const { t } = useTranslation()
+  const to = RouteUtils.getNFTInstanceRoute(scope, instance.token?.contract_addr, instance.id)
+
+  return (
+    <Typography>
+      <Trans
+        i18nKey="nft.instanceIdLink"
+        t={t}
+        components={{
+          InstanceLink: (
+            <Link component={RouterLink} to={to}>
+              {instance.id}
+            </Link>
+          ),
+        }}
+      />
+    </Typography>
+  )
+}

--- a/src/app/pages/TokenDashboardPage/TokenInventoryCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenInventoryCard.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
-import { Trans, useTranslation } from 'react-i18next'
-import { Link as RouterLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
@@ -8,7 +7,6 @@ import CardContent from '@mui/material/CardContent'
 import ImageList from '@mui/material/ImageList'
 import ImageListItem from '@mui/material/ImageListItem'
 import ImageListItemBar from '@mui/material/ImageListItemBar'
-import Link from '@mui/material/Link'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from '../AccountDetailsPage/CardEmptyState'
@@ -18,6 +16,7 @@ import { RouteUtils } from '../../utils/route-utils'
 import { TablePagination } from '../../components/Table/TablePagination'
 import { useTokenInventory } from './hook'
 import { ImageListItemImage } from './ImageListItemImage'
+import { NFTInstanceLink } from './NFTLinks'
 
 export const tokenInventoryContainerId = 'inventory'
 
@@ -55,19 +54,7 @@ const TokenInventoryView: FC<TokenDashboardContext> = ({ scope, address }) => {
                 <ImageListItem key={instance.id}>
                   <ImageListItemImage instance={instance} to={to} />
                   <ImageListItemBar
-                    title={
-                      <Trans
-                        i18nKey="nft.instanceIdLink"
-                        t={t}
-                        components={{
-                          InstanceLink: (
-                            <Link component={RouterLink} to={to}>
-                              #{instance.id}
-                            </Link>
-                          ),
-                        }}
-                      />
-                    }
+                    title={<NFTInstanceLink scope={scope} instance={instance} />}
                     subtitle={
                       owner ? <AccountLink scope={scope} address={owner} alwaysTrim={true} /> : undefined
                     }

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -172,9 +172,9 @@ export const useAccountTokenInventory = (scope: SearchScope, address: string, to
     inventory,
     pagination: {
       ...pagination,
-      isTotalCountClipped,
       rowsPerPage: NUMBER_OF_INVENTORY_ITEMS,
     },
+    isTotalCountClipped,
     totalCount,
   }
 }

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -151,8 +151,8 @@ export const addressParamLoader = async ({ params }: LoaderFunctionArgs) => {
 export const contractAddressParamLoader = async ({ params }: LoaderFunctionArgs) => {
   validateAddressParam(params.contractAddress!)
   // TODO: remove conversion when API supports querying by EVM address
-  const oasisContractAddress = await getOasisAddress(params.contractAddress!)
-  return { ethContractAddress: params.contractAddress, oasisContractAddress }
+  const address = await getOasisAddress(params.contractAddress!)
+  return address
 }
 
 export const blockHeightParamLoader = async ({ params }: LoaderFunctionArgs) => {

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -148,6 +148,13 @@ export const addressParamLoader = async ({ params }: LoaderFunctionArgs) => {
   return address
 }
 
+export const contractAddressParamLoader = async ({ params }: LoaderFunctionArgs) => {
+  validateAddressParam(params.contractAddress!)
+  // TODO: remove conversion when API supports querying by EVM address
+  const oasisContractAddress = await getOasisAddress(params.contractAddress!)
+  return { ethContractAddress: params.contractAddress, oasisContractAddress }
+}
+
 export const blockHeightParamLoader = async ({ params }: LoaderFunctionArgs) => {
   return validateBlockHeightParam(params.blockHeight!)
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -122,6 +122,7 @@
     }
   },
   "nft": {
+    "accountCollection": "ERC-721 Tokens",
     "collection": "Collection",
     "instanceIdLink": "ID: <InstanceLink />",
     "instanceTokenId": "Token ID",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -40,6 +40,7 @@
     "block": "Block",
     "bytes": "{{value, number}}",
     "cancel": "Cancel",
+    "collection": "Collection",
     "copy": "Copy",
     "data": "Data",
     "emerald": "Emerald",
@@ -67,6 +68,7 @@
     "nfts": "NFTs",
     "not_defined": "Not defined",
     "oasis": "Oasis",
+    "owned": "Owned",
     "paratime": "Paratime",
     "parentheses": "({{subject}})",
     "percentage": "Percentage",
@@ -123,7 +125,6 @@
   },
   "nft": {
     "accountCollection": "ERC-721 Tokens",
-    "collection": "Collection",
     "instanceIdLink": "ID: <InstanceLink />",
     "instanceTokenId": "Token ID",
     "instanceTitleSuffix": "(NFT Instance)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -125,6 +125,7 @@
   },
   "nft": {
     "accountCollection": "ERC-721 Tokens",
+    "collectionLink": "Collection: <CollectionLink />",
     "instanceIdLink": "ID: <InstanceLink />",
     "instanceTokenId": "Token ID",
     "instanceTitleSuffix": "(NFT Instance)",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import { SearchResultsPage } from './app/pages/SearchResultsPage'
 import {
   addressParamLoader,
   blockHeightParamLoader,
+  contractAddressParamLoader,
   transactionParamLoader,
   scopeLoader,
 } from './app/utils/route-utils'
@@ -107,6 +108,7 @@ export const routes: RouteObject[] = [
                   {
                     path: ':contractAddress',
                     Component: () => <AccountNFTCollectionCard {...useAccountDetailsProps()} />,
+                    loader: contractAddressParamLoader,
                   },
                 ],
               },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -23,6 +23,7 @@ import { TokensPage } from './app/pages/TokensOverviewPage'
 import { ContractCodeCard } from './app/pages/AccountDetailsPage/ContractCodeCard'
 import { TokenDashboardPage, useTokenDashboardProps } from './app/pages/TokenDashboardPage'
 import { AccountTokenTransfersCard } from './app/pages/AccountDetailsPage/AccountTokenTransfersCard'
+import { AccountNFTCollectionCard } from './app/pages/AccountDetailsPage/AccountNFTCollectionCard'
 import { TokenTransfersCard } from './app/pages/TokenDashboardPage/TokenTransfersCard'
 import { TokenHoldersCard } from './app/pages/TokenDashboardPage/TokenHoldersCard'
 import { TokenInventoryCard } from './app/pages/TokenDashboardPage/TokenInventoryCard'
@@ -102,6 +103,10 @@ export const routes: RouteObject[] = [
                   {
                     path: '',
                     Component: () => <AccountTokensCard {...useAccountDetailsProps()} type="ERC721" />,
+                  },
+                  {
+                    path: ':contractAddress',
+                    Component: () => <AccountNFTCollectionCard {...useAccountDetailsProps()} />,
                   },
                 ],
               },

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -398,6 +398,19 @@ export const defaultTheme = createTheme({
         },
       },
     },
+    MuiBreadcrumbs: {
+      styleOverrides: {
+        li: {
+          fontSize: '24px',
+        },
+        separator: {
+          color: COLORS.brandDark,
+          fontSize: '24px',
+          paddingRight: 3,
+          paddingLeft: 3,
+        },
+      },
+    },
     MuiCardHeader: {
       styleOverrides: {
         root: ({ theme }) => ({


### PR DESCRIPTION
Currently, in most cases this view will have no data, because an older version of the block analyzer was running (that didn't save NFT ownership, only balances)

stage env test url: http://localhost:1234/mainnet/emerald/address/oasis1qz9vum3457ngpqe2utn22cun5p3qe3hpvvskc9rh/tokens/erc-721/0x21844b05AEe1441606c701ABA4a2335Bc8f88120


![Screenshot from 2023-12-01 15-38-04](https://github.com/oasisprotocol/explorer/assets/891392/6acfe60b-de4b-4490-a5da-0eca30b8cf4e)

