### PR TITLE
Prepare layout components for Consensus

### DIFF
--- a/.changelog/1133.trivial.md
+++ b/.changelog/1133.trivial.md
@@ -1,0 +1,1 @@
+Prepare layout components for Consensus

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -20,6 +20,13 @@ export type FreshnessInfo = {
   lastUpdate?: string
 }
 
+export const useConsensusFreshness = () => {
+  // TODO: Placeholder for consensus freshness checks
+  return {
+    outOfDate: false,
+  }
+}
+
 export const useRuntimeFreshness = (scope: SearchScope): FreshnessInfo => {
   const isApiReachable = useIsApiReachable(scope.network).reachable
   if (scope.layer === Layer.consensus) {

--- a/src/app/components/PageLayout/index.tsx
+++ b/src/app/components/PageLayout/index.tsx
@@ -10,6 +10,7 @@ import { NetworkOfflineBanner, RuntimeOfflineBanner } from '../OfflineBanner'
 import { Search } from '../Search'
 import { useIsApiReachable } from '../OfflineBanner/hook'
 import { Network } from '../../../types/network'
+import { Layer } from '../../../oasis-nexus/api'
 
 interface PageLayoutProps {
   mobileFooterAction?: ReactNode
@@ -29,7 +30,7 @@ export const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({ children, m
     <>
       <BuildBanner />
       <NetworkOfflineBanner />
-      {scope?.valid && <RuntimeOfflineBanner />}
+      {scope?.valid && scope.layer !== Layer.consensus && <RuntimeOfflineBanner />}
       <Box
         sx={{
           minHeight: '100vh',

--- a/src/app/components/ParaTimePicker/LayerDetails.tsx
+++ b/src/app/components/ParaTimePicker/LayerDetails.tsx
@@ -88,12 +88,32 @@ type LayerDetailsProps = {
   handleConfirm: () => void
   network: Network
   selectedLayer: Layer
+  isOutOfDate: boolean | undefined
 }
 
 // Prevent modal height from changing height when switching between layers
 const contentMinHeight = '270px'
 
-export const LayerDetails: FC<LayerDetailsProps> = ({ handleConfirm, network, selectedLayer }) => {
+export const LayerDetails: FC<LayerDetailsProps> = (props: LayerDetailsProps) =>
+  props.selectedLayer === Layer.consensus ? <ConsensusDetails /> : <RuntimeDetails {...props} />
+
+// TODO: Placeholder for Consensus LayerDetailsView
+const ConsensusDetails = () => {
+  return <></>
+}
+
+const RuntimeDetails: FC<LayerDetailsProps> = props => {
+  const { network, selectedLayer: layer } = props
+  const isOutOfDate = useRuntimeFreshness({ network, layer }).outOfDate
+  return <LayerDetailsView {...props} isOutOfDate={isOutOfDate} />
+}
+
+export const LayerDetailsView: FC<LayerDetailsProps> = ({
+  handleConfirm,
+  isOutOfDate,
+  network,
+  selectedLayer,
+}) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const { isMobile, isTablet } = useScreenSize()
@@ -101,7 +121,6 @@ export const LayerDetails: FC<LayerDetailsProps> = ({ handleConfirm, network, se
   const layerLabels = getLayerLabels(t)
   const icons = getNetworkIcons()
   const layer = selectedLayer
-  const isOutOfDate = useRuntimeFreshness({ network, layer: selectedLayer }).outOfDate
   const details = getDetails(t)[network][layer]
 
   if (!details) {

--- a/src/app/components/ParaTimePicker/index.tsx
+++ b/src/app/components/ParaTimePicker/index.tsx
@@ -18,17 +18,17 @@ import { styled } from '@mui/material/styles'
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { MobileNetworkButton } from '../PageLayout/NetworkButton'
-import { useRuntimeFreshness } from '../OfflineBanner/hook'
 
 type ParaTimePickerProps = {
   onClose: () => void
   onConfirm: (network: Network, layer: Layer) => void
   open: boolean
+  isOutOfDate: boolean | undefined
 }
 
-export const ParaTimePicker: FC<ParaTimePickerProps> = ({ onClose, onConfirm, open }) => (
+export const ParaTimePicker: FC<ParaTimePickerProps> = ({ onClose, onConfirm, open, isOutOfDate }) => (
   <Drawer anchor="top" open={open} onClose={onClose}>
-    <ParaTimePickerContent onClose={onClose} onConfirm={onConfirm} />
+    <ParaTimePickerContent onClose={onClose} onConfirm={onConfirm} isOutOfDate={isOutOfDate} />
   </Drawer>
 )
 
@@ -81,7 +81,7 @@ enum ParaTimePickerTabletStep {
   ParaTimeDetails,
 }
 
-const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ onClose, onConfirm }) => {
+const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ isOutOfDate, onClose, onConfirm }) => {
   const { isMobile, isTablet } = useScreenSize()
   const { t } = useTranslation()
   const { network, layer } = useRequiredScopeParam()
@@ -95,7 +95,6 @@ const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ onClose, onConf
     setSelectedLayer(RouteUtils.getEnabledLayersForNetwork(newNetwork)[0])
   }
   const handleConfirm = () => onConfirm(selectedNetwork, selectedLayer)
-  const { outOfDate } = useRuntimeFreshness({ network, layer })
 
   return (
     <StyledParaTimePickerContent>
@@ -129,7 +128,7 @@ const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ onClose, onConf
             )}
           </div>
           <MobileNetworkButton
-            isOutOfDate={outOfDate}
+            isOutOfDate={isOutOfDate}
             network={network}
             layer={layer}
             onClick={handleConfirm}
@@ -171,6 +170,7 @@ const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ onClose, onConf
                 handleConfirm={handleConfirm}
                 selectedLayer={selectedLayer}
                 network={selectedNetwork}
+                isOutOfDate={isOutOfDate}
               />
             </Grid>
           )}


### PR DESCRIPTION
Currently Consensus work is blocked because layout is bound to `useRuntimeFreshness` hook.