### PR TITLE
Hide instance token number row in details page

### DIFF
--- a/.changelog/1060.feature.md
+++ b/.changelog/1060.feature.md
@@ -1,0 +1,1 @@
+Add NFT feature

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -72,12 +72,14 @@ export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
                 </dd>
               </>
             )}
-            {nft?.token?.num_transfers && (
+            {/* 
+            // TODO: uncomment when instance num_transfers is available
+            {nft?.num_transfers && (
               <>
                 <dt>{t('nft.transfers')}</dt>
                 <dd>{nft.token.num_transfers!.toLocaleString()}</dd>
               </>
-            )}
+            )} */}
             <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
             <dd>
               <AccountLink scope={account} address={account.address_eth || account.address} />


### PR DESCRIPTION
Hide incorrect `num_transfers` in instance details page. 

Will validate with backend before merging, but it looks like we are missing data https://oasisprotocol.clickup.com/t/86938qdwd