### PR TITLE
Do not change runtime to Emerald when switching network

### DIFF
--- a/.changelog/1152.bugfix.md
+++ b/.changelog/1152.bugfix.md
@@ -1,0 +1,1 @@
+Do not change runtime to Emerald when switching network

--- a/src/app/components/ParaTimePicker/index.tsx
+++ b/src/app/components/ParaTimePicker/index.tsx
@@ -91,8 +91,10 @@ const ParaTimePickerContent: FC<ParaTimePickerContentProps> = ({ isOutOfDate, on
     ParaTimePickerTabletStep.ParaTimeDetails,
   )
   const selectNetwork = (newNetwork: Network) => {
+    const enabledLayers = RouteUtils.getEnabledLayersForNetwork(newNetwork)
+    const targetLayer = enabledLayers.includes(selectedLayer) ? selectedLayer : enabledLayers[0]
     setSelectedNetwork(newNetwork)
-    setSelectedLayer(RouteUtils.getEnabledLayersForNetwork(newNetwork)[0])
+    setSelectedLayer(targetLayer)
   }
   const handleConfirm = () => onConfirm(selectedNetwork, selectedLayer)
 


### PR DESCRIPTION
- ~replace collapsible section~ 
- fix issue with selecting Emerald always when switching network
