### PR TITLE
Display the votes on the network proposal details page

### DIFF
--- a/.changelog/1214.feature.md
+++ b/.changelog/1214.feature.md
@@ -1,0 +1,1 @@
+Display the votes on the network proposal details page

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
 import Link from '@mui/material/Link'
@@ -10,11 +10,17 @@ import { SearchScope } from '../../../types/searchScope'
 export const AccountLink: FC<{
   scope: SearchScope
   address: string
+  title?: ReactNode
   alwaysTrim?: boolean
-}> = ({ scope, address, alwaysTrim }) => {
+}> = ({ scope, address, title, alwaysTrim }) => {
   const { isTablet } = useScreenSize()
   const to = RouteUtils.getAccountRoute(scope, address)
-  return (
+
+  return title ? (
+    <Link component={RouterLink} to={to}>
+      {title}
+    </Link>
+  ) : (
     <Typography variant="mono" component="span">
       {alwaysTrim || isTablet ? (
         <TrimLinkLabel label={address} to={to} />

--- a/src/app/components/Proposals/ProposalVoteIndicator.tsx
+++ b/src/app/components/Proposals/ProposalVoteIndicator.tsx
@@ -1,0 +1,77 @@
+import { FC } from 'react'
+import { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import CancelIcon from '@mui/icons-material/Cancel'
+import RemoveCircleIcon from '@mui/icons-material/RemoveCircle'
+import { styled } from '@mui/material/styles'
+import { COLORS } from '../../../styles/theme/colors'
+import { ProposalVoteValue } from '../../../types/vote'
+
+const StyledBox = styled(Box)(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 3,
+  flex: 1,
+  borderRadius: 10,
+  padding: theme.spacing(2, 2, 2, '10px'),
+  fontSize: '12px',
+  minWidth: '85px',
+}))
+
+const StyledIcon = styled(Box)({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontSize: '18px',
+})
+
+const getStatuses = (t: TFunction) => ({
+  [ProposalVoteValue.abstain]: {
+    backgroundColor: COLORS.lightSilver,
+    icon: RemoveCircleIcon,
+    iconColor: COLORS.grayMedium,
+    label: t('networkProposal.vote.abstain'),
+    textColor: COLORS.grayExtraDark,
+  },
+  [ProposalVoteValue.yes]: {
+    backgroundColor: COLORS.honeydew,
+    icon: CheckCircleIcon,
+    iconColor: COLORS.eucalyptus,
+    label: t('networkProposal.vote.yes'),
+    textColor: COLORS.grayExtraDark,
+  },
+  [ProposalVoteValue.no]: {
+    backgroundColor: COLORS.linen,
+    icon: CancelIcon,
+    iconColor: COLORS.errorIndicatorBackground,
+    label: t('networkProposal.vote.no'),
+    textColor: COLORS.grayExtraDark,
+  },
+})
+
+type ProposalVoteIndicatorProps = {
+  vote: ProposalVoteValue
+}
+
+export const ProposalVoteIndicator: FC<ProposalVoteIndicatorProps> = ({ vote }) => {
+  const { t } = useTranslation()
+
+  if (!ProposalVoteValue[vote]) {
+    return null
+  }
+
+  const statusConfig = getStatuses(t)[vote]
+  const IconComponent = statusConfig.icon
+
+  return (
+    <StyledBox sx={{ backgroundColor: statusConfig.backgroundColor, color: statusConfig.textColor }}>
+      {statusConfig.label}
+      <StyledIcon sx={{ color: statusConfig.iconColor }}>
+        <IconComponent color="inherit" fontSize="inherit" />
+      </StyledIcon>
+    </StyledBox>
+  )
+}

--- a/src/app/components/Proposals/VoteTypePills.tsx
+++ b/src/app/components/Proposals/VoteTypePills.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Typography from '@mui/material/Typography'
+import { COLORS } from '../../../styles/theme/colors'
+import { ProposalVoteValue, VoteType } from '../../../types/vote'
+
+type VoteTypePillsProps = {
+  handleChange: (voteType: VoteType) => void
+  value?: VoteType
+}
+
+export const VoteTypePills: FC<VoteTypePillsProps> = ({ handleChange, value }) => {
+  const { t } = useTranslation()
+  const options: { label: string; value: VoteType }[] = [
+    {
+      label: t('networkProposal.vote.all'),
+      value: 'any',
+    },
+    {
+      label: t('networkProposal.vote.yes'),
+      value: ProposalVoteValue.yes,
+    },
+    {
+      label: t('networkProposal.vote.abstain'),
+      value: ProposalVoteValue.abstain,
+    },
+    {
+      label: t('networkProposal.vote.no'),
+      value: ProposalVoteValue.no,
+    },
+  ]
+
+  return (
+    <>
+      {options.map(option => {
+        const selected = option.value === value
+        return (
+          <Chip
+            key={option.value}
+            onClick={() => handleChange(option.value)}
+            clickable
+            color="secondary"
+            label={
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Typography component="span" sx={{ fontSize: 16 }}>
+                  {option.label}
+                </Typography>
+              </Box>
+            }
+            sx={{
+              mr: 3,
+              borderColor: COLORS.brandMedium,
+              backgroundColor: selected ? COLORS.brandMedium : COLORS.brandMedium15,
+              color: selected ? COLORS.white : COLORS.grayExtraDark,
+            }}
+            variant={selected ? 'outlined-selected' : 'outlined'}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/src/app/components/Proposals/VoterSearchBar.tsx
+++ b/src/app/components/Proposals/VoterSearchBar.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import TextField from '@mui/material/TextField'
+import SearchIcon from '@mui/icons-material/Search'
+import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import InputAdornment from '@mui/material/InputAdornment'
+import { COLORS } from '../../../styles/theme/colors'
+import { SearchVariant } from '../Search'
+import { useTranslation } from 'react-i18next'
+import IconButton from '@mui/material/IconButton'
+
+export interface SearchBarProps {
+  variant: SearchVariant
+  value: string
+  onChange: (value: string) => void
+}
+
+export const VoterSearchBar: FC<SearchBarProps> = ({ variant, value, onChange }) => {
+  const { t } = useTranslation()
+  const startAdornment = variant === 'button' && (
+    <InputAdornment
+      position="start"
+      disablePointerEvents // Pass clicks through, so it focuses the input
+    >
+      <SearchIcon sx={{ color: COLORS.grayDark }} />
+    </InputAdornment>
+  )
+
+  const onClearValue = () => onChange('')
+
+  const endAdornment = (
+    <InputAdornment position="end">
+      <>
+        {value && (
+          <IconButton color="inherit" onClick={onClearValue}>
+            <HighlightOffIcon />
+          </IconButton>
+        )}
+      </>
+    </InputAdornment>
+  )
+
+  return (
+    <>
+      <TextField
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        InputProps={{
+          inputProps: {
+            sx: {
+              p: 0,
+              marginRight: 2,
+            },
+          },
+          startAdornment,
+          endAdornment,
+        }}
+        placeholder={t('networkProposal.searchForVoters')}
+        // FormHelperTextProps={{
+        //   component: 'div', // replace p with div tag
+        //   sx: {
+        //     marginTop: 0,
+        //     marginBottom: 0,
+        //     marginLeft: variant === 'button' ? '48px' : '17px',
+        //     marginRight: variant === 'button' ? '48px' : '17px',
+        //   },
+        // }}
+      />
+    </>
+  )
+}

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -7,15 +7,42 @@ export interface SimplePaginationEngine {
   linkToPage: (pageNumber: number) => To
 }
 
+/**
+ * The data returned by a comprehensive pagination engine to the data consumer component
+ */
 export interface PaginatedResults<Item> {
+  /**
+   * Control interface that can be plugged to a Table's `pagination` prop
+   */
   tablePaginationProps: TablePaginationProps
+
+  /**
+   * The data provided to the data consumer in the current window
+   */
   data: Item[] | undefined
 }
 
+/**
+ * A Comprehensive PaginationEngine sits between the server and the consumer of the data and does transformations
+ *
+ * Specifically, the interface for loading the data and the one for the data consumers are decoupled.
+ */
 export interface ComprehensivePaginationEngine<Item, QueryResult extends List> {
-  selectedPage: number
-  offsetForQuery: number
-  limitForQuery: number
-  paramsForQuery: { offset: number; limit: number }
+  /**
+   * The currently selected page from the data consumer's POV
+   */
+  selectedPageForClient: number
+
+  /**
+   * Parameters for data to be loaded from the server
+   */
+  paramsForServer: { offset: number; limit: number }
+
+  /**
+   * Get the current data/state info for the data consumer component.
+   *
+   * @param queryResult the data coming in the server, requested according to this engine's specs, including metadata
+   * @param key The field where the actual records can be found within queryResults
+   */
   getResults: (queryResult: QueryResult | undefined, key?: keyof QueryResult) => PaginatedResults<Item>
 }

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -20,6 +20,11 @@ export interface PaginatedResults<Item> {
    * The data provided to the data consumer in the current window
    */
   data: Item[] | undefined
+
+  /**
+   * Is the data set still loading from the server?
+   */
+  isLoading: boolean
 }
 
 /**
@@ -41,8 +46,13 @@ export interface ComprehensivePaginationEngine<Item, QueryResult extends List> {
   /**
    * Get the current data/state info for the data consumer component.
    *
+   * @param isLoading Is the data still being loaded from the server?
    * @param queryResult the data coming in the server, requested according to this engine's specs, including metadata
    * @param key The field where the actual records can be found within queryResults
    */
-  getResults: (queryResult: QueryResult | undefined, key?: keyof QueryResult) => PaginatedResults<Item>
+  getResults: (
+    isLoading: boolean,
+    queryResult: QueryResult | undefined,
+    key?: keyof QueryResult,
+  ) => PaginatedResults<Item>
 }

--- a/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
+++ b/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
@@ -66,7 +66,7 @@ export function useComprehensiveSearchParamsPagination<Item, QueryResult extends
   return {
     selectedPageForClient: selectedPage,
     paramsForServer: paramsForQuery,
-    getResults: (queryResult, key) => {
+    getResults: (isLoading, queryResult, key) => {
       const data = queryResult
         ? key
           ? (queryResult[key] as Item[])
@@ -83,6 +83,7 @@ export function useComprehensiveSearchParamsPagination<Item, QueryResult extends
       return {
         tablePaginationProps: tableProps,
         data: filteredData,
+        isLoading,
       }
     },
     // tableProps,

--- a/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
+++ b/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
@@ -64,10 +64,8 @@ export function useComprehensiveSearchParamsPagination<Item, QueryResult extends
   }
 
   return {
-    selectedPage,
-    offsetForQuery: offset,
-    limitForQuery: limit,
-    paramsForQuery,
+    selectedPageForClient: selectedPage,
+    paramsForServer: paramsForQuery,
     getResults: (queryResult, key) => {
       const data = queryResult
         ? key

--- a/src/app/components/Validators/DeferredValidatorLink.tsx
+++ b/src/app/components/Validators/DeferredValidatorLink.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react'
+import { AccountLink } from '../Account/AccountLink'
+import { Network } from '../../../types/network'
+import { Layer, Validator } from '../../../oasis-nexus/api'
+import Skeleton from '@mui/material/Skeleton'
+import { SearchScope } from '../../../types/searchScope'
+import Box from '@mui/material/Box'
+import { ValidatorImage } from './ValidatorImage'
+
+export const DeferredValidatorLink: FC<{
+  network: Network
+  address: string
+  validator: Validator | undefined
+  isLoading: boolean
+  isError: boolean
+  highlightedPart?: string | undefined
+}> = ({ network, address, validator, isError, isLoading, highlightedPart }) => {
+  const scope: SearchScope = { network, layer: Layer.consensus }
+
+  if (isError) {
+    console.log('Warning: failed to look up validators!')
+  }
+
+  const validatorImage = (
+    <ValidatorImage
+      address={address}
+      name={validator?.media?.name}
+      logotype={validator?.media?.logotype}
+      highlightedPart={highlightedPart}
+    />
+  )
+  // TODO: switch to ValidatorLink, when validator detail pages become available
+  return (
+    <Box sx={{ display: 'inline-flex' }}>
+      <AccountLink scope={scope} address={address} title={validatorImage} />
+      {isLoading && <Skeleton variant="circular" width="1em" height="1em" />}
+    </Box>
+  )
+}

--- a/src/app/components/Validators/ValidatorImage.tsx
+++ b/src/app/components/Validators/ValidatorImage.tsx
@@ -4,6 +4,8 @@ import ImageNotSupportedIcon from '@mui/icons-material/ImageNotSupported'
 import { hasValidProtocol } from '../../utils/url'
 import { COLORS } from 'styles/theme/colors'
 import { Circle } from '../Circle'
+import { HighlightedText } from '../HighlightedText'
+import Box from "@mui/material/Box";
 
 const StyledImage = styled('img')({
   width: '28px',
@@ -15,9 +17,10 @@ type ValidatorImageProps = {
   address: string
   name: string | undefined
   logotype: string | undefined
+  highlightedPart?: string | undefined
 }
 
-export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotype }) => {
+export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotype, highlightedPart }) => {
   return (
     <>
       {logotype && hasValidProtocol(logotype) ? (
@@ -27,6 +30,13 @@ export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotyp
           <ImageNotSupportedIcon sx={{ color: COLORS.grayMedium, fontSize: 18 }} />
         </Circle>
       )}
+      {name ? (
+        <Box sx={{ display: 'inline' }}>
+          <HighlightedText text={name} pattern={highlightedPart} />
+        </Box>
+      ) : (
+        address
+      )}{' '}
     </>
   )
 }

--- a/src/app/hooks/useBooleanFlagInUrl.ts
+++ b/src/app/hooks/useBooleanFlagInUrl.ts
@@ -1,0 +1,21 @@
+import { useSearchParams } from 'react-router-dom'
+import { UrlSettingOptions } from './useStringInUrl'
+
+export const useBooleanFlagInUrl = (param: string, defaultValue: boolean) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const valueString = searchParams.get(param)?.toLowerCase()
+  const value = valueString === 'true' ? true : valueString === 'false' ? false : defaultValue
+  const setValue = (newValue: boolean, options: UrlSettingOptions = {}) => {
+    const { replace, preventScrollReset = true, deleteParams = [] } = options
+    if (newValue === defaultValue) {
+      searchParams.delete(param)
+    } else {
+      searchParams.set(param, newValue.toString())
+    }
+    deleteParams.forEach(p => searchParams.delete(p))
+    setSearchParams(searchParams, { replace, preventScrollReset })
+  }
+
+  const toggleValue = () => setValue(!value)
+  return { value, setValue, toggleValue }
+}

--- a/src/app/hooks/useStringInUrl.ts
+++ b/src/app/hooks/useStringInUrl.ts
@@ -1,0 +1,38 @@
+import { useSearchParams } from 'react-router-dom'
+
+export type UrlSettingOptions = {
+  /**
+   * Should we replace the current state in the history, instead of appending a new state?
+   *
+   * Default is false
+   */
+  replace?: boolean
+
+  /**
+   * Should we block scrolling to the top?
+   *
+   * Default is true
+   */
+  preventScrollReset?: boolean
+
+  /**
+   * Should we delete some other params while setting this one?
+   */
+  deleteParams?: string[]
+}
+
+export const useStringInUrl = (paramName: string, defaultValue: string = '') => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const value = searchParams.get(paramName) ?? defaultValue
+  const setValue = (newValue: string, options: UrlSettingOptions = {}) => {
+    const { replace, preventScrollReset = true, deleteParams = [] } = options
+    if (newValue === defaultValue) {
+      searchParams.delete(paramName)
+    } else {
+      searchParams.set(paramName, newValue)
+    }
+    deleteParams.forEach(p => searchParams.delete(p))
+    setSearchParams(searchParams, { replace, preventScrollReset })
+  }
+  return { value, setValue }
+}

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -1,0 +1,149 @@
+import { FC } from 'react'
+import { useParams } from 'react-router-dom'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { SubPageCard } from '../../components/SubPageCard'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { TablePaginationProps } from '../../components/Table/TablePagination'
+import { useTranslation } from 'react-i18next'
+import { Table, TableCellAlign, TableColProps } from '../../components/Table'
+import { ExtendedVote, ProposalVoteValue } from '../../../types/vote'
+import { useClientSidePagination } from '../../components/Table/useClientSidePagination'
+import {
+  AllVotesData,
+  useAllVotes,
+  useVoterSearch,
+  useVoterSearchPattern,
+  useWantedVoteFilter,
+  useWantedVoteType,
+} from './hooks'
+import { ProposalVoteIndicator } from '../../components/Proposals/ProposalVoteIndicator'
+import { DeferredValidatorLink } from '../../components/Validators/DeferredValidatorLink'
+import { CardHeaderWithResponsiveActions } from '../../components/CardHeaderWithResponsiveActions'
+import { VoteTypePills } from '../../components/Proposals/VoteTypePills'
+import { AppErrors } from '../../../types/errors'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { VoterSearchBar } from '../../components/Proposals/VoterSearchBar'
+
+const PAGE_SIZE = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+
+type ProposalVotesProps = {
+  isLoading: boolean
+  votes: ExtendedVote[] | undefined
+  limit: number
+  pagination: TablePaginationProps
+}
+
+const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, limit, pagination }) => {
+  const { t } = useTranslation()
+  const scope = useRequiredScopeParam()
+
+  const voterNameFragment = useVoterSearchPattern()
+
+  const tableColumns: TableColProps[] = [
+    { key: 'index', content: '', width: '50px' },
+    { key: 'voter', content: t('common.voter'), align: TableCellAlign.Left },
+    { key: 'vote', content: t('common.vote'), align: TableCellAlign.Right },
+  ]
+  const tableRows = votes?.map(vote => {
+    return {
+      key: `vote-${vote.index}`,
+      data: [
+        {
+          key: 'index',
+          content: `#${vote.index}`,
+        },
+        {
+          key: 'voter',
+          content: (
+            <DeferredValidatorLink
+              network={scope.network}
+              address={vote.address}
+              isLoading={vote.areValidatorsLoading}
+              isError={vote.haveValidatorsFailed}
+              validator={vote.validator}
+              highlightedPart={voterNameFragment}
+            />
+          ),
+        },
+        {
+          key: 'vote',
+          content: <ProposalVoteIndicator vote={vote.vote as ProposalVoteValue} />,
+          align: TableCellAlign.Right,
+        },
+      ],
+    }
+  })
+  return (
+    <Table
+      name={t('common.votes')}
+      columns={tableColumns}
+      rows={tableRows}
+      rowsNumber={limit}
+      isLoading={isLoading}
+      pagination={pagination}
+    />
+  )
+}
+
+export const ProposalVotesView: FC = () => {
+  const { network } = useRequiredScopeParam()
+  const proposalId = parseInt(useParams().proposalId!, 10)
+
+  const filter = useWantedVoteFilter()
+
+  const pagination = useClientSidePagination<ExtendedVote, AllVotesData>({
+    paramName: 'page',
+    clientPageSize: PAGE_SIZE,
+    serverPageSize: 1000,
+    filter,
+  })
+
+  // Get all the votes
+  const allVotes = useAllVotes(network, proposalId)
+
+  // Get the section of the votes that we should display in the table
+  const displayedVotes = pagination.getResults(allVotes)
+
+  if (
+    !allVotes.isLoading &&
+    displayedVotes.tablePaginationProps.selectedPage > 1 &&
+    !displayedVotes.data?.length
+  ) {
+    throw AppErrors.PageDoesNotExist
+  }
+
+  return (
+    <ProposalVotes
+      isLoading={allVotes.isLoading}
+      votes={displayedVotes.data}
+      limit={PAGE_SIZE}
+      pagination={displayedVotes.tablePaginationProps}
+    />
+  )
+}
+
+export const ProposalVotesCard: FC = () => {
+  const { t } = useTranslation()
+
+  const { wantedVoteType, setWantedVoteType } = useWantedVoteType()
+  const { voterSearchInput, setVoterSearchPattern } = useVoterSearch()
+
+  return (
+    <SubPageCard>
+      <CardHeaderWithResponsiveActions
+        action={
+          <>
+            <VoterSearchBar variant={'button'} value={voterSearchInput} onChange={setVoterSearchPattern} />
+            <VoteTypePills handleChange={setWantedVoteType} value={wantedVoteType} />
+          </>
+        }
+        disableTypography
+        component="h3"
+        title={t('common.votes')}
+      />
+      <ErrorBoundary light={true}>
+        <ProposalVotesView />
+      </ErrorBoundary>
+    </SubPageCard>
+  )
+}

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -1,0 +1,172 @@
+import {
+  List,
+  useGetConsensusProposalsProposalIdVotes,
+  useGetConsensusValidators,
+} from '../../../oasis-nexus/api'
+import { Network } from '../../../types/network'
+import {
+  ExtendedVote,
+  getFilterForVoteType,
+  getRandomVote,
+  ProposalVoteValue,
+  VoteFilter,
+  VoteType,
+} from '../../../types/vote'
+import { useSearchParams } from 'react-router-dom'
+
+export type AllVotesData = List & {
+  isLoading: boolean
+  isError: boolean
+  loadedVotes: ExtendedVote[]
+}
+
+const DEBUG_MODE = true // TODO disable debug mode before merging
+
+const voteTable: Record<string, ProposalVoteValue> = {}
+
+const getRandomVoteFor = (address: string) => {
+  const storedVote = voteTable[address]
+  if (storedVote) return storedVote
+  const newVote = getRandomVote()
+  voteTable[address] = newVote
+  return newVote
+}
+
+const useValidatorMap = (network: Network) => {
+  const { data, isLoading, isError } = useGetConsensusValidators(network)
+  return {
+    isLoading,
+    isError,
+    map: (data as any)?.data.map ?? new Map(),
+  }
+}
+
+export const useAllVotes = (network: Network, proposalId: number): AllVotesData => {
+  const query = useGetConsensusProposalsProposalIdVotes(network, proposalId)
+  const {
+    map: validators,
+    isLoading: areValidatorsLoading,
+    isError: haveValidatorsFailed,
+  } = useValidatorMap(network)
+  const { isLoading, isError, data } = query
+
+  const extendedVotes = (data?.data.votes || []).map(
+    (vote, index): ExtendedVote => ({
+      ...vote,
+      index: index + 1,
+      areValidatorsLoading,
+      haveValidatorsFailed,
+      validator: validators.get(vote.address),
+    }),
+  )
+
+  return {
+    isLoading,
+    isError,
+    loadedVotes: DEBUG_MODE
+      ? extendedVotes.map(v => ({ ...v, vote: getRandomVoteFor(v.address) })) || []
+      : extendedVotes,
+    total_count: data?.data.total_count ?? 0,
+    is_total_count_clipped: data?.data.is_total_count_clipped ?? false,
+  }
+}
+
+export type VoteStats = {
+  isLoading: boolean
+  isError: boolean
+
+  /**
+   * Did we manage to get all data from the server?
+   */
+  isComplete: boolean
+
+  /**
+   * The results of counting the votes
+   */
+  tally: Record<ProposalVoteValue, bigint>
+
+  /**
+   * The total number of (valid) votes
+   */
+  allVotesCount: number
+
+  /**
+   * The total amount of valid votes (considering the shares)
+   */
+  allVotesPower: bigint
+}
+
+export const useVoteStats = (network: Network, proposalId: number): VoteStats => {
+  const { isLoading, isError, loadedVotes, total_count, is_total_count_clipped } = useAllVotes(
+    network,
+    proposalId,
+  )
+  const tally: Record<ProposalVoteValue, bigint> = {
+    yes: 0n,
+    no: 0n,
+    abstain: 0n,
+  }
+  // TODO: instead of 1n, we should add the power of the vote, but that data is not available yet.
+  loadedVotes.forEach(vote => (tally[vote.vote as ProposalVoteValue] += 1n))
+  const allVotesCount = loadedVotes.length
+  const allVotesPower = tally.yes + tally.no + tally.abstain
+  const isComplete = !isError && loadedVotes.length === total_count && !is_total_count_clipped
+  return {
+    isLoading,
+    isError,
+    isComplete,
+    tally,
+    allVotesCount,
+    allVotesPower,
+  }
+}
+
+const TYPE_PARAM = 'vote'
+export const useWantedVoteType = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const wantedVoteType: VoteType = (searchParams.get(TYPE_PARAM) as VoteType) ?? 'any'
+  const setWantedVoteType = (newType: VoteType) => {
+    if (newType === 'any') {
+      searchParams.delete(TYPE_PARAM)
+    } else {
+      searchParams.set(TYPE_PARAM, newType)
+    }
+    searchParams.delete('page')
+    setSearchParams(searchParams, { preventScrollReset: true })
+  }
+  return { wantedVoteType, setWantedVoteType }
+}
+
+const SEARCH_PARAM = 'voter'
+
+export const useVoterSearch = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const voterSearchInput = searchParams.get(SEARCH_PARAM) ?? ''
+  const setVoterSearchPattern = (pattern: string) => {
+    if (pattern === '') {
+      searchParams.delete(SEARCH_PARAM)
+    } else {
+      searchParams.set(SEARCH_PARAM, pattern)
+    }
+    searchParams.delete('page')
+    setSearchParams(searchParams, { preventScrollReset: true })
+  }
+  return { voterSearchInput, setVoterSearchPattern }
+}
+
+export const useVoterSearchPattern = () => {
+  const { voterSearchInput } = useVoterSearch()
+  return voterSearchInput.length < 3 ? undefined : voterSearchInput
+}
+
+export const useWantedVoteFilter = (): VoteFilter => {
+  const { wantedVoteType } = useWantedVoteType()
+  const voterSearchPattern = useVoterSearchPattern()
+  const typeFilter = getFilterForVoteType(wantedVoteType)
+  if (!voterSearchPattern) {
+    return typeFilter
+  } else {
+    return (vote: ExtendedVote) =>
+      typeFilter(vote) && !!vote.validator?.media?.name?.toLowerCase().includes(voterSearchPattern)
+  }
+}

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import InfoIcon from '@mui/icons-material/Info'
+import CancelIcon from '@mui/icons-material/Cancel'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { Layer, Proposal, useGetConsensusProposalsProposalId } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
@@ -19,6 +20,9 @@ import { AccountLink } from '../../components/Account/AccountLink'
 import { HighlightedText } from '../../components/HighlightedText'
 import { ProposalIdLoaderData } from '../../utils/route-utils'
 import { COLORS } from 'styles/theme/colors'
+import { ProposalVotesCard } from './ProposalVotesCard'
+import { useVoteStats } from './hooks'
+import Skeleton from '@mui/material/Skeleton'
 import { getTypeNameForProposal } from '../../../types/proposalType'
 
 export const ProposalDetailsPage: FC = () => {
@@ -29,6 +33,11 @@ export const ProposalDetailsPage: FC = () => {
   }
   const { proposalId, searchTerm } = useLoaderData() as ProposalIdLoaderData
 
+  const {
+    isLoading: areStatsLoading,
+    allVotesCount,
+    isComplete: areStatsComplete,
+  } = useVoteStats(scope.network, proposalId)
   const { isLoading, data } = useGetConsensusProposalsProposalId(scope.network, proposalId)
   if (!data?.data && !isLoading) {
     throw AppErrors.NotFoundProposalId
@@ -36,10 +45,27 @@ export const ProposalDetailsPage: FC = () => {
   const proposal = data?.data!
   return (
     <PageLayout>
-      <SubPageCard featured title={t('common.proposal')} mainTitle>
-        <ProposalDetailView isLoading={isLoading} proposal={proposal} highlightedPart={searchTerm} />
+      <SubPageCard featured title={t('common.proposal')} maintitle>
+        <ProposalDetailView
+          isLoading={isLoading}
+          proposal={proposal}
+          totalVotesLoading={areStatsLoading}
+          totalVotesProblematic={!areStatsComplete && !areStatsLoading}
+          totalVotes={allVotesCount}
+          highlightedPart={searchTerm}
+        />
       </SubPageCard>
+      <ProposalVotesCard />
     </PageLayout>
+  )
+}
+
+const VoteLoadingProblemIndicator: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <Tooltip title={t('networkProposal.failedToLoadAllVotes')}>
+      <CancelIcon color="error" fontSize="inherit" sx={{ ml: 2 }} />
+    </Tooltip>
   )
 }
 
@@ -47,9 +73,21 @@ export const ProposalDetailView: FC<{
   proposal: Proposal
   highlightedPart?: string
   isLoading?: boolean
+  totalVotesLoading?: boolean
+  totalVotesProblematic?: boolean
+  totalVotes?: number | undefined
   showLayer?: boolean
   standalone?: boolean
-}> = ({ proposal, highlightedPart, isLoading, showLayer = false, standalone = false }) => {
+}> = ({
+  proposal,
+  isLoading,
+  totalVotesLoading,
+  totalVotesProblematic,
+  totalVotes,
+  showLayer = false,
+  standalone = false,
+  highlightedPart,
+}) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   if (isLoading) return <TextSkeleton numberOfRows={7} />
@@ -83,9 +121,26 @@ export const ProposalDetailView: FC<{
         <AccountLink scope={proposal} address={proposal.submitter} />
       </dd>
 
-      {/*Not enough data*/}
-      {/*<dt>{t('common.totalVotes')}</dt>*/}
-      {/*<dd>{proposal.invalid_votes}</dd>*/}
+      {(totalVotes || totalVotesLoading || totalVotesProblematic) && (
+        <>
+          <dt>{t('common.totalVotes')}</dt>
+          <dd>
+            {totalVotesLoading ? (
+              <Skeleton variant="text" sx={{ width: '25%' }} />
+            ) : (
+              totalVotes?.toLocaleString()
+            )}
+            {totalVotesProblematic && <VoteLoadingProblemIndicator />}
+          </dd>
+        </>
+      )}
+
+      {proposal.invalid_votes !== '0' && (
+        <>
+          <dt>{t('common.invalidVotes')}</dt>
+          <dd>{proposal.invalid_votes}</dd>
+        </>
+      )}
 
       <dt>{t('common.status')}</dt>
       <dd>

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -87,7 +87,7 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
 
   const { isFetched, isLoading, data } = query
 
-  const results = pagination.getResults(data?.data)
+  const results = pagination.getResults(isLoading, data?.data)
 
   if (isFetched && pagination.selectedPageForClient > 1 && !results.data?.length) {
     throw AppErrors.PageDoesNotExist
@@ -96,7 +96,7 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
   return {
     isLoading,
     isFetched,
-    results: pagination.getResults(data?.data),
+    results: pagination.getResults(isLoading, data?.data),
   }
 }
 

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -72,7 +72,7 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
     network,
     layer, // This is OK since consensus has been handled separately
     {
-      ...pagination.paramsForQuery,
+      ...pagination.paramsForServer,
       type: RuntimeEventType.evmlog,
       // The following is the hex-encoded signature for Transfer(address,address,uint256)
       evm_log_signature: 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
@@ -89,7 +89,7 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
 
   const results = pagination.getResults(data?.data)
 
-  if (isFetched && pagination.selectedPage > 1 && !results.data?.length) {
+  if (isFetched && pagination.selectedPageForClient > 1 && !results.data?.length) {
     throw AppErrors.PageDoesNotExist
   }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -88,6 +88,7 @@
     "hash": "Hash",
     "height": "Height",
     "hide": "Hide",
+    "invalidVotes": "Invalid votes",
     "loadMore": "Load more",
     "lessThanAmount": "&lt; {{value, number}} <TickerLink />",
     "method": "Method",
@@ -140,6 +141,9 @@
     "valueInTokenWithLink": "{{value, number}} <TickerLink />",
     "view": "View",
     "viewAll": "View all",
+    "vote": "Vote",
+    "voter": "Voter",
+    "votes": "Votes",
     "paraTimeOnline": "ParaTime Online",
     "paraTimeOutOfDate": "ParaTime Out of date",
     "mainnet": "Mainnet",
@@ -182,6 +186,7 @@
     "create": "Created",
     "createTooltip": "Voting created on epoch shown.",
     "deposit": "Deposit",
+    "failedToLoadAllVotes": "Failed to load all the votes, number might be incomplete!",
     "handler": "Title",
     "id": "ID",
     "listTitle": "Network Change Proposals",
@@ -195,7 +200,14 @@
       "upgrade": "Upgrade",
       "parameterUpgrade": "Parameter upgrade",
       "cancellation": "Cancellation"
-    }
+    },
+    "vote": {
+      "yes": "Yes",
+      "no": "No",
+      "abstain": "Abstained",
+      "all": "All votes"
+    },
+    "searchForVoters": "Search for voters"
   },
   "nft": {
     "accountCollection": "ERC-721 Tokens",

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -905,15 +905,19 @@ export const useGetConsensusValidators: typeof generated.useGetConsensusValidato
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.ValidatorList, headers, status) => {
           if (status !== 200) return data
+          const validators = data.validators.map(validator => {
+            return {
+              ...validator,
+              escrow: fromBaseUnits(validator.escrow, consensusDecimals),
+              ticker,
+            }
+          })
+          const map = new Map<string, generated.Validator>()
+          validators.forEach(validator => map.set(validator.entity_address, validator))
           return {
             ...data,
-            validators: data.validators.map(validator => {
-              return {
-                ...validator,
-                escrow: fromBaseUnits(validator.escrow, consensusDecimals),
-                ticker,
-              }
-            }),
+            validators,
+            map,
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -1,0 +1,38 @@
+import { ProposalVote, Validator } from '../oasis-nexus/api'
+
+export type ProposalVoteValue = (typeof ProposalVoteValue)[keyof typeof ProposalVoteValue]
+
+/**
+ * Valid vote types for network proposals
+ *
+ * Based on https://github.com/oasisprotocol/nexus/blob/main/storage/oasis/nodeapi/api.go#L199
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ProposalVoteValue = {
+  yes: 'yes',
+  no: 'no',
+  abstain: 'abstain',
+} as const
+
+export const getRandomVote = (): ProposalVoteValue =>
+  [ProposalVoteValue.yes, ProposalVoteValue.no, ProposalVoteValue.abstain][Math.floor(Math.random() * 3)]
+
+export type VoteType = ProposalVoteValue | 'any'
+
+export type ExtendedVote = ProposalVote & {
+  index: number
+  areValidatorsLoading: boolean
+  haveValidatorsFailed: boolean
+  validator?: Validator
+}
+
+export type VoteFilter = (vote: ExtendedVote) => boolean
+
+const voteFilters: Record<VoteType, VoteFilter> = {
+  any: () => true,
+  yes: vote => vote.vote === ProposalVoteValue.yes,
+  no: vote => vote.vote === ProposalVoteValue.no,
+  abstain: vote => vote.vote === ProposalVoteValue.abstain,
+}
+
+export const getFilterForVoteType = (voteType: VoteType): VoteFilter => voteFilters[voteType]


### PR DESCRIPTION
Display votes on the proposal details page.

Design is [here](https://www.figma.com/file/8dwSyYOOm3vlgbvxPGT29p/Block-Explorer-(Post-Launch)?node-id=6092%3A212988).

Some of the required data is not yet provided by nexus, including:
 - Timestamps for votes
 - Voting power accompanying the votes

Therefore, some parts are not implemented yet.
