### PR TITLE
Assemble changes for 1.7.0 release

### DIFF
--- a/.changelog/1144.trivial.md
+++ b/.changelog/1144.trivial.md
@@ -1,1 +1,0 @@
-Init Consensus dashboard validators card

--- a/.changelog/1162.internal.md
+++ b/.changelog/1162.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1163.internal.md
+++ b/.changelog/1163.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1166.internal.md
+++ b/.changelog/1166.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1167.internal.md
+++ b/.changelog/1167.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1169.internal.md
+++ b/.changelog/1169.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1171.internal.md
+++ b/.changelog/1171.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1176.trivial.md
+++ b/.changelog/1176.trivial.md
@@ -1,1 +1,0 @@
-Use proper checksum ETH address format in links

--- a/.changelog/1178.feature.md
+++ b/.changelog/1178.feature.md
@@ -1,1 +1,0 @@
-In block details, add prev and next buttons

--- a/.changelog/1180.internal.md
+++ b/.changelog/1180.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1182.internal.md
+++ b/.changelog/1182.internal.md
@@ -1,1 +1,0 @@
-Update Testnet Sapphire block gas limit

--- a/.changelog/1183.internal.md
+++ b/.changelog/1183.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1184.internal.md
+++ b/.changelog/1184.internal.md
@@ -1,1 +1,0 @@
-Group all renovate dependency updates under on Changelog entry

--- a/.changelog/1185.trivial.md
+++ b/.changelog/1185.trivial.md
@@ -1,1 +1,0 @@
-Add Consensus snapshot section layout

--- a/.changelog/1186.bugfix.md
+++ b/.changelog/1186.bugfix.md
@@ -1,1 +1,0 @@
-Fix Safari buggy display of block fill

--- a/.changelog/1187.internal.md
+++ b/.changelog/1187.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1188.internal.md
+++ b/.changelog/1188.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1192.feature.md
+++ b/.changelog/1192.feature.md
@@ -1,1 +1,0 @@
-Add support for searching for network proposal by name

--- a/.changelog/1194.trivial.md
+++ b/.changelog/1194.trivial.md
@@ -1,1 +1,0 @@
-Display detailed timestamp when hovering on age

--- a/.changelog/1195.internal.md
+++ b/.changelog/1195.internal.md
@@ -1,1 +1,0 @@
-Update dependencies

--- a/.changelog/1196.trivial.md
+++ b/.changelog/1196.trivial.md
@@ -1,1 +1,0 @@
-Simplify network selection in layer picker

--- a/.changelog/1197.trivial.md
+++ b/.changelog/1197.trivial.md
@@ -1,1 +1,0 @@
-Add Consensus validator list

--- a/.changelog/1199.internal.md
+++ b/.changelog/1199.internal.md
@@ -1,1 +1,0 @@
-Switch to production API

--- a/.changelog/1201.trivial.md
+++ b/.changelog/1201.trivial.md
@@ -1,1 +1,0 @@
-Improve block details next button

--- a/.changelog/1202.feature.md
+++ b/.changelog/1202.feature.md
@@ -1,1 +1,0 @@
-Add Network proposal details page

--- a/.changelog/1204.trivial.md
+++ b/.changelog/1204.trivial.md
@@ -1,1 +1,0 @@
-Add Consensus proposals list page

--- a/.changelog/1205.trivial.md
+++ b/.changelog/1205.trivial.md
@@ -1,1 +1,0 @@
-Update a comment in NextBlockButton

--- a/.changelog/1208.trivial.md
+++ b/.changelog/1208.trivial.md
@@ -1,1 +1,0 @@
-Proposal details: detect and display type

--- a/.changelog/1210.bugfix.md
+++ b/.changelog/1210.bugfix.md
@@ -1,1 +1,0 @@
-Show view all link only for ERC721 tokens

--- a/.changelog/1215.bugfix.md
+++ b/.changelog/1215.bugfix.md
@@ -1,1 +1,0 @@
-Stop using mainnet block gas limit on testnet

--- a/.changelog/1219.bugfix.md
+++ b/.changelog/1219.bugfix.md
@@ -1,1 +1,0 @@
-Hide next/prev block buttons on mobile lists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 1.7.0 (2024-02-01)
+
+### Features
+
+- In block details, add prev and next buttons
+  ([#1178](https://github.com/oasisprotocol/explorer/issues/1178),
+  [#1219](https://github.com/oasisprotocol/explorer/issues/1219))
+
+### Bug Fixes and Improvements
+
+- Fix Safari buggy display of block fill
+  ([#1186](https://github.com/oasisprotocol/explorer/issues/1186))
+
+- Show view all link only for ERC721 tokens
+  ([#1210](https://github.com/oasisprotocol/explorer/issues/1210))
+
+- Stop using mainnet block gas limit on testnet
+  ([#1215](https://github.com/oasisprotocol/explorer/issues/1215))
+
+### Internal Changes
+
+- Switch to production API
+  ([#1199](https://github.com/oasisprotocol/explorer/issues/1199))
+
+- Update Testnet Sapphire block gas limit
+  ([#1182](https://github.com/oasisprotocol/explorer/issues/1182))
+
+- Group all renovate dependency updates under on Changelog entry
+  ([#1184](https://github.com/oasisprotocol/explorer/issues/1184))
+
+- Update dependencies
+  ([#1162](https://github.com/oasisprotocol/explorer/issues/1162),
+  [#1163](https://github.com/oasisprotocol/explorer/issues/1163),
+  [#1166](https://github.com/oasisprotocol/explorer/issues/1166),
+  [#1167](https://github.com/oasisprotocol/explorer/issues/1167),
+  [#1169](https://github.com/oasisprotocol/explorer/issues/1169),
+  [#1171](https://github.com/oasisprotocol/explorer/issues/1171),
+  [#1180](https://github.com/oasisprotocol/explorer/issues/1180),
+  [#1183](https://github.com/oasisprotocol/explorer/issues/1183),
+  [#1187](https://github.com/oasisprotocol/explorer/issues/1187),
+  [#1188](https://github.com/oasisprotocol/explorer/issues/1188),
+  [#1195](https://github.com/oasisprotocol/explorer/issues/1195))
+
 ## 1.6.0 (2024-01-24)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lukaw3d/parcel-bundler-json-schemas/main/package_schema.json",
   "name": "@oasisprotocol/explorer-frontend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Another attempt to deploy Explorer. We were not able to deploy 1.6.0 due to unstable staging API.