### PR TITLE
Assemble changes for 1.4.0 release

### DIFF
--- a/.changelog/1000.internal.md
+++ b/.changelog/1000.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/react to v18.2.35

--- a/.changelog/1001.internal.md
+++ b/.changelog/1001.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/react to v18.2.36

--- a/.changelog/1002.internal.md
+++ b/.changelog/1002.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/1003.internal.md
+++ b/.changelog/1003.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1004.internal.md
+++ b/.changelog/1004.internal.md
@@ -1,1 +1,0 @@
-Get latest Nexus API stuff, except new event types

--- a/.changelog/1005.internal.md
+++ b/.changelog/1005.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.9.3

--- a/.changelog/1007.internal.md
+++ b/.changelog/1007.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/jest to ^29.5.8

--- a/.changelog/1008.internal.md
+++ b/.changelog/1008.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/1009.internal.md
+++ b/.changelog/1009.internal.md
@@ -1,1 +1,0 @@
-Update dependency axios to v1.6.1

--- a/.changelog/1010.internal.md
+++ b/.changelog/1010.internal.md
@@ -1,1 +1,0 @@
-Update dependency swiper to v11.0.4

--- a/.changelog/1011.internal.md
+++ b/.changelog/1011.internal.md
@@ -1,1 +1,0 @@
-Update dependency orval to ^6.20.0

--- a/.changelog/1012.bugfix.md
+++ b/.changelog/1012.bugfix.md
@@ -1,1 +1,0 @@
-Prevent app crash when rendering new event types

--- a/.changelog/1013.internal.md
+++ b/.changelog/1013.internal.md
@@ -1,1 +1,0 @@
-Update dependency i18next to v23.7.1

--- a/.changelog/1014.internal.md
+++ b/.changelog/1014.internal.md
@@ -1,1 +1,0 @@
-Update i18n dependencies

--- a/.changelog/1015.internal.md
+++ b/.changelog/1015.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1016.internal.md
+++ b/.changelog/1016.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/1017.internal.md
+++ b/.changelog/1017.internal.md
@@ -1,1 +1,0 @@
-Update dependency storybook-addon-react-router-v6 to v2.0.10

--- a/.changelog/1018.trivial.md
+++ b/.changelog/1018.trivial.md
@@ -1,1 +1,0 @@
-Enable scrollable tabs

--- a/.changelog/1019.internal.md
+++ b/.changelog/1019.internal.md
@@ -1,1 +1,0 @@
-Update dependency axios to v1.6.2

--- a/.changelog/1020.internal.md
+++ b/.changelog/1020.internal.md
@@ -1,1 +1,0 @@
-Update parcel monorepo to v2.10.3

--- a/.changelog/1021.internal.md
+++ b/.changelog/1021.internal.md
@@ -1,1 +1,0 @@
-Use Oasis bot token in renovate workflow

--- a/.changelog/1022.internal.md
+++ b/.changelog/1022.internal.md
@@ -1,1 +1,0 @@
-Update dependency react-i18next to v13.5.0

--- a/.changelog/1023.internal.md
+++ b/.changelog/1023.internal.md
@@ -1,1 +1,0 @@
-Update dependency react-router-dom to v6.19.0

--- a/.changelog/1024.internal.md
+++ b/.changelog/1024.internal.md
@@ -1,1 +1,0 @@
-Update dependency @playwright/test to ^1.40.0

--- a/.changelog/1025.internal.md
+++ b/.changelog/1025.internal.md
@@ -1,1 +1,0 @@
-Update test dependencies

--- a/.changelog/1026.internal.md
+++ b/.changelog/1026.internal.md
@@ -1,1 +1,0 @@
-Update dependency eslint to v8.54.0

--- a/.changelog/1027.internal.md
+++ b/.changelog/1027.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.10.1

--- a/.changelog/1028.internal.md
+++ b/.changelog/1028.internal.md
@@ -1,1 +1,0 @@
-Update dependency typescript to v5.3.2

--- a/.changelog/1029.internal.md
+++ b/.changelog/1029.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1030.internal.md
+++ b/.changelog/1030.internal.md
@@ -1,1 +1,0 @@
-Update test dependencies

