### PR TITLE
Don't directly include internal enum values in URLs

### DIFF
--- a/.changelog/1079.internal.md
+++ b/.changelog/1079.internal.md
@@ -1,0 +1,1 @@
+Don't directly include internal enum values in URLs

--- a/src/app/utils/externalLinks.ts
+++ b/src/app/utils/externalLinks.ts
@@ -40,9 +40,9 @@ const faucetUrl = 'https://faucet.testnet.oasis.dev/'
 const faucetParaTimeBaseUrl = `${faucetUrl}?paratime=`
 export const faucet = {
   [Layer.consensus]: faucetUrl,
-  [Layer.emerald]: `${faucetParaTimeBaseUrl}${Layer.emerald}`,
-  [Layer.sapphire]: `${faucetParaTimeBaseUrl}${Layer.sapphire}`,
-  [Layer.cipher]: `${faucetParaTimeBaseUrl}${Layer.cipher}`,
+  [Layer.emerald]: `${faucetParaTimeBaseUrl}emerald`,
+  [Layer.sapphire]: `${faucetParaTimeBaseUrl}sapphire`,
+  [Layer.cipher]: `${faucetParaTimeBaseUrl}cipher`,
 }
 
 export const api = {


### PR DESCRIPTION
(When generating the faucet links)