### PR TITLE
Enable Consensus layer conditionally

### DIFF
--- a/.changelog/1138.trivial.md
+++ b/.changelog/1138.trivial.md
@@ -1,0 +1,1 @@
+Enable Consensus layer conditionally

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -8,7 +8,7 @@ import {
   getEvmBech32Address,
 } from '../../utils/helpers'
 import { Network } from '../../../types/network'
-import { RouteUtils, SpecifiedPerEnabledLayer } from '../../utils/route-utils'
+import { RouteUtils, SpecifiedPerEnabledRuntime } from '../../utils/route-utils'
 import { AppError, AppErrors } from '../../../types/errors'
 import { Layer } from '../../../oasis-nexus/api'
 
@@ -48,7 +48,7 @@ export const searchSuggestionTerms: Record<Network, Partial<Record<Layer, LayerS
       suggestedTokenFragment: 'USD',
     },
   },
-} satisfies SpecifiedPerEnabledLayer
+} satisfies SpecifiedPerEnabledRuntime
 
 export const textSearchMininumLength = 3
 

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -15,7 +15,7 @@ import { docs } from '../../utils/externalLinks'
 import { Layer } from '../../../oasis-nexus/api'
 import { getLayerLabels } from '../../utils/content'
 import { Network } from '../../../types/network'
-import { SpecifiedPerEnabledLayer } from '../../utils/route-utils'
+import { SpecifiedPerEnabledRuntime } from '../../utils/route-utils'
 import { SearchScope } from '../../../types/searchScope'
 
 const StyledLink = styled(Link)(() => ({
@@ -121,7 +121,7 @@ const getContent = (t: TFunction): Record<Network, NetworkContent> => {
         },
       },
     },
-  } satisfies SpecifiedPerEnabledLayer
+  } satisfies SpecifiedPerEnabledRuntime
 }
 
 type LearningSectionProps = PaperProps & {

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,3 +123,5 @@ export const deploys = {
   staging: 'https://explorer.stg.oasis.io',
   localhost: 'http://localhost:1234',
 }
+
+export const stableDeploys = [...deploys.production, deploys.staging]


### PR DESCRIPTION
- make Consensus layer enabled for non prod envs to unblock dev and access stage previews 
- (not sure about this) split between ENABLED_RUNTIMES and _CONSENSUS for now as we don't want to provide search suggestions and we will need Consensus specific components like ConsensusLearningMaterial

to make Consensus rendering happy we will need (https://github.com/oasisprotocol/explorer/pull/1133, and  routing changes for example https://github.com/oasisprotocol/explorer/pull/1129)