--- a/.changelog/1031.internal.md
+++ b/.changelog/1031.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/1032.internal.md
+++ b/.changelog/1032.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/1033.internal.md
+++ b/.changelog/1033.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/jest to ^29.5.10

--- a/.changelog/1034.internal.md
+++ b/.changelog/1034.internal.md
@@ -1,1 +1,0 @@
-Update dependency swiper to v11.0.5

--- a/.changelog/1036.feature.md
+++ b/.changelog/1036.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1038.feature.md
+++ b/.changelog/1038.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1039.bugfix.md
+++ b/.changelog/1039.bugfix.md
@@ -1,1 +1,0 @@
-Fix address formatting on empty account

--- a/.changelog/1040.internal.md
+++ b/.changelog/1040.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1041.internal.md
+++ b/.changelog/1041.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/1042.internal.md
+++ b/.changelog/1042.internal.md
@@ -1,1 +1,0 @@
-Update dependency orval to ^6.21.0

--- a/.changelog/1043.feature.md
+++ b/.changelog/1043.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1044.internal.md
+++ b/.changelog/1044.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/1045.internal.md
+++ b/.changelog/1045.internal.md
@@ -1,1 +1,0 @@
-Update dependency i18next to v23.7.7

--- a/.changelog/1046.internal.md
+++ b/.changelog/1046.internal.md
@@ -1,1 +1,0 @@
-Update test dependencies

--- a/.changelog/1047.internal.md
+++ b/.changelog/1047.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.10.2

--- a/.changelog/1048.internal.md
+++ b/.changelog/1048.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/1049.trivial.md
+++ b/.changelog/1049.trivial.md
@@ -1,1 +1,0 @@
-Add support for handling direct child routes in RouterTabs

--- a/.changelog/1050.internal.md
+++ b/.changelog/1050.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/1051.feature.md
+++ b/.changelog/1051.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1052.feature.md
+++ b/.changelog/1052.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1053.internal.md
+++ b/.changelog/1053.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/1054.internal.md
+++ b/.changelog/1054.internal.md
@@ -1,1 +1,0 @@
-Update test dependencies

--- a/.changelog/1055.internal.md
+++ b/.changelog/1055.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.10.3

--- a/.changelog/1056.internal.md
+++ b/.changelog/1056.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/1057.internal.md
+++ b/.changelog/1057.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/1058.internal.md
+++ b/.changelog/1058.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1059.internal.md
+++ b/.changelog/1059.internal.md
@@ -1,1 +1,0 @@
-Update API bindings

--- a/.changelog/1061.bugfix.md
+++ b/.changelog/1061.bugfix.md
@@ -1,1 +1,0 @@
-Fix address formatting on empty account

--- a/.changelog/1063.internal.md
+++ b/.changelog/1063.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1064.internal.md
+++ b/.changelog/1064.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/react to v18.2.42

--- a/.changelog/1065.bugfix.md
+++ b/.changelog/1065.bugfix.md
@@ -1,1 +1,0 @@
-Fix Testnet Faucet links

--- a/.changelog/1067.internal.md
+++ b/.changelog/1067.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/1068.internal.md
+++ b/.changelog/1068.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/jest to ^29.5.11

--- a/.changelog/1069.feature.md
+++ b/.changelog/1069.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/1072.internal.md
+++ b/.changelog/1072.internal.md
@@ -1,1 +1,0 @@
-Update actions/setup-python action to v5

--- a/.changelog/1073.bugfix.md
+++ b/.changelog/1073.bugfix.md
@@ -1,1 +1,0 @@
-Fetch account balance from RPC node

--- a/.changelog/1074.internal.md
+++ b/.changelog/1074.internal.md
@@ -1,1 +1,0 @@
-Update fontsource monorepo

--- a/.changelog/1075.internal.md
+++ b/.changelog/1075.internal.md
@@ -1,1 +1,0 @@
-Update dependency typescript to v5.3.3

--- a/.changelog/1076.internal.md
+++ b/.changelog/1076.internal.md
@@ -1,1 +1,0 @@
-Update dependency i18next to v23.7.8

--- a/.changelog/1078.internal.md
+++ b/.changelog/1078.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/1079.internal.md
+++ b/.changelog/1079.internal.md
@@ -1,1 +1,0 @@
-Don't directly include internal enum values in URLs

