### PR TITLE
Improve block details next button

### DIFF
--- a/.changelog/1201.trivial.md
+++ b/.changelog/1201.trivial.md
@@ -1,0 +1,1 @@
+Improve block details next button

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -40,7 +40,9 @@ export const NextBlockButton: FC<{ scope: SearchScope; currentRound: number }> =
 }) => {
   const { latestBlock } = useRuntimeFreshness(scope)
   const { t } = useTranslation()
-  const disabled = latestBlock === currentRound
+  const disabled = !!latestBlock && currentRound >= latestBlock
+  // If the next button is disabled, we want to poll the freshness info, because it will probably be enabled in a few secs
+  useRuntimeFreshness(scope, { polling: disabled }) // This will trigger refreshing to see if there isa new block
   return (
     <Tooltip title={disabled ? t('blocks.viewingLatest') : t('blocks.viewNext')} placement="top">
       <Box>

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -48,7 +48,7 @@ export const NextBlockButton: FC<{ scope: SearchScope; currentRound: number }> =
           component={RouterLink}
           to={RouteUtils.getBlockRoute(scope, currentRound + 1)}
           type="next"
-          disabled={latestBlock === currentRound}
+          disabled={disabled}
           sx={{ background: COLORS.grayMediumLight }}
         />
       </Box>

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -28,12 +28,17 @@ export const useConsensusFreshness = (network: Network) => {
   }
 }
 
-export const useRuntimeFreshness = (scope: SearchScope): FreshnessInfo => {
+export const useRuntimeFreshness = (
+  scope: SearchScope,
+  queryParams: { polling?: boolean } = {},
+): FreshnessInfo => {
   const isApiReachable = useIsApiReachable(scope.network).reachable
   if (scope.layer === Layer.consensus) {
     throw new AppError(AppErrors.UnsupportedLayer)
   }
-  const query = useGetRuntimeStatus(scope.network, scope.layer)
+  const query = useGetRuntimeStatus(scope.network, scope.layer, {
+    query: { refetchInterval: queryParams.polling ? 8000 : undefined },
+  })
   const data = query.data?.data
   const lastUpdate = useFormattedTimestampStringWithDistance(data?.latest_block_time)
   const latestBlock = data?.latest_block


### PR DESCRIPTION
When displaying the latest block details, keep polling.
The idea is that the "View next block" button should be enabled as soon as a new block is available.

Please note that
 - No polling happens when we are displaying any other block besides the latest
 - As soon as we detect that the currently displayed block is no longer the latest block, and so the "view next block" button can be enabled, the polling stops.