### PR TITLE
Simplify search scopes and fix search on error pages

### DIFF
--- a/.changelog/1159.internal.md
+++ b/.changelog/1159.internal.md
@@ -1,1 +1,1 @@
-Simplify search scopes
+Simplify search scopes and fix search on error pages

--- a/.changelog/1159.internal.md
+++ b/.changelog/1159.internal.md
@@ -1,0 +1,1 @@
+Simplify search scopes

--- a/src/app/components/PageLayout/Header.tsx
+++ b/src/app/components/PageLayout/Header.tsx
@@ -49,7 +49,7 @@ export const Header: FC = () => {
               showText={!scrollTrigger && !isMobile}
             />
           </Grid>
-          {scope?.valid && (
+          {scope && (
             <>
               <Grid lg={6} xs={8}>
                 <NetworkSelector layer={scope.layer} network={scope.network} />

--- a/src/app/components/PageLayout/index.tsx
+++ b/src/app/components/PageLayout/index.tsx
@@ -30,7 +30,7 @@ export const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({ children, m
     <>
       <BuildBanner />
       <NetworkOfflineBanner />
-      {scope?.valid && scope.layer !== Layer.consensus && <RuntimeOfflineBanner />}
+      {scope && scope.layer !== Layer.consensus && <RuntimeOfflineBanner />}
       <Box
         sx={{
           minHeight: '100vh',

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -10,7 +10,6 @@ import {
 import { Network } from '../../../types/network'
 import { RouteUtils, SpecifiedPerEnabledRuntime } from '../../utils/route-utils'
 import { AppError, AppErrors } from '../../../types/errors'
-import { Layer } from '../../../oasis-nexus/api'
 
 type LayerSuggestions = {
   suggestedBlock: string
@@ -19,7 +18,7 @@ type LayerSuggestions = {
   suggestedTokenFragment: string
 }
 
-export const searchSuggestionTerms: Record<Network, Partial<Record<Layer, LayerSuggestions>>> = {
+export const searchSuggestionTerms = {
   mainnet: {
     emerald: {
       suggestedBlock: '4260',
@@ -33,6 +32,8 @@ export const searchSuggestionTerms: Record<Network, Partial<Record<Layer, LayerS
       suggestedAccount: '0x90adE3B7065fa715c7a150313877dF1d33e777D5',
       suggestedTokenFragment: 'mock',
     },
+    cipher: undefined,
+    consensus: undefined,
   },
   testnet: {
     emerald: {
@@ -47,8 +48,10 @@ export const searchSuggestionTerms: Record<Network, Partial<Record<Layer, LayerS
       suggestedAccount: '0xfA3AC9f65C9D75EE3978ab76c6a1105f03156204',
       suggestedTokenFragment: 'USD',
     },
+    cipher: undefined,
+    consensus: undefined,
   },
-} satisfies SpecifiedPerEnabledRuntime
+} satisfies SpecifiedPerEnabledRuntime<LayerSuggestions>
 
 export const textSearchMininumLength = 3
 

--- a/src/app/hooks/useScopeParam.ts
+++ b/src/app/hooks/useScopeParam.ts
@@ -1,68 +1,29 @@
 import { useRouteLoaderData, useParams, useRouteError } from 'react-router-dom'
 import { Network } from '../../types/network'
-import { RouteUtils } from '../utils/route-utils'
 import { AppError, AppErrors } from '../../types/errors'
 import { SearchScope } from '../../types/searchScope'
-import { Layer } from '../../oasis-nexus/api'
 
 export const useNetworkParam = (): Network | undefined => {
   const { network } = useParams()
   return network as Network | undefined
 }
 
-type ScopeInfo = SearchScope & {
-  valid: boolean
-}
-
-type Scope = {
-  layer: Layer | undefined
-  network: Network | undefined
-}
-
 /**
  * Use this in situations where we might or might not have a scope
  */
-export const useScopeParam = (): ScopeInfo | undefined => {
-  const runtimeScope = useRouteLoaderData('runtimeScope') as Scope
-  const consensusScope = useRouteLoaderData('consensusScope') as Scope
-  const loaderData = runtimeScope || consensusScope
+export const useScopeParam = (): SearchScope | undefined => {
+  const runtimeScope = useRouteLoaderData('runtimeScope') as SearchScope | undefined
+  const consensusScope = useRouteLoaderData('consensusScope') as SearchScope | undefined
   const error = useRouteError()
 
-  if (loaderData?.network === undefined && loaderData?.layer === undefined) return undefined
-
-  const { network, layer } = loaderData
-
-  const scope: ScopeInfo = {
-    network: network as Network,
-    layer: layer as Layer,
-    valid: true,
-  }
-
-  if (network === undefined || layer === undefined) {
-    scope.valid = false
-    if (!error)
-      throw new Error(
-        'You must either specify both network and layer or none of them. You can not have one but not the other.',
-      )
-  }
-
-  if (!RouteUtils.getEnabledNetworks().includes(scope.network)) {
-    scope.valid = false
-    if (!error) throw new AppError(AppErrors.UnsupportedNetwork)
-  }
-
-  if (!RouteUtils.getEnabledLayersForNetwork(scope.network).includes(scope.layer)) {
-    scope.valid = false
-    if (!error) throw new AppError(AppErrors.UnsupportedLayer)
-  }
-
-  return scope
+  if (error) throw error
+  return runtimeScope ?? consensusScope ?? undefined
 }
 
 /**
  * Use this in situations where we require to have a scope
  */
-export const useRequiredScopeParam = (): ScopeInfo => {
+export const useRequiredScopeParam = (): SearchScope => {
   const scope = useScopeParam()
 
   if (!scope) throw new AppError(AppErrors.UnsupportedNetwork)

--- a/src/app/hooks/useScopeParam.ts
+++ b/src/app/hooks/useScopeParam.ts
@@ -1,4 +1,4 @@
-import { useRouteLoaderData, useParams, useRouteError } from 'react-router-dom'
+import { useRouteLoaderData, useParams } from 'react-router-dom'
 import { Network } from '../../types/network'
 import { AppError, AppErrors } from '../../types/errors'
 import { SearchScope } from '../../types/searchScope'
@@ -14,9 +14,6 @@ export const useNetworkParam = (): Network | undefined => {
 export const useScopeParam = (): SearchScope | undefined => {
   const runtimeScope = useRouteLoaderData('runtimeScope') as SearchScope | undefined
   const consensusScope = useRouteLoaderData('consensusScope') as SearchScope | undefined
-  const error = useRouteError()
-
-  if (error) throw error
   return runtimeScope ?? consensusScope ?? undefined
 }
 

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -44,8 +44,7 @@ type LayerContent = {
   secondary: Content
   tertiary: Content
 }
-type NetworkContent = Partial<Record<Layer, LayerContent>>
-const getContent = (t: TFunction): Record<Network, NetworkContent> => {
+const getContent = (t: TFunction) => {
   const labels = getLayerLabels(t)
 
   return {
@@ -84,6 +83,8 @@ const getContent = (t: TFunction): Record<Network, NetworkContent> => {
           url: docs.paraTimeTransfer,
         },
       },
+      [Layer.cipher]: undefined,
+      [Layer.consensus]: undefined,
     },
     [Network.testnet]: {
       [Layer.emerald]: {
@@ -120,8 +121,10 @@ const getContent = (t: TFunction): Record<Network, NetworkContent> => {
           url: docs.sapphireTestnetHardhat,
         },
       },
+      [Layer.cipher]: undefined,
+      [Layer.consensus]: undefined,
     },
-  } satisfies SpecifiedPerEnabledRuntime
+  } satisfies SpecifiedPerEnabledRuntime<LayerContent>
 }
 
 type LearningSectionProps = PaperProps & {

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -173,26 +173,13 @@ export const transactionParamLoader = async ({ params }: LoaderFunctionArgs) => 
   return validateTxHashParam(params.hash!)
 }
 
-export const scopeConsensusLoader = async (args: LoaderFunctionArgs) => {
-  const {
-    params: { network },
-  } = args
-
-  if (!network || !RouteUtils.getEnabledNetworks().includes(network as Network)) {
-    throw new AppError(AppErrors.InvalidUrl)
-  }
-
-  return {
-    network: network as Network,
-    layer: Layer.consensus,
-  }
-}
-
-export const scopeRuntimeLoader = async (args: LoaderFunctionArgs) => {
-  const {
-    params: { network, layer },
-  } = args
-
+export const assertEnabledScope = ({
+  network,
+  layer,
+}: {
+  network: string | undefined
+  layer: string | undefined
+}): SearchScope => {
   if (!network || !RouteUtils.getEnabledNetworks().includes(network as Network)) {
     throw new AppError(AppErrors.InvalidUrl)
   }
@@ -203,9 +190,5 @@ export const scopeRuntimeLoader = async (args: LoaderFunctionArgs) => {
   ) {
     throw new AppError(AppErrors.UnsupportedLayer)
   }
-
-  return {
-    network: network as Network,
-    layer: layer as Layer,
-  }
+  return { network, layer } as SearchScope
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -59,11 +59,11 @@ export const routes: RouteObject[] = [
         loader: searchParamLoader,
       },
       {
-        path: '/:network/consensus',
+        path: '/:_network/consensus',
         element: <NetworkSpecificPart />,
         errorElement: withDefaultTheme(<RoutingErrorPage />),
         loader: async ({ params }): Promise<SearchScope> => {
-          return assertEnabledScope({ network: params.network, layer: Layer.consensus })
+          return assertEnabledScope({ network: params._network, layer: Layer.consensus })
         },
         id: 'consensusScope',
         children: [
@@ -74,11 +74,11 @@ export const routes: RouteObject[] = [
         ],
       },
       {
-        path: '/:network/:layer',
+        path: '/:_network/:_layer',
         element: <NetworkSpecificPart />,
         errorElement: withDefaultTheme(<RoutingErrorPage />),
         loader: async ({ params }): Promise<SearchScope> => {
-          return assertEnabledScope({ network: params.network, layer: params.layer })
+          return assertEnabledScope({ network: params._network, layer: params._layer })
         },
         id: 'runtimeScope',
         children: [

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,8 +13,7 @@ import {
   addressParamLoader,
   blockHeightParamLoader,
   transactionParamLoader,
-  scopeConsensusLoader,
-  scopeRuntimeLoader,
+  assertEnabledScope,
 } from './app/utils/route-utils'
 import { searchParamLoader } from './app/components/Search/search-utils'
 import { RoutingErrorPage } from './app/pages/RoutingErrorPage'
@@ -31,6 +30,8 @@ import { TokenInventoryCard } from './app/pages/TokenDashboardPage/TokenInventor
 import { NFTInstanceDashboardPage, useNftDetailsProps } from './app/pages/NFTInstanceDashboardPage'
 import { NFTMetadataCard } from './app/pages/NFTInstanceDashboardPage/NFTMetadataCard'
 import { ConsensusDashboardPage } from 'app/pages/ConsensusDashboardPage'
+import { Layer } from './oasis-nexus/api'
+import { SearchScope } from './types/searchScope'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork network={useRequiredScopeParam().network}>
@@ -61,7 +62,9 @@ export const routes: RouteObject[] = [
         path: '/:network/consensus',
         element: <NetworkSpecificPart />,
         errorElement: withDefaultTheme(<RoutingErrorPage />),
-        loader: scopeConsensusLoader,
+        loader: async ({ params }): Promise<SearchScope> => {
+          return assertEnabledScope({ network: params.network, layer: Layer.consensus })
+        },
         id: 'consensusScope',
         children: [
           {
@@ -74,7 +77,9 @@ export const routes: RouteObject[] = [
         path: '/:network/:layer',
         element: <NetworkSpecificPart />,
         errorElement: withDefaultTheme(<RoutingErrorPage />),
-        loader: scopeRuntimeLoader,
+        loader: async ({ params }): Promise<SearchScope> => {
+          return assertEnabledScope({ network: params.network, layer: params.layer })
+        },
         id: 'runtimeScope',
         children: [
           {


### PR DESCRIPTION
Includes #1129 and #1157
Supersedes #1145 and #1146

I'm pretty sure this behaves the same way. @csillag @buberdds please check.
Do we have a list of edge-case URLs we can put into E2E tests?
- scope = undefined
- scope = undefined but isn't an error (https://explorer.dev.oasis.io/search?q=abc)
- scope.valid = false
- specify network but not layer

| Before | #1145 and #1146 | After |
| --- | --- | --- |
| https://explorer.dev.oasis.io/abc/xyz (broken) | https://9855550d.oasis-explorer.pages.dev/abc/xyz | https://2f68a07b.oasis-explorer.pages.dev/abc/xyz |
| https://explorer.dev.oasis.io/abc/xyz/block (broken) | https://9855550d.oasis-explorer.pages.dev/abc/xyz/block | https://2f68a07b.oasis-explorer.pages.dev/abc/xyz/block |
| https://explorer.dev.oasis.io/abc/xyz/search?q=123 (broken) | https://9855550d.oasis-explorer.pages.dev/abc/xyz/search?q=123 | https://2f68a07b.oasis-explorer.pages.dev/abc/xyz/search?q=123 |
| https://explorer.dev.oasis.io/testnet/xyz (search broken) | https://9855550d.oasis-explorer.pages.dev/testnet/xyz | https://2f68a07b.oasis-explorer.pages.dev/testnet/xyz |
| https://explorer.dev.oasis.io/testnet/xyz/block (search broken) | https://9855550d.oasis-explorer.pages.dev/testnet/xyz/block | https://2f68a07b.oasis-explorer.pages.dev/testnet/xyz/block |
| https://explorer.dev.oasis.io/testnet/sapphire | https://9855550d.oasis-explorer.pages.dev/testnet/sapphire | https://2f68a07b.oasis-explorer.pages.dev/testnet/sapphire |