--- a/.changelog/1080.trivial.md
+++ b/.changelog/1080.trivial.md
@@ -1,1 +1,0 @@
-Improve the no results found screen

--- a/.changelog/1081.feature.md
+++ b/.changelog/1081.feature.md
@@ -1,1 +1,0 @@
-Implement searching for blocks by hash

--- a/.changelog/1083.internal.md
+++ b/.changelog/1083.internal.md
@@ -1,1 +1,0 @@
-Update dependency @oasisprotocol/client to v1

--- a/.changelog/1084.internal.md
+++ b/.changelog/1084.internal.md
@@ -1,1 +1,0 @@
-Update dependency @oasisprotocol/client-rt to v1

--- a/.changelog/1086.internal.md
+++ b/.changelog/1086.internal.md
@@ -1,1 +1,0 @@
-Update dependency markdownlint-cli to v0.38.0

--- a/.changelog/1087.internal.md
+++ b/.changelog/1087.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/react to v18.2.43

--- a/.changelog/1088.internal.md
+++ b/.changelog/1088.internal.md
@@ -1,1 +1,0 @@
-Update dependency prettier to v3.1.1

--- a/.changelog/1090.internal.md
+++ b/.changelog/1090.internal.md
@@ -1,1 +1,0 @@
-Update critical dependency @babel/traverse to v7.23.6

--- a/.changelog/1091.internal.md
+++ b/.changelog/1091.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/1092.internal.md
+++ b/.changelog/1092.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/1093.internal.md
+++ b/.changelog/1093.internal.md
@@ -1,1 +1,0 @@
-Update dependency i18next to v23.7.9

--- a/.changelog/1094.internal.md
+++ b/.changelog/1094.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/react to v18.2.45

--- a/.changelog/1095.internal.md
+++ b/.changelog/1095.internal.md
@@ -1,1 +1,0 @@
-Add CODEOWNERS

--- a/.changelog/1989.trivial.md
+++ b/.changelog/1989.trivial.md
@@ -1,1 +1,0 @@
-Pull in latest API code

--- a/.changelog/893.internal.md
+++ b/.changelog/893.internal.md
@@ -1,1 +1,0 @@
-Add basic handling of new event types

--- a/.changelog/898.trivial.md
+++ b/.changelog/898.trivial.md
@@ -1,1 +1,0 @@
-Display TX format for unencrypted transactions

--- a/.changelog/909.feature.md
+++ b/.changelog/909.feature.md
@@ -1,1 +1,0 @@
-Add NFT feature

--- a/.changelog/948.internal.md
+++ b/.changelog/948.internal.md
@@ -1,1 +1,0 @@
-Update API bindings, except the new event types

--- a/.changelog/968.internal.md
+++ b/.changelog/968.internal.md
@@ -1,1 +1,0 @@
-Update fontsource monorepo

--- a/.changelog/971.internal.md
+++ b/.changelog/971.internal.md
@@ -1,1 +1,0 @@
-Update actions/setup-node action to v4

--- a/.changelog/972.internal.md
+++ b/.changelog/972.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/973.internal.md
+++ b/.changelog/973.internal.md
@@ -1,1 +1,0 @@
-Update Node.js to v20

--- a/.changelog/974.internal.md
+++ b/.changelog/974.internal.md
@@ -1,1 +1,0 @@
-Update material-ui monorepo

--- a/.changelog/975.internal.md
+++ b/.changelog/975.internal.md
@@ -1,1 +1,0 @@
-Update parcel monorepo to v2.10.1

--- a/.changelog/976.internal.md
+++ b/.changelog/976.internal.md
@@ -1,1 +1,0 @@
-Update dependency swiper to v11

--- a/.changelog/977.internal.md
+++ b/.changelog/977.internal.md
@@ -1,1 +1,0 @@
-Update to latest Orval version (for code generation)

--- a/.changelog/980.internal.md
+++ b/.changelog/980.internal.md
@@ -1,1 +1,0 @@
-Install setuptools to make Towncrier fork work with Python 3.12

--- a/.changelog/981.internal.md
+++ b/.changelog/981.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/node to v18.18.7

