### PR TITLE
Proposal details: detect and display type

### DIFF
--- a/.changelog/1208.trivial.md
+++ b/.changelog/1208.trivial.md
@@ -1,0 +1,1 @@
+Proposal details: detect and display type

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -17,6 +17,7 @@ import { ProposalStatusIcon } from '../../components/Proposals/ProposalStatusIco
 import { TextSkeleton } from '../../components/Skeleton'
 import { AccountLink } from '../../components/Account/AccountLink'
 import { COLORS } from 'styles/theme/colors'
+import { getTypeNameForProposal } from '../../../types/proposalType'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -50,6 +51,8 @@ export const ProposalDetailView: FC<{
   const { isMobile } = useScreenSize()
   if (isLoading) return <TextSkeleton numberOfRows={7} />
 
+  const proposalType = getTypeNameForProposal(t, proposal)
+
   return (
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'} standalone={standalone}>
       {showLayer && (
@@ -67,9 +70,8 @@ export const ProposalDetailView: FC<{
       <dt>{t('common.title')}</dt>
       <dd>{proposal.handler}</dd>
 
-      {/*Not enough data*/}
-      {/*<dt>{t('common.type')}</dt>*/}
-      {/*<dd>???</dd>*/}
+      <dt>{t('common.type')}</dt>
+      <dd>{proposalType}</dd>
 
       <dt>{t('common.submitter')}</dt>
       <dd>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -157,6 +157,11 @@
       "failed": "Failed",
       "passed": "Passed",
       "rejected": "Rejected"
+    },
+    "type": {
+      "upgrade": "Upgrade",
+      "parameterUpgrade": "Parameter upgrade",
+      "cancellation": "Cancellation"
     }
   },
   "nft": {

--- a/src/types/proposalType.ts
+++ b/src/types/proposalType.ts
@@ -1,0 +1,37 @@
+import { TFunction } from 'i18next'
+import { Proposal } from '../oasis-nexus/api'
+
+export type ProposalType = (typeof ProposalType)[keyof typeof ProposalType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ProposalType = {
+  upgrade: 'upgrade',
+  parameterUpgrade: 'parameterUpgrade',
+  cancellation: 'cancellation',
+} as const
+
+/**
+ * Detect the proposal type from looking at the data
+ *
+ * if type=Cancellation, the cancels field will be nonempty
+ * if type=ParameterUpgrade, the parameters_change_module and parameters_change fields will be nonempty
+ * if type=Upgrade, all of the above fields will be empty
+ */
+export const detectProposalType = (proposal: Proposal): ProposalType => {
+  const { cancels, parameters_change } = proposal
+  if (cancels) return ProposalType.cancellation
+  if (parameters_change) return ProposalType.parameterUpgrade
+  return ProposalType.upgrade
+}
+
+export const getProposalTypeNames = (t: TFunction): Record<ProposalType, string> => ({
+  [ProposalType.upgrade]: t('networkProposal.type.upgrade'),
+  [ProposalType.parameterUpgrade]: t('networkProposal.type.parameterUpgrade'),
+  [ProposalType.cancellation]: t('networkProposal.type.cancellation'),
+})
+
+export const getTypeNameForProposal = (t: TFunction, proposal: Proposal) => {
+  const names = getProposalTypeNames(t)
+  const wantedType = detectProposalType(proposal)
+  return names[wantedType]
+}


### PR DESCRIPTION
Let's try to detect the type of network proposal, to the best of out ability.
Currently every single proposal is detected as `Upgrade`, and the Nexus guys are aware of this.

If new information becomes available, this will be updated.

**Update:** the logic has been proven to  be correct, and now we have some cancellations and parameter upgrades (on staging testnet) which are detected correctly.