### PR TITLE
Handle missing data when displaying token transfers

### DIFF
--- a/.changelog/1126.bugfix.md
+++ b/.changelog/1126.bugfix.md
@@ -1,0 +1,1 @@
+Handle missing data when displaying token transfers

--- a/src/app/components/Tokens/TokenTransfers.tsx
+++ b/src/app/components/Tokens/TokenTransfers.tsx
@@ -217,7 +217,11 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
           ? [
               {
                 key: 'tokenType',
-                content: <TokenTypeTag tokenType={transfer.evm_token!.type} />,
+                content: transfer.evm_token ? (
+                  <TokenTypeTag tokenType={transfer.evm_token.type} />
+                ) : (
+                  t('common.missing')
+                ),
                 align: TableCellAlign.Center,
               },
             ]


### PR DESCRIPTION
Usually we have data about the token, but not always.