--- a/.changelog/982.internal.md
+++ b/.changelog/982.internal.md
@@ -1,1 +1,0 @@
-Update react dependencies

--- a/.changelog/983.internal.md
+++ b/.changelog/983.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.9.1

--- a/.changelog/984.internal.md
+++ b/.changelog/984.internal.md
@@ -1,1 +1,0 @@
-Update storybook dependencies

--- a/.changelog/985.internal.md
+++ b/.changelog/985.internal.md
@@ -1,1 +1,0 @@
-Update dependency axios to v1.6.0

--- a/.changelog/986.internal.md
+++ b/.changelog/986.internal.md
@@ -1,1 +1,0 @@
-Update lint dependencies

--- a/.changelog/987.internal.md
+++ b/.changelog/987.internal.md
@@ -1,1 +1,0 @@
-Update dependency @types/jest to ^29.5.7

--- a/.changelog/990.feature.md
+++ b/.changelog/990.feature.md
@@ -1,1 +1,0 @@
-Show block-level evens in block details

--- a/.changelog/991.internal.md
+++ b/.changelog/991.internal.md
@@ -1,1 +1,0 @@
-Refactor code for showing events

--- a/.changelog/992.feature.md
+++ b/.changelog/992.feature.md
@@ -1,1 +1,0 @@
-Show events on account details page

--- a/.changelog/994.internal.md
+++ b/.changelog/994.internal.md
@@ -1,1 +1,0 @@
-Update dependency recharts to v2.9.2

--- a/.changelog/995.internal.md
+++ b/.changelog/995.internal.md
@@ -1,1 +1,0 @@
-Update parcel monorepo to v2.10.2

--- a/.changelog/996.internal.md
+++ b/.changelog/996.internal.md
@@ -1,1 +1,0 @@
-Update dependency @ethereumjs/util to v9.0.1

--- a/.changelog/998.internal.md
+++ b/.changelog/998.internal.md
@@ -1,1 +1,0 @@
-Update dependency storybook-addon-react-router-v6 to v2.0.9

