### PR TITLE
Support advertising relevant dApps for specific addresses

### DIFF
--- a/.changelog/1085.feature.md
+++ b/.changelog/1085.feature.md
@@ -1,0 +1,1 @@
+Support advertising specific dApps on relevant token pages

--- a/src/app/components/DappBanner/index.tsx
+++ b/src/app/components/DappBanner/index.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
+import { COLORS } from '../../../styles/theme/colors'
+import Box from '@mui/material/Box'
+import { useTranslation } from 'react-i18next'
+import { SearchScope } from '../../../types/searchScope'
+import { getDappForEthAddress } from '../../config/dapps'
+import Button from '@mui/material/Button'
+import { useScreenSize } from '../../hooks/useScreensize'
+
+export const DappBanner: FC<{ scope: SearchScope; ethAddress: string | undefined }> = ({
+  scope,
+  ethAddress,
+}) => {
+  const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+
+  if (!ethAddress) {
+    return null
+  }
+
+  const dApp = getDappForEthAddress(t, scope.network, scope.layer, ethAddress)
+
+  return (
+    !!dApp && (
+      <Card
+        sx={{
+          backgroundColor: COLORS.brandMedium,
+          border: `2px dashed ${COLORS.white}`,
+        }}
+      >
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+              alignItems: 'center',
+              gap: 3,
+            }}
+          >
+            <Typography
+              variant="h3"
+              sx={{
+                color: COLORS.white,
+                fontSize: isMobile ? '18px' : '24px',
+                fontWeight: 700,
+                lineHeight: '140%' /* 33.6px */,
+              }}
+            >
+              {dApp.description}
+            </Typography>
+            &nbsp;
+            <Button
+              href={dApp.url}
+              sx={{
+                backgroundColor: COLORS.white,
+                fontSize: '18px',
+                fontWeight: 500,
+                lineHeight: '125%',
+                textTransform: 'none',
+              }}
+              variant="outlined"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {dApp.label}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+    )
+  )
+}

--- a/src/app/config/dapps/index.ts
+++ b/src/app/config/dapps/index.ts
@@ -1,0 +1,34 @@
+import { Layer } from '../../../oasis-nexus/api'
+import { Network } from '../../../types/network'
+import { wRose } from './wrose'
+import { TFunction } from 'i18next'
+
+export type DappReference = {
+  description: string
+  label: string
+  url: string
+}
+
+export type DappReferenceGenerator = (t: TFunction) => DappReference
+
+const dappsForToken: Record<Network, Partial<Record<Layer, Record<string, DappReferenceGenerator>>>> = {
+  [Network.testnet]: {
+    [Layer.sapphire]: {
+      [wRose.testnetAddress]: wRose.app,
+    },
+  },
+  [Network.mainnet]: {
+    [Layer.sapphire]: {
+      [wRose.mainnetAddress]: wRose.app,
+    },
+  },
+}
+
+/**
+ * Return a dApp relevant to a given address, what we want to advertise
+ */
+export const getDappForEthAddress = (t: TFunction, network: Network, layer: Layer, ethAddress: string) => {
+  const generator = dappsForToken[network]?.[layer]?.[ethAddress]
+  const dApp = generator ? generator(t) : undefined
+  return dApp
+}

--- a/src/app/config/dapps/wrose.ts
+++ b/src/app/config/dapps/wrose.ts
@@ -1,0 +1,18 @@
+import type { DappReference } from './index'
+import type { TFunction } from 'i18next'
+
+/**
+ * A dApp that lets you wrap or unwrap ROSE on an Oasis EVM-compatible ParaTime.
+ *
+ * See https://github.com/oasisprotocol/dapp-wrose/tree/master
+ */
+export const wRose = {
+  // The addresses come from https://github.com/oasisprotocol/dapp-wrose/blob/master/src/constants/config.ts for the
+  mainnetAddress: '0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3',
+  testnetAddress: '0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94',
+  app: (t: TFunction): DappReference => ({
+    description: t('dapps.wrose.description'),
+    label: t('dapps.wrose.label'),
+    url: 'https://wrose.oasis.io/',
+  }),
+}

