### PR TITLE
Handle new transfer event types

### DIFF
--- a/.changelog/1189.trivial.md
+++ b/.changelog/1189.trivial.md
@@ -1,0 +1,1 @@
+Handle new transfer event types

--- a/src/app/components/Tokens/TokenTransferIcon.tsx
+++ b/src/app/components/Tokens/TokenTransferIcon.tsx
@@ -23,7 +23,10 @@ const getTokenTransferLabel = (t: TFunction, name: string | undefined): string =
       return t('tokens.transferEventType.minting')
     case 'Burning':
       return t('tokens.transferEventType.burning')
+    case 'TaskAcceptorChanged':
+      return t('tokens.transferEventType.taskAcceptorChanged')
     default:
+      console.log('We have no idea about transfer event', name)
       return t('tokens.transferEventType.unknown', { name })
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -280,7 +280,8 @@
       "minting": "Minting",
       "burning": "Burning",
       "unavailable": "Unknown token transfer event",
-      "unknown": "Unknown: {{name}}"
+      "unknown": "Unknown: {{name}}",
+      "taskAcceptorChanged": "Task acceptor changed"
     },
     "type": "Token Type"
   },


### PR DESCRIPTION
We see them in the data now, for example [here](https://explorer.dev.oasis.io/mainnet/sapphire/tx/0x6990c0f6d4178090e07c9d48fc38fcb987e5daed54a940fa17a057922f17c344):

![image](https://github.com/oasisprotocol/explorer/assets/2093792/70df9a69-101b-425b-a5a5-255030bffbb5)

After the fix:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/5e89a725-7465-4824-94cf-bbc07d01db53)