--- a/.changelog/999.internal.md
+++ b/.changelog/999.internal.md
@@ -1,1 +1,0 @@
-Update dependency eslint to v8.53.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,205 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 1.4.0 (2023-12-14)
+
+### Features
+
+- Add NFT feature
+  ([#909](https://github.com/oasisprotocol/explorer/issues/909),
+  [#1036](https://github.com/oasisprotocol/explorer/issues/1036),
+  [#1038](https://github.com/oasisprotocol/explorer/issues/1038),
+  [#1043](https://github.com/oasisprotocol/explorer/issues/1043),
+  [#1051](https://github.com/oasisprotocol/explorer/issues/1051),
+  [#1052](https://github.com/oasisprotocol/explorer/issues/1052),
+  [#1069](https://github.com/oasisprotocol/explorer/issues/1069))
+
+- Show block-level evens in block details
+  ([#990](https://github.com/oasisprotocol/explorer/issues/990))
+
+- Show events on account details page
+  ([#992](https://github.com/oasisprotocol/explorer/issues/992))
+
+- Implement searching for blocks by hash
+  ([#1081](https://github.com/oasisprotocol/explorer/issues/1081))
+
+### Bug Fixes and Improvements
+
+- Prevent app crash when rendering new event types
+  ([#1012](https://github.com/oasisprotocol/explorer/issues/1012))
+
+- Fix address formatting on empty account
+  ([#1039](https://github.com/oasisprotocol/explorer/issues/1039),
+  [#1061](https://github.com/oasisprotocol/explorer/issues/1061))
+
+- Fix Testnet Faucet links
+  ([#1065](https://github.com/oasisprotocol/explorer/issues/1065))
+
+- Fetch account balance from RPC node
+  ([#1073](https://github.com/oasisprotocol/explorer/issues/1073))
+
+### Internal Changes
+
+- Add basic handling of new event types
+  ([#893](https://github.com/oasisprotocol/explorer/issues/893))
+
+- Install setuptools to make Towncrier fork work with Python 3.12
+  ([#980](https://github.com/oasisprotocol/explorer/issues/980))
+
+- Refactor code for showing events
+  ([#991](https://github.com/oasisprotocol/explorer/issues/991))
+
+- Don't directly include internal enum values in URLs
+  ([#1079](https://github.com/oasisprotocol/explorer/issues/1079))
+
+- Use Oasis bot token in renovate workflow
+  ([#1021](https://github.com/oasisprotocol/explorer/issues/1021))
+
+- Update API bindings
+  ([#1059](https://github.com/oasisprotocol/explorer/issues/1059),
+  [#1004](https://github.com/oasisprotocol/explorer/issues/1004),
+  [#948](https://github.com/oasisprotocol/explorer/issues/948),
+  [#977](https://github.com/oasisprotocol/explorer/issues/977),
+  [#1089](https://github.com/oasisprotocol/explorer/issues/1089))
+
+- Update lint dependencies
+  ([#972](https://github.com/oasisprotocol/explorer/issues/972),
+  [#986](https://github.com/oasisprotocol/explorer/issues/986),
+  [#1003](https://github.com/oasisprotocol/explorer/issues/1003),
+  [#1015](https://github.com/oasisprotocol/explorer/issues/1015),
+  [#1029](https://github.com/oasisprotocol/explorer/issues/1029),
+  [#1040](https://github.com/oasisprotocol/explorer/issues/1040),
+  [#1058](https://github.com/oasisprotocol/explorer/issues/1058),
+  [#1063](https://github.com/oasisprotocol/explorer/issues/1063),
+  [#1091](https://github.com/oasisprotocol/explorer/issues/1091),
+  [#1026](https://github.com/oasisprotocol/explorer/issues/1026),
+  [#999](https://github.com/oasisprotocol/explorer/issues/999))
+
+- Update material-ui monorepo
+  ([#974](https://github.com/oasisprotocol/explorer/issues/974),
+  [#1002](https://github.com/oasisprotocol/explorer/issues/1002),
+  [#1016](https://github.com/oasisprotocol/explorer/issues/1016),
+  [#1050](https://github.com/oasisprotocol/explorer/issues/1050),
+  [#1067](https://github.com/oasisprotocol/explorer/issues/1067),
+  [#1092](https://github.com/oasisprotocol/explorer/issues/1092))
+
+- Update swiper dependencies
+  ([#976](https://github.com/oasisprotocol/explorer/issues/976),
+  [#1010](https://github.com/oasisprotocol/explorer/issues/1010),
+  [#1034](https://github.com/oasisprotocol/explorer/issues/1034))
+
+- Update react dependencies
+  ([#982](https://github.com/oasisprotocol/explorer/issues/982),
+  [#1008](https://github.com/oasisprotocol/explorer/issues/1008),
+  [#1031](https://github.com/oasisprotocol/explorer/issues/1031),
+  [#1032](https://github.com/oasisprotocol/explorer/issues/1032),
+  [#1041](https://github.com/oasisprotocol/explorer/issues/1041),
+  [#1057](https://github.com/oasisprotocol/explorer/issues/1057))
+
+- Update recharts dependencies
+  ([#983](https://github.com/oasisprotocol/explorer/issues/983),
+  [#994](https://github.com/oasisprotocol/explorer/issues/994),
+  [#1005](https://github.com/oasisprotocol/explorer/issues/1005),
+  [#1027](https://github.com/oasisprotocol/explorer/issues/1027),
+  [#1047](https://github.com/oasisprotocol/explorer/issues/1047),
+  [#1055](https://github.com/oasisprotocol/explorer/issues/1055))
+
+- Update storybook dependencies
+  ([#984](https://github.com/oasisprotocol/explorer/issues/984),
+  [#1044](https://github.com/oasisprotocol/explorer/issues/1044),
+  [#1048](https://github.com/oasisprotocol/explorer/issues/1048),
+  [#1053](https://github.com/oasisprotocol/explorer/issues/1053),
+  [#1056](https://github.com/oasisprotocol/explorer/issues/1056),
+  [#1078](https://github.com/oasisprotocol/explorer/issues/1078),
+  [#998](https://github.com/oasisprotocol/explorer/issues/998),
+  [#1017](https://github.com/oasisprotocol/explorer/issues/1017))
+
+- Update i18next dependencies
+  ([#1013](https://github.com/oasisprotocol/explorer/issues/1013),
+  [#1022](https://github.com/oasisprotocol/explorer/issues/1022),
+  [#1045](https://github.com/oasisprotocol/explorer/issues/1045),
+  [#1076](https://github.com/oasisprotocol/explorer/issues/1076),
+  [#1093](https://github.com/oasisprotocol/explorer/issues/1093),
+  [#1014](https://github.com/oasisprotocol/explorer/issues/1014))
+
+- Update test dependencies
+  ([#1025](https://github.com/oasisprotocol/explorer/issues/1025),
+  [#1030](https://github.com/oasisprotocol/explorer/issues/1030),
+  [#1046](https://github.com/oasisprotocol/explorer/issues/1046),
+  [#1054](https://github.com/oasisprotocol/explorer/issues/1054),
+  [#1024](https://github.com/oasisprotocol/explorer/issues/1024))
+
+- Update TypeScript type definitions
+  ([#981](https://github.com/oasisprotocol/explorer/issues/981),
+  [#987](https://github.com/oasisprotocol/explorer/issues/987),
+  [#1001](https://github.com/oasisprotocol/explorer/issues/1001),
+  [#1007](https://github.com/oasisprotocol/explorer/issues/1007),
+  [#1000](https://github.com/oasisprotocol/explorer/issues/1000),
+  [#1033](https://github.com/oasisprotocol/explorer/issues/1033),
+  [#1064](https://github.com/oasisprotocol/explorer/issues/1064),
+  [#1068](https://github.com/oasisprotocol/explorer/issues/1068),
+  [#1087](https://github.com/oasisprotocol/explorer/issues/1087),
+  [#1094](https://github.com/oasisprotocol/explorer/issues/1094))
+
+- Update axios dependencies
+  ([#1009](https://github.com/oasisprotocol/explorer/issues/1009),
+  [#985](https://github.com/oasisprotocol/explorer/issues/985),
+  [#1019](https://github.com/oasisprotocol/explorer/issues/1019))
+
+- Update fontsource monorepo
+  ([#968](https://github.com/oasisprotocol/explorer/issues/968),
+  [#1074](https://github.com/oasisprotocol/explorer/issues/1074))
+
+- Update Node.js to v20
+  ([#973](https://github.com/oasisprotocol/explorer/issues/973))
+
+- Update actions/setup-node action to v4
+  ([#971](https://github.com/oasisprotocol/explorer/issues/971))
+
+- Update parcel monorepo
+  ([#975](https://github.com/oasisprotocol/explorer/issues/975),
+  [#995](https://github.com/oasisprotocol/explorer/issues/995),
+  [#1020](https://github.com/oasisprotocol/explorer/issues/1020))
+
+- Update dependency @ethereumjs/util to v9.0.1
+  ([#996](https://github.com/oasisprotocol/explorer/issues/996))
+
+- Update dependency orval to ^6.20.0
+  ([#1011](https://github.com/oasisprotocol/explorer/issues/1011))
+
+- Update dependency react-router-dom to v6.19.0
+  ([#1023](https://github.com/oasisprotocol/explorer/issues/1023))
+
+- Update dependency typescript to v5.3.2
+  ([#1028](https://github.com/oasisprotocol/explorer/issues/1028))
+
+- Update dependency orval to ^6.21.0
+  ([#1042](https://github.com/oasisprotocol/explorer/issues/1042))
+
+- Update actions/setup-python action to v5
+  ([#1072](https://github.com/oasisprotocol/explorer/issues/1072))
+
+- Update dependency typescript to v5.3.3
+  ([#1075](https://github.com/oasisprotocol/explorer/issues/1075))
+
+- Update dependency @oasisprotocol/client to v1
+  ([#1083](https://github.com/oasisprotocol/explorer/issues/1083))
+
+- Update dependency @oasisprotocol/client-rt to v1
+  ([#1084](https://github.com/oasisprotocol/explorer/issues/1084))
+
+- Update dependency markdownlint-cli to v0.38.0
+  ([#1086](https://github.com/oasisprotocol/explorer/issues/1086))
+
+- Update dependency prettier to v3.1.1
+  ([#1088](https://github.com/oasisprotocol/explorer/issues/1088))
+
+- Update critical dependency @babel/traverse to v7.23.6
+  ([#1090](https://github.com/oasisprotocol/explorer/issues/1090))
+
+- Add CODEOWNERS
+  ([#1095](https://github.com/oasisprotocol/explorer/issues/1095))
+
 ## 1.3.0 (2023-10-23)
 
 ### Features
@@ -37,11 +236,11 @@ The format is inspired by [Keep a Changelog].
 
 - Update material-ui monorepo
   ([#867](https://github.com/oasisprotocol/explorer/issues/867),
-   [#875](https://github.com/oasisprotocol/explorer/issues/875),
-   [#895](https://github.com/oasisprotocol/explorer/issues/895),
-   [#927](https://github.com/oasisprotocol/explorer/issues/927),
-   [#936](https://github.com/oasisprotocol/explorer/issues/936),
-   [#952](https://github.com/oasisprotocol/explorer/issues/952))
+  [#875](https://github.com/oasisprotocol/explorer/issues/875),
+  [#895](https://github.com/oasisprotocol/explorer/issues/895),
+  [#927](https://github.com/oasisprotocol/explorer/issues/927),
+  [#936](https://github.com/oasisprotocol/explorer/issues/936),
+  [#952](https://github.com/oasisprotocol/explorer/issues/952))
 
 - Update dependency react-router-dom to v6.16.0
   ([#868](https://github.com/oasisprotocol/explorer/issues/868))
@@ -60,17 +259,17 @@ The format is inspired by [Keep a Changelog].
 
 - Update storybook dependencies
   ([#873](https://github.com/oasisprotocol/explorer/issues/873),
-   [#951](https://github.com/oasisprotocol/explorer/issues/951))
+  [#951](https://github.com/oasisprotocol/explorer/issues/951))
 
 - Update test dependencies
   ([#874](https://github.com/oasisprotocol/explorer/issues/874))
 
 - Update react dependencies
   ([#876](https://github.com/oasisprotocol/explorer/issues/876),
-   [#926](https://github.com/oasisprotocol/explorer/issues/926),
-   [#931](https://github.com/oasisprotocol/explorer/issues/931),
-   [#935](https://github.com/oasisprotocol/explorer/issues/935),
-   [#937](https://github.com/oasisprotocol/explorer/issues/937))
+  [#926](https://github.com/oasisprotocol/explorer/issues/926),
+  [#931](https://github.com/oasisprotocol/explorer/issues/931),
+  [#935](https://github.com/oasisprotocol/explorer/issues/935),
+  [#937](https://github.com/oasisprotocol/explorer/issues/937))
 
 - Update lint dependencies to v6.7.2
   ([#877](https://github.com/oasisprotocol/explorer/issues/877))
@@ -140,8 +339,8 @@ The format is inspired by [Keep a Changelog].
 
 - Update fontsource monorepo
   ([#923](https://github.com/oasisprotocol/explorer/issues/923),
-   [#932](https://github.com/oasisprotocol/explorer/issues/932),
-   [#962](https://github.com/oasisprotocol/explorer/issues/962))
+  [#932](https://github.com/oasisprotocol/explorer/issues/932),
+  [#962](https://github.com/oasisprotocol/explorer/issues/962))
 
 - Update storybook dependencies to v7.4.6
   ([#924](https://github.com/oasisprotocol/explorer/issues/924))
@@ -298,12 +497,11 @@ The format is inspired by [Keep a Changelog].
 
 - Fix charts by syncing with the latest tx_volume stats API changes
   ([#812](https://github.com/oasisprotocol/explorer/issues/812))
-  
 - Homepage fixes
   ([#754](https://github.com/oasisprotocol/explorer/issues/754),
-   [#759](https://github.com/oasisprotocol/explorer/issues/759),
-   [#752](https://github.com/oasisprotocol/explorer/issues/752),
-   [#758](https://github.com/oasisprotocol/explorer/issues/758))
+  [#759](https://github.com/oasisprotocol/explorer/issues/759),
+  [#752](https://github.com/oasisprotocol/explorer/issues/752),
+  [#758](https://github.com/oasisprotocol/explorer/issues/758))
 
 - Fix alignment of fiat value tooltip in Account details
   ([#753](https://github.com/oasisprotocol/explorer/issues/753))
@@ -328,12 +526,11 @@ The format is inspired by [Keep a Changelog].
 
 - When listing token balances, use locally available data
   ([#762](https://github.com/oasisprotocol/explorer/issues/762))
-  
+
 ### Internal Changes
 
 - Handle Renovate default commitMessageExtra description
   ([#767](https://github.com/oasisprotocol/explorer/issues/767))
-  
 - Follow Nexus API changes
   ([#737](https://github.com/oasisprotocol/explorer/issues/737))
 
@@ -362,7 +559,6 @@ The format is inspired by [Keep a Changelog].
 
 - Fix variable names in useRuntimeFreshness
   ([#811](https://github.com/oasisprotocol/explorer/issues/811))
-  
 - Update storybook dependencies to v7.3.2
   ([#749](https://github.com/oasisprotocol/explorer/issues/749))
 
@@ -371,9 +567,9 @@ The format is inspired by [Keep a Changelog].
 
 - Update material-ui monorepo
   ([#757](https://github.com/oasisprotocol/explorer/issues/757),
-   [#783](https://github.com/oasisprotocol/explorer/issues/783),
-   [#795](https://github.com/oasisprotocol/explorer/issues/795),
-   [#840](https://github.com/oasisprotocol/explorer/issues/840))
+  [#783](https://github.com/oasisprotocol/explorer/issues/783),
+  [#795](https://github.com/oasisprotocol/explorer/issues/795),
+  [#840](https://github.com/oasisprotocol/explorer/issues/840))
 
 - Update dependency @types/node to v18.17.0
   ([#763](https://github.com/oasisprotocol/explorer/issues/763))
@@ -381,7 +577,7 @@ The format is inspired by [Keep a Changelog].
 - Update lint dependencies to v6.2.0
   ([#764](https://github.com/oasisprotocol/explorer/issues/764))
 
-- Update dependency @types/testing-library__jest-dom to v5.14.9
+- Update dependency @types/testing-library\_\_jest-dom to v5.14.9
   ([#765](https://github.com/oasisprotocol/explorer/issues/765))
 
 - Update dependency @mui/material to v5.14.2
@@ -422,7 +618,7 @@ The format is inspired by [Keep a Changelog].
 
 - Update lint dependencies
   ([#786](https://github.com/oasisprotocol/explorer/issues/786),
-   [#794](https://github.com/oasisprotocol/explorer/issues/794))
+  [#794](https://github.com/oasisprotocol/explorer/issues/794))
 
 - Update fontsource monorepo to ^5.0.8
   ([#788](https://github.com/oasisprotocol/explorer/issues/788))
@@ -441,7 +637,7 @@ The format is inspired by [Keep a Changelog].
 
 - Update i18n dependencies
   ([#793](https://github.com/oasisprotocol/explorer/issues/793),
-   [#817](https://github.com/oasisprotocol/explorer/issues/817))
+  [#817](https://github.com/oasisprotocol/explorer/issues/817))
 
 - Update dependency recharts to v2.7.3
   ([#801](https://github.com/oasisprotocol/explorer/issues/801))
@@ -651,7 +847,7 @@ The format is inspired by [Keep a Changelog].
 - Remove "Decoded" column from events to improve mobile layout
   ([#672](https://github.com/oasisprotocol/explorer/issues/672))
 
-- Update dependency @types/testing-library__jest-dom to v5.14.7
+- Update dependency @types/testing-library\_\_jest-dom to v5.14.7
   ([#673](https://github.com/oasisprotocol/explorer/issues/673))
 
 - Pull the API specs directly from GitHub
@@ -687,7 +883,7 @@ The format is inspired by [Keep a Changelog].
 - Fix changelog fragment file name
   ([#714](https://github.com/oasisprotocol/explorer/issues/714))
 
-- Update dependency @types/testing-library__jest-dom to v5.14.8
+- Update dependency @types/testing-library\_\_jest-dom to v5.14.8
   ([#717](https://github.com/oasisprotocol/explorer/issues/717))
 
 - Update material-ui monorepo

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lukaw3d/parcel-bundler-json-schemas/main/package_schema.json",
   "name": "@oasisprotocol/explorer-frontend",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
To fully support NFTs we need to wait for reindexing, but based on Product meeting we want to deploy the latest code this sprint.  