### PR TITLE
Handle NFT image loading errors

### DIFF
--- a/.changelog/1147.bugfix.md
+++ b/.changelog/1147.bugfix.md
@@ -1,0 +1,1 @@
+Handle NFT image loading errors

--- a/src/app/components/ImagePreview/index.tsx
+++ b/src/app/components/ImagePreview/index.tsx
@@ -32,6 +32,7 @@ const StyledImage = styled('img')({
 type ImagePreviewProps = {
   handlePreviewClose: () => void
   handlePreviewOpen: () => void
+  onError: () => void
   previewOpen: boolean
   src: string
   title: string | undefined
@@ -41,6 +42,7 @@ type ImagePreviewProps = {
 export const ImagePreview: FC<ImagePreviewProps> = ({
   handlePreviewClose,
   handlePreviewOpen,
+  onError,
   previewOpen,
   src,
   title,
@@ -53,7 +55,7 @@ export const ImagePreview: FC<ImagePreviewProps> = ({
     <>
       <Box>
         <StyledButton onClick={handlePreviewOpen}>
-          <StyledThumbnail src={src} alt={label} maxThumbnailSize={maxThumbnailSize} />
+          <StyledThumbnail onError={onError} src={src} alt={label} maxThumbnailSize={maxThumbnailSize} />
         </StyledButton>
       </Box>
       <Modal

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
@@ -5,6 +5,7 @@ import { Button } from '@mui/base/Button'
 import CardContent from '@mui/material/CardContent'
 import Card from '@mui/material/Card'
 import ContrastIcon from '@mui/icons-material/Contrast'
+import Link from '@mui/material/Link'
 import Skeleton from '@mui/material/Skeleton'
 import Tooltip from '@mui/material/Tooltip'
 import OpenInFullIcon from '@mui/icons-material/OpenInFull'
@@ -73,10 +74,12 @@ type InstanceImageCardProps = {
 }
 
 export const InstanceImageCard: FC<InstanceImageCardProps> = ({ isFetched, isLoading, nft }) => {
+  const { t } = useTranslation()
   const [darkMode, setDarkMode] = useState(false)
   const [previewOpen, setPreviewOpen] = useState(false)
   const handlePreviewOpen = () => setPreviewOpen(true)
   const handlePreviewClose = () => setPreviewOpen(false)
+  const [imageLoadError, setImageLoadError] = useState(false)
 
   return (
     <Card
@@ -91,11 +94,30 @@ export const InstanceImageCard: FC<InstanceImageCardProps> = ({ isFetched, isLoa
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
+            justifyContent: 'space-between',
+            minHeight: imageSize,
           }}
         >
           {isLoading && <Skeleton variant="rectangular" width={imageSize} height={imageSize} />}
-          {isFetched && nft && !isNftImageUrlValid(nft.image) && <NoPreview placeholderSize={imageSize} />}
-          {isFetched && nft && isNftImageUrlValid(nft.image) && (
+          {isFetched && nft && imageLoadError && (
+            <Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <NoPreview placeholderSize={imageSize} />
+                {isNftImageUrlValid(nft.image) && (
+                  <Link href={nft.image} rel="noopener noreferrer" target="_blank">
+                    {t('nft.openInNewTab')}
+                  </Link>
+                )}
+              </Box>
+            </Box>
+          )}
+          {isFetched && nft && isNftImageUrlValid(nft.image) && !imageLoadError && (
             <>
               <Box
                 sx={{
@@ -109,6 +131,7 @@ export const InstanceImageCard: FC<InstanceImageCardProps> = ({ isFetched, isLoa
                   handlePreviewOpen={handlePreviewOpen}
                   previewOpen={previewOpen}
                   src={processNftImageUrl(nft.image)}
+                  onError={() => setImageLoadError(true)}
                   title={nft.name}
                   maxThumbnailSize={imageSize}
                 />

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
@@ -99,7 +99,10 @@ export const InstanceImageCard: FC<InstanceImageCardProps> = ({ isFetched, isLoa
           }}
         >
           {isLoading && <Skeleton variant="rectangular" width={imageSize} height={imageSize} />}
-          {isFetched && nft && imageLoadError && (
+          {/* API did not process NFT data fully */}
+          {isFetched && !nft?.image && <NoPreview placeholderSize={imageSize} />}
+          {/* API processed NFT data, but image prop is not valid image source */}
+          {isFetched && nft?.image && imageLoadError && (
             <Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>
               <Box
                 sx={{

--- a/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
+++ b/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import Box from '@mui/material/Box'
@@ -57,11 +57,13 @@ type ImageListItemImageProps = {
 export const ImageListItemImage: FC<ImageListItemImageProps> = ({ instance, to }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
+  const [imageLoadError, setImageLoadError] = useState(false)
 
   return (
     <Link component={RouterLink} to={to} sx={{ display: 'flex', position: 'relative' }}>
-      {isNftImageUrlValid(instance.image) ? (
+      {isNftImageUrlValid(instance.image) && !imageLoadError ? (
         <StyledImage
+          onError={() => setImageLoadError(true)}
           src={processNftImageUrl(instance.image)}
           alt={getNftInstanceLabel(instance)}
           loading="lazy"

--- a/src/app/utils/nft-images.ts
+++ b/src/app/utils/nft-images.ts
@@ -1,7 +1,7 @@
 import { AppError, AppErrors } from 'types/errors'
 import { accessIpfsUrl } from './ipfs'
 
-const validProtocols = ['http:', 'https:', 'ftp:', 'ipfs:']
+const validProtocols = ['http:', 'https:', 'ftp:', 'ipfs:', 'data:']
 
 export const isNftImageUrlValid = (url: string | undefined): boolean => {
   if (!url) {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -140,6 +140,7 @@
     "noMetadata": "There is no metadata on record for this NFT.",
     "noPreview": "No preview available",
     "openInFullscreen": "Open in fullscreen",
+    "openInNewTab": "Open in a new tab",
     "owner": "Owner",
     "ownerLink": "Owner: <OwnerLink />",
     "switchBackgroundColor": "Switch between dark and light background",


### PR DESCRIPTION
- show no preview state based on image load error (we cannot rely on `image` prop send via API for now)
- will work with base64-encoded Data URLs 

updated:
![Screenshot from 2024-01-11 13-25-58](https://github.com/oasisprotocol/explorer/assets/891392/8fa3feab-845c-488d-a919-3908b275ba25)
![Screenshot from 2024-01-11 13-26-09](https://github.com/oasisprotocol/explorer/assets/891392/50d0bec0-50db-41fe-90ca-f5d14b067e1a)

master:
![Screenshot from 2024-01-11 13-28-54](https://github.com/oasisprotocol/explorer/assets/891392/2fdb4bed-2998-4d7d-a435-f5e92abfef97)

![Screenshot from 2024-01-11 13-29-04](https://github.com/oasisprotocol/explorer/assets/891392/9a04de09-cc7b-4e5b-ba6a-59435d9fec18)
