### PR TITLE
Support recovering from invalid URLs using search

### DIFF
--- a/.changelog/1145.bugfix.md
+++ b/.changelog/1145.bugfix.md
@@ -1,0 +1,1 @@
+Handle URLs with invalid networks

--- a/.changelog/1146.bugfix.md
+++ b/.changelog/1146.bugfix.md
@@ -1,0 +1,1 @@
+Support recovering from invalid URLs using search

--- a/src/app/components/AppendMobileSearch/index.tsx
+++ b/src/app/components/AppendMobileSearch/index.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles'
 import Box from '@mui/material/Box'
 import { Search } from '../Search'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 
 interface AppendMobileSearchProps {
   action?: ReactNode
@@ -37,11 +37,9 @@ const SearchWrapper = styled(Box)(() => ({
   marginLeft: 'auto',
 }))
 
-export const AppendMobileSearch: FC<PropsWithChildren<AppendMobileSearchProps> & { scope?: SearchScope }> = ({
-  scope,
-  children,
-  action,
-}) => {
+export const AppendMobileSearch: FC<
+  PropsWithChildren<AppendMobileSearchProps> & { scope?: SearchScopeCandidate }
+> = ({ scope, children, action }) => {
   const { isMobile } = useScreenSize()
 
   return (

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -8,7 +8,7 @@ import Link from '@mui/material/Link'
 import { useTheme } from '@mui/material/styles'
 import { useConstant } from '../../hooks/useConstant'
 import { AppendMobileSearch } from '../AppendMobileSearch'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 import { api, github } from '../../utils/externalLinks'
 
 const FooterBox = styled(Box)(({ theme }) => ({
@@ -36,7 +36,7 @@ const StyledLinksGroup = styled(Box)(({ theme }) => ({
 }))
 
 interface FooterProps {
-  scope?: SearchScope
+  scope?: SearchScopeCandidate
   mobileSearchAction?: ReactNode
 }
 

--- a/src/app/components/PageLayout/index.tsx
+++ b/src/app/components/PageLayout/index.tsx
@@ -23,12 +23,14 @@ export const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({ children, m
   const theme = useTheme()
   const { isMobile, isTablet } = useScreenSize()
   const scope = useScopeParam()
-  const isApiReachable = useIsApiReachable(scope?.network || Network.mainnet).reachable
+  const isApiReachable = useIsApiReachable(
+    scope?.valid && scope.network ? scope?.network : Network.mainnet,
+  ).reachable
 
   return (
     <>
       <BuildBanner />
-      <NetworkOfflineBanner />
+      {scope?.valid && <NetworkOfflineBanner />}
       {scope?.valid && <RuntimeOfflineBanner />}
       <Box
         sx={{

--- a/src/app/components/Search/SearchSuggestionsButtons.tsx
+++ b/src/app/components/Search/SearchSuggestionsButtons.tsx
@@ -10,7 +10,7 @@ import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet'
 import TokenIcon from '@mui/icons-material/Token'
 import { searchSuggestionTerms } from './search-utils'
 import { OptionalBreak } from '../OptionalBreak'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 
 const PlainTextButton = styled(Button)({
   fontSize: 'inherit',
@@ -30,14 +30,17 @@ export const SuggestionButton = styled(PlainTextButton)({
 })
 
 interface Props {
-  scope: SearchScope | undefined
+  scope: SearchScopeCandidate | undefined
   onClickSuggestion: (suggestion: string) => void
 }
 
 export const SearchSuggestionsButtons: FC<Props> = ({ scope, onClickSuggestion }) => {
   const { t } = useTranslation()
   const { suggestedBlock, suggestedTransaction, suggestedAccount, suggestedTokenFragment } =
-    (scope?.network && scope?.layer && searchSuggestionTerms[scope.network][scope.layer]) ??
+    (scope?.network &&
+      scope?.layer &&
+      (scope?.valid || undefined) &&
+      searchSuggestionTerms[scope.network][scope.layer]) ??
     searchSuggestionTerms['mainnet']['sapphire']!
 
   return (

--- a/src/app/components/Search/SearchSuggestionsLinksForNoResults.tsx
+++ b/src/app/components/Search/SearchSuggestionsLinksForNoResults.tsx
@@ -9,12 +9,12 @@ import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet'
 import TokenIcon from '@mui/icons-material/Token'
 import { RouteUtils } from '../../utils/route-utils'
 import { OptionalBreak } from '../OptionalBreak'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { SxProps } from '@mui/material/styles'
 
 interface Props {
-  scope: SearchScope | undefined
+  scope: SearchScopeCandidate | undefined
 }
 
 const iconSxProps: SxProps = {

--- a/src/app/components/Search/index.tsx
+++ b/src/app/components/Search/index.tsx
@@ -17,7 +17,7 @@ import IconButton from '@mui/material/IconButton'
 import { SearchSuggestionsButtons } from './SearchSuggestionsButtons'
 import { formHelperTextClasses } from '@mui/material/FormHelperText'
 import { outlinedInputClasses } from '@mui/material/OutlinedInput'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 import { textSearchMininumLength } from './search-utils'
 import Typography from '@mui/material/Typography'
 import { isValidBlockHeight } from '../../utils/helpers'
@@ -95,7 +95,7 @@ SearchButton.defaultProps = {
 }
 
 export interface SearchProps {
-  scope?: SearchScope
+  scope?: SearchScopeCandidate
   variant: SearchVariant
   disabled?: boolean
   onFocusChange?: (hasFocus: boolean) => void

--- a/src/app/hooks/useScopeParam.ts
+++ b/src/app/hooks/useScopeParam.ts
@@ -2,7 +2,7 @@ import { useParams, useRouteError } from 'react-router-dom'
 import { Network } from '../../types/network'
 import { RouteUtils } from '../utils/route-utils'
 import { AppError, AppErrors } from '../../types/errors'
-import { SearchScope } from '../../types/searchScope'
+import { SearchScopeCandidate } from '../../types/searchScope'
 import { Layer } from '../../oasis-nexus/api'
 
 export const useNetworkParam = (): Network | undefined => {
@@ -10,20 +10,16 @@ export const useNetworkParam = (): Network | undefined => {
   return network as Network | undefined
 }
 
-type ScopeInfo = SearchScope & {
-  valid: boolean
-}
-
 /**
  * Use this in situations where we might or might not have a scope
  */
-export const useScopeParam = (): ScopeInfo | undefined => {
+export const useScopeParam = (): SearchScopeCandidate | undefined => {
   const { network, layer } = useParams()
   const error = useRouteError()
 
   if (network === undefined && layer === undefined) return undefined
 
-  const scope: ScopeInfo = {
+  const scope: SearchScopeCandidate = {
     network: network as Network,
     layer: layer as Layer,
     valid: true,
@@ -42,7 +38,7 @@ export const useScopeParam = (): ScopeInfo | undefined => {
     if (!error) throw new AppError(AppErrors.UnsupportedNetwork)
   }
 
-  if (!RouteUtils.getEnabledLayersForNetwork(scope.network).includes(scope.layer)) {
+  if (scope.valid && !RouteUtils.getEnabledLayersForNetwork(scope.network).includes(scope.layer)) {
     scope.valid = false
     if (!error) throw new AppError(AppErrors.UnsupportedLayer)
   }
@@ -53,7 +49,7 @@ export const useScopeParam = (): ScopeInfo | undefined => {
 /**
  * Use this in situations where we require to have a scope
  */
-export const useRequiredScopeParam = (): ScopeInfo => {
+export const useRequiredScopeParam = (): SearchScopeCandidate => {
   const scope = useScopeParam()
 
   if (!scope) throw new AppError(AppErrors.UnsupportedNetwork)

--- a/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
@@ -17,13 +17,13 @@ import { AppendMobileSearch } from '../../components/AppendMobileSearch'
 import { Network } from '../../../types/network'
 import { getLayerNames } from '../../../types/layers'
 import { TestnetFaucet } from './TestnetFaucet'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 
 const StyledGrid = styled(Grid)(() => ({
   display: 'flex',
 }))
 
-export const ParaTimeSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const ParaTimeSnapshot: FC<{ scope: SearchScopeCandidate }> = ({ scope }) => {
   const { t } = useTranslation()
   const defaultChartDurationValue = useConstant<ChartDuration>(() => ChartDuration.TODAY)
   const [chartDuration, setChartDuration] = useState<ChartDuration>(defaultChartDurationValue)

--- a/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
@@ -36,7 +36,12 @@ export const GlobalSearchResultsView: FC<{ searchResults: SearchResults; tokenPr
 
   return (
     <>
-      {!mainnetResults.length && (otherResults.length ? <NoResultsOnMainnet /> : <NoResultsWhatsoever />)}
+      {!mainnetResults.length &&
+        (otherResults.length ? (
+          <NoResultsOnMainnet isScopeValid={true} />
+        ) : (
+          <NoResultsWhatsoever isScopeValid={true} />
+        ))}
       {
         <SearchResultsList
           key={Network.mainnet}

--- a/src/app/pages/SearchResultsPage/NoResults.tsx
+++ b/src/app/pages/SearchResultsPage/NoResults.tsx
@@ -7,14 +7,15 @@ import Link from '@mui/material/Link'
 import { SearchSuggestionsLinksForNoResults } from '../../components/Search/SearchSuggestionsLinksForNoResults'
 import { OptionalBreak } from '../../components/OptionalBreak'
 import { useTheme } from '@mui/material/styles'
-import { getNameForScope, SearchScope } from '../../../types/searchScope'
+import { getNameForScope, SearchScopeCandidate } from '../../../types/searchScope'
 import { getNetworkNames, Network } from '../../../types/network'
 import { Layer } from '../../../oasis-nexus/api'
 
 export const NoResults: FC<{
   network?: Network
   layer?: Layer
-}> = ({ network, layer }) => {
+  isScopeValid: boolean
+}> = ({ network, layer, isScopeValid }) => {
   const { t } = useTranslation()
   const theme = useTheme()
   const title = network
@@ -41,7 +42,9 @@ export const NoResults: FC<{
             />
           </p>
           <p>
-            <SearchSuggestionsLinksForNoResults scope={layer && network ? { network, layer } : undefined} />
+            <SearchSuggestionsLinksForNoResults
+              scope={layer && network ? { network, layer, valid: isScopeValid } : undefined}
+            />
           </p>
         </Box>
       }
@@ -49,11 +52,18 @@ export const NoResults: FC<{
   )
 }
 
-export const NoResultsWhatsoever: FC = () => <NoResults />
-export const NoResultsOnNetwork: FC<{ network: Network }> = ({ network }) => <NoResults network={network} />
+export const NoResultsWhatsoever: FC<{ isScopeValid: boolean }> = ({ isScopeValid }) => (
+  <NoResults isScopeValid={isScopeValid} />
+)
+export const NoResultsOnNetwork: FC<{ network: Network; isScopeValid: boolean }> = ({
+  network,
+  isScopeValid,
+}) => <NoResults network={network} isScopeValid={isScopeValid} />
 
-export const NoResultsOnMainnet: FC = () => <NoResultsOnNetwork network={Network.mainnet} />
+export const NoResultsOnMainnet: FC<{ isScopeValid: boolean }> = ({ isScopeValid }) => (
+  <NoResultsOnNetwork network={Network.mainnet} isScopeValid={isScopeValid} />
+)
 
-export const NoResultsInScope: FC<{ scope: SearchScope }> = ({ scope }) => (
-  <NoResults network={scope.network} layer={scope.layer} />
+export const NoResultsInScope: FC<{ scope: SearchScopeCandidate }> = ({ scope }) => (
+  <NoResults network={scope.network} layer={scope.layer} isScopeValid={scope.valid} />
 )

--- a/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
@@ -5,7 +5,7 @@ import {
   getFilterForScope,
   getNameForScope,
   getInverseFilterForScope,
-  SearchScope,
+  SearchScopeCandidate,
 } from '../../../types/searchScope'
 import { getThemesForNetworks } from '../../../styles/theme'
 import { RouteUtils } from '../../utils/route-utils'
@@ -17,7 +17,7 @@ import { HideMoreResults, ShowMoreResults } from './notifications'
 import { useRedirectIfSingleResult } from './useRedirectIfSingleResult'
 
 export const ScopedSearchResultsView: FC<{
-  wantedScope: SearchScope
+  wantedScope: SearchScopeCandidate
   searchResults: SearchResults
   tokenPrices: AllTokenPrices
 }> = ({ wantedScope, searchResults, tokenPrices }) => {

--- a/src/app/pages/SearchResultsPage/SearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsView.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import Divider from '@mui/material/Divider'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { TextSkeleton } from '../../components/Skeleton'
@@ -12,7 +12,7 @@ import { getFilterForLayer } from '../../../types/layers'
 import { useScreenSize } from '../../hooks/useScreensize'
 
 export const SearchResultsView: FC<{
-  wantedScope?: SearchScope
+  wantedScope?: SearchScopeCandidate
   searchResults: SearchResults
   isLoading: boolean
   tokenPrices: AllTokenPrices

--- a/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
@@ -11,12 +11,12 @@ import { TokenSupplyCard } from './TokenSupplyCard'
 import { TokenHoldersCountCard } from './TokenHoldersCountCard'
 import { TokenTypeCard } from './TokenTypeCard'
 import { TokenTotalTransactionsCard } from './TokenTotalTransactionsCard'
-import { SearchScope } from '../../../types/searchScope'
+import { SearchScopeCandidate } from '../../../types/searchScope'
 
 const StyledGrid = styled(Grid)(() => ({
   display: 'flex',
 }))
-export const TokenSnapshot: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenSnapshot: FC<{ scope: SearchScopeCandidate; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const theme = useTheme()

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -4,7 +4,7 @@ import { isValidBlockHeight, isValidOasisAddress, isValidEthAddress } from './he
 import { AppError, AppErrors } from '../../types/errors'
 import { EvmTokenType, Layer } from '../../oasis-nexus/api'
 import { Network } from '../../types/network'
-import { SearchScope } from '../../types/searchScope'
+import { SearchScope, SearchScopeCandidate } from '../../types/searchScope'
 
 export type SpecifiedPerEnabledLayer<T = any> = {
   [N in keyof (typeof RouteUtils)['ENABLED_LAYERS_FOR_NETWORK']]: {
@@ -73,8 +73,8 @@ export abstract class RouteUtils {
     return tokenAddress ? `${tokenRoutes}#${encodeURIComponent(tokenAddress)}` : tokenRoutes
   }
 
-  static getSearchRoute = (scope: SearchScope | undefined, searchTerm: string) => {
-    return scope
+  static getSearchRoute = (scope: SearchScopeCandidate | undefined, searchTerm: string) => {
+    return scope?.valid
       ? `/${scope.network}/${scope.layer}/search?q=${encodeURIComponent(searchTerm)}`
       : `/search?q=${encodeURIComponent(searchTerm)}`
   }

--- a/src/types/searchScope.ts
+++ b/src/types/searchScope.ts
@@ -8,6 +8,13 @@ export interface SearchScope {
   layer: Layer
 }
 
+/**
+ * Use this in situations where a proposed search scope might be invalid
+ */
+export type SearchScopeCandidate = SearchScope & {
+  valid: boolean
+}
+
 export const MainnetEmerald: SearchScope = {
   network: Network.mainnet,
   layer: Layer.emerald,


### PR DESCRIPTION
When launching a search from an invalid URL (like, invalid network or invalid layer), we should just jump to the global search page.

Implemented on top of #1145.