### PR TITLE
In block details, add prev and next buttons 

### DIFF
--- a/.changelog/1178.feature.md
+++ b/.changelog/1178.feature.md
@@ -1,0 +1,1 @@
+In block details, add prev and next buttons

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -1,0 +1,57 @@
+import { FC } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PaginationItem from '@mui/material/PaginationItem'
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import { SearchScope } from '../../../types/searchScope'
+import { COLORS } from '../../../styles/theme/colors'
+import { useRuntimeFreshness } from '../OfflineBanner/hook'
+import { RouteUtils } from '../../utils/route-utils'
+
+export const PrevBlockButton: FC<{ scope: SearchScope; currentRound: number }> = ({
+  scope,
+  currentRound,
+}) => {
+  const { t } = useTranslation()
+  const disabled = currentRound === 0
+  return (
+    <Tooltip title={disabled ? t('blocks.viewingFirst') : t('blocks.viewPrevious')} placement="top">
+      <Box>
+        <PaginationItem
+          component={RouterLink}
+          to={RouteUtils.getBlockRoute(scope, currentRound - 1)}
+          type="previous"
+          disabled={disabled}
+          sx={{
+            marginLeft: 4,
+            marginRight: 1,
+            background: COLORS.grayMediumLight,
+          }}
+        />
+      </Box>
+    </Tooltip>
+  )
+}
+
+export const NextBlockButton: FC<{ scope: SearchScope; currentRound: number }> = ({
+  scope,
+  currentRound,
+}) => {
+  const { latestBlock } = useRuntimeFreshness(scope)
+  const { t } = useTranslation()
+  const disabled = latestBlock === currentRound
+  return (
+    <Tooltip title={disabled ? t('blocks.viewingLatest') : t('blocks.viewNext')} placement="top">
+      <Box>
+        <PaginationItem
+          component={RouterLink}
+          to={RouteUtils.getBlockRoute(scope, currentRound + 1)}
+          type="next"
+          disabled={latestBlock === currentRound}
+          sx={{ background: COLORS.grayMediumLight }}
+        />
+      </Box>
+    </Tooltip>
+  )
+}

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -18,6 +18,7 @@ export type FreshnessInfo = {
   unavailable?: boolean
   outOfDate?: boolean
   lastUpdate?: string
+  latestBlock?: number
 }
 
 export const useConsensusFreshness = (network: Network) => {
@@ -35,6 +36,7 @@ export const useRuntimeFreshness = (scope: SearchScope): FreshnessInfo => {
   const query = useGetRuntimeStatus(scope.network, scope.layer)
   const data = query.data?.data
   const lastUpdate = useFormattedTimestampString(data?.latest_block_time)
+  const latestBlock = data?.latest_block
 
   if (query.isError) {
     return {
@@ -71,5 +73,6 @@ export const useRuntimeFreshness = (scope: SearchScope): FreshnessInfo => {
   return {
     outOfDate: timeSinceLastUpdate > outOfDateThreshold,
     lastUpdate: lastUpdate,
+    latestBlock,
   }
 }

--- a/src/app/pages/BlockDetailPage/index.tsx
+++ b/src/app/pages/BlockDetailPage/index.tsx
@@ -19,6 +19,7 @@ import { RouteUtils } from '../../utils/route-utils'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { EventsCard } from './EventsCard'
+import { NextBlockButton, PrevBlockButton } from '../../components/BlockNavigationButtons'
 
 export const BlockDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -88,6 +89,8 @@ export const BlockDetailView: FC<{
       <dd>
         <BlockLink scope={block} height={block.round} />
         <CopyToClipboard value={block.round.toString()} />
+        <PrevBlockButton scope={block} currentRound={block.round} />
+        <NextBlockButton scope={block} currentRound={block.round} />
       </dd>
 
       <dt>{t('common.hash')}</dt>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -19,7 +19,11 @@
     "tooltip": "{{value, number}} accounts"
   },
   "blocks": {
-    "latest": "Latest Blocks"
+    "latest": "Latest Blocks",
+    "viewingFirst": "You are viewing the first block",
+    "viewingLatest": "You are viewing the latest block",
+    "viewNext": "View next block",
+    "viewPrevious": "View previous block"
   },
   "block": {
     "gasUsed": "{{value, number}} | {{percentage, number}}"


### PR DESCRIPTION
As requested on Slack by @kostko 
Design is [here]

The implementation looks like this:
![image](https://github.com/oasisprotocol/explorer/assets/2093792/50c580e2-27eb-4d50-a592-7f7b8ccf8ef4)



