### PR TITLE
Enable Consensus routing

### DIFF
--- a/.changelog/1129.trivial.md
+++ b/.changelog/1129.trivial.md
@@ -1,0 +1,1 @@
+Enable Consensus routing

--- a/src/app/hooks/useScopeParam.ts
+++ b/src/app/hooks/useScopeParam.ts
@@ -1,4 +1,4 @@
-import { useParams, useRouteError } from 'react-router-dom'
+import { useRouteLoaderData, useParams, useRouteError } from 'react-router-dom'
 import { Network } from '../../types/network'
 import { RouteUtils } from '../utils/route-utils'
 import { AppError, AppErrors } from '../../types/errors'
@@ -14,14 +14,23 @@ type ScopeInfo = SearchScope & {
   valid: boolean
 }
 
+type Scope = {
+  layer: Layer | undefined
+  network: Network | undefined
+}
+
 /**
  * Use this in situations where we might or might not have a scope
  */
 export const useScopeParam = (): ScopeInfo | undefined => {
-  const { network, layer } = useParams()
+  const runtimeScope = useRouteLoaderData('runtimeScope') as Scope
+  const consensusScope = useRouteLoaderData('consensusScope') as Scope
+  const loaderData = runtimeScope || consensusScope
   const error = useRouteError()
 
-  if (network === undefined && layer === undefined) return undefined
+  if (loaderData?.network === undefined && loaderData?.layer === undefined) return undefined
+
+  const { network, layer } = loaderData
 
   const scope: ScopeInfo = {
     network: network as Network,

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -176,7 +176,22 @@ export const transactionParamLoader = async ({ params }: LoaderFunctionArgs) => 
   return validateTxHashParam(params.hash!)
 }
 
-export const scopeLoader = async (args: LoaderFunctionArgs) => {
+export const scopeConsensusLoader = async (args: LoaderFunctionArgs) => {
+  const {
+    params: { network },
+  } = args
+
+  if (!network || !RouteUtils.getEnabledNetworks().includes(network as Network)) {
+    throw new AppError(AppErrors.InvalidUrl)
+  }
+
+  return {
+    network: network as Network,
+    layer: Layer.consensus,
+  }
+}
+
+export const scopeRuntimeLoader = async (args: LoaderFunctionArgs) => {
   const {
     params: { network, layer },
   } = args
@@ -192,5 +207,8 @@ export const scopeLoader = async (args: LoaderFunctionArgs) => {
     throw new AppError(AppErrors.UnsupportedLayer)
   }
 
-  return true
+  return {
+    network: network as Network,
+    layer: layer as Layer,
+  }
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,7 +13,8 @@ import {
   addressParamLoader,
   blockHeightParamLoader,
   transactionParamLoader,
-  scopeLoader,
+  scopeConsensusLoader,
+  scopeRuntimeLoader,
 } from './app/utils/route-utils'
 import { searchParamLoader } from './app/components/Search/search-utils'
 import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
@@ -29,6 +30,7 @@ import { TokenHoldersCard } from './app/pages/TokenDashboardPage/TokenHoldersCar
 import { TokenInventoryCard } from './app/pages/TokenDashboardPage/TokenInventoryCard'
 import { NFTInstanceDashboardPage, useNftDetailsProps } from './app/pages/NFTInstanceDashboardPage'
 import { NFTMetadataCard } from './app/pages/NFTInstanceDashboardPage/NFTMetadataCard'
+import { ConsensusDashboardPage } from 'app/pages/ConsensusDashboardPage'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -56,10 +58,24 @@ export const routes: RouteObject[] = [
         loader: searchParamLoader,
       },
       {
+        path: '/:network/consensus',
+        element: <NetworkSpecificPart />,
+        errorElement: withDefaultTheme(<RoutingErrorPage />),
+        loader: scopeConsensusLoader,
+        id: 'consensusScope',
+        children: [
+          {
+            path: '',
+            element: <ConsensusDashboardPage />,
+          },
+        ],
+      },
+      {
         path: '/:network/:layer',
         element: <NetworkSpecificPart />,
         errorElement: withDefaultTheme(<RoutingErrorPage />),
-        loader: scopeLoader,
+        loader: scopeRuntimeLoader,
+        id: 'runtimeScope',
         children: [
           {
             path: '',


### PR DESCRIPTION
Consensus mockups don't match most of our ParaTimes views so we prob need to setup separated views. To discuss how we want to handle routes

here we can keep dynamic segments for ParaTimes and we will be able to add specific Consensus (static segment) routes

```
          {
            path: 'consensus',
            errorElement: withDefaultTheme(<RoutingErrorPage />),
            loader: scopeLoader,
            children: [
              {
                path: '',
                element: <ConsensusDashboardPage />,
              },
            ],
          },
          // our current runtimes paths
```
Will match backend design (consensus - runtimes separation) more. We keep current Paratimes as is. ~W can rename some stuff like :layer to :runtime if we go with splats.~

possible routing options:
- dynamic segments for ParaTimes static for Consensus
- dynamic segments only 
- static segments
- (breaking change) re-define routes hierarchy (mainnet/runtime/:layer, mainnet/consensus) 



