### PR TITLE
Add transparency to text highlight color

### DIFF
--- a/.changelog/1223.trivial.md
+++ b/.changelog/1223.trivial.md
@@ -1,0 +1,1 @@
+Add transparency to text highlight color

--- a/src/app/components/HighlightedText/index.tsx
+++ b/src/app/components/HighlightedText/index.tsx
@@ -26,7 +26,7 @@ export interface HighlightOptions {
 }
 
 const defaultHighlightStyle: SxProps = {
-  background: '#FFFF54',
+  background: '#FFFF5480',
   padding: '4px',
   margin: '-4px',
 }


### PR DESCRIPTION
This is a follow-up to #646.

In order avoid the problem of hiding parts of the characters adjacent to the highlighted text, the highlighting background needs to be partially transparent.

For example, when highlighting "uma" in "Kumaji":

Before the fix: 

![image](https://github.com/oasisprotocol/explorer/assets/2093792/021bd39f-5332-4adf-9ec2-1e0c7745ccfc)

The right part of the letter "K" is partially hidden.

After the fix:

![image](https://github.com/oasisprotocol/explorer/assets/2093792/ff89d415-55f2-42cb-844c-5ee64f46bc0a)