--- a/src/app/pages/AccountDetailsPage/index.tsx
+++ b/src/app/pages/AccountDetailsPage/index.tsx
@@ -18,6 +18,7 @@ import { SearchScope } from '../../../types/searchScope'
 import { AccountDetailsCard } from './AccountDetailsCard'
 import { AccountEventsCard } from './AccountEventsCard'
 import { EventFilterMode } from '../../components/RuntimeEvents/EventListFilterSwitch'
+import { DappBanner } from '../../components/DappBanner'
 
 export type AccountDetailsContext = {
   scope: SearchScope
@@ -67,6 +68,7 @@ export const AccountDetailsPage: FC = () => {
         token={token}
         tokenPriceInfo={tokenPriceInfo}
       />
+      <DappBanner scope={scope} ethAddress={account?.address_eth} />
       <RouterTabs
         tabs={[
           { label: t('common.transactions'), to: txLink },

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -15,6 +15,7 @@ import { contractCodeContainerId } from '../AccountDetailsPage/ContractCodeCard'
 import { tokenHoldersContainerId } from './TokenHoldersCard'
 import { SearchScope } from '../../../types/searchScope'
 import { tokenInventoryContainerId } from './TokenInventoryCard'
+import { DappBanner } from '../../components/DappBanner'
 
 export type TokenDashboardContext = {
   scope: SearchScope
@@ -29,7 +30,7 @@ export const TokenDashboardPage: FC = () => {
   const scope = useRequiredScopeParam()
   const address = useLoaderData() as string
 
-  const { isError } = useTokenInfo(scope, address)
+  const { token, isError } = useTokenInfo(scope, address)
 
   if (isError) {
     throw AppErrors.InvalidAddress
@@ -48,6 +49,7 @@ export const TokenDashboardPage: FC = () => {
   return (
     <PageLayout>
       <TokenTitleCard scope={scope} address={address} />
+      <DappBanner scope={scope} ethAddress={token?.eth_contract_addr} />
       <TokenSnapshot scope={scope} address={address} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
       <TokenDetailsCard scope={scope} address={address} />

--- a/src/app/pages/TransactionDetailPage/index.tsx
+++ b/src/app/pages/TransactionDetailPage/index.tsx
@@ -37,6 +37,7 @@ import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { base64ToHex } from '../../utils/helpers'
+import { DappBanner } from '../../components/DappBanner'
 
 type TransactionSelectionResult = {
   wantedTransaction?: RuntimeTransaction
@@ -128,6 +129,8 @@ export const TransactionDetailPage: FC = () => {
           addressSwitchOption={addressSwitchOption}
         />
       </SubPageCard>
+      <DappBanner scope={scope} ethAddress={transaction?.sender_0_eth} />
+      <DappBanner scope={scope} ethAddress={transaction?.to_eth} />
       {transaction && (
         <SubPageCard title={t('common.events')}>
           <TransactionEvents transaction={transaction} addressSwitchOption={addressSwitchOption} />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -123,6 +123,12 @@
       "verifyInSourcify": "Verify through <SourcifyLink>Sourcify</SourcifyLink>"
     }
   },
+  "dapps":{
+    "wrose": {
+      "description": "Looking to wrap or unwrap your wROSE?",
+      "label": "Use our ROSE (un)wrapper"
+    }
+  },
   "nft": {
     "accountCollection": "ERC-721 Tokens",
     "collectionLink": "Collection: <CollectionLink />",


### PR DESCRIPTION
Using the [wRose dApp](https://wrose.oasis.io) as an example.

Task is [here](https://app.clickup.com/t/86936cx71).

### Designs:

- Token page: [Desktop](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?type=design&node-id=8362-94013&mode=design&t=Yh5FlEWHVyDYcRvw-0) and [Mobile](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?type=design&node-id=8363-95481&mode=design&t=kWL0SPGnK8U5InDU-0)
- Transaction details page: [Desktop](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?type=design&node-id=8362-94807&mode=design&t=HfwNFNk6VI1IAWCT-0) and [Mobile](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?type=design&node-id=8363-95104&mode=design&t=l582ez7ErQYOVpgt-0)