### PR TITLE
Table styles override

### DIFF
--- a/src/app/components/SubPageCard/index.tsx
+++ b/src/app/components/SubPageCard/index.tsx
@@ -95,7 +95,7 @@ export const SubPageCard: FC<SubPageCardProps> = ({
           {action && <Box sx={{ marginLeft: 'auto' }}>{action}</Box>}
         </Box>
       )}
-      <StyledCard featured={featured} noPadding={noPadding}>
+      <StyledCard featured={featured} noPadding={noPadding} sx={{ backgroundColor: 'transparent' }}>
         {!isMobile && (
           <StyledBox featured={featured}>
             <CardHeader

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -108,15 +108,26 @@ export const Table: FC<TableProps> = ({
 
   return (
     <>
-      <TableContainer>
-        <MuiTable aria-label={name}>
-          <TableHead>
-            <TableRow>
+      <TableContainer
+        sx={{ width: '100% !important', marginLeft: '0 !important', paddingRight: '0 !important' }}
+      >
+        <MuiTable aria-label={name} sx={{ display: 'flex' }}>
+          <TableHead sx={{ display: 'flex' }}>
+            <TableRow
+              sx={{
+                display: 'flex',
+
+                position: 'absolute',
+                top: '-9999px',
+                left: '-9999px',
+              }}
+            >
               {columns.map((column, index) => (
                 <TableCell
                   key={column.key}
                   align={column.align}
                   sx={{
+                    display: 'flex',
                     width: column.width || 'auto',
                     ...(stickyColumn && !index && isMobile ? stickyColumnStyles : {}),
                   }}
@@ -126,17 +137,33 @@ export const Table: FC<TableProps> = ({
               ))}
             </TableRow>
           </TableHead>
-          <TableBody>
+          <TableBody sx={{ display: 'flex', flex: 1, flexDirection: 'column' }}>
             {(alwaysWaitWhileLoading || !rows) && isLoading && (
               <SkeletonTableRows rowsNumber={rowsNumber} columnsNumber={columns.length} />
             )}
             {rows?.map(row => (
-              <StyledTableRow key={row.key} highlight={row.highlight}>
+              <StyledTableRow
+                key={row.key}
+                highlight={row.highlight}
+                sx={{ backgroundColor: 'white', borderRadius: 5, marginBottom: '16px', padding: '8px 16px' }}
+              >
                 {row.data.map((cell, index) => (
                   <TableCell
+                    data-title={columns[index].content}
                     key={cell.key}
-                    align={cell.align}
+                    // align={cell.align}
                     sx={{
+                      display: 'flex',
+                      content: 'attr(data-title)',
+                      border: 'none',
+                      position: 'relative',
+                      padding: '8px 0 8px 0',
+                      '&:before': {
+                        width: '100px',
+                        content: 'attr(data-title)',
+                        whiteSpace: 'break-spaces',
+                      },
+
                       ...(stickyColumn && !index && isMobile ? stickyColumnStyles : {}),
                       ...(extraHorizontalSpaceOnMobile && isMobile ? extraHorizontalPaddingStyles : {}),
                     }}

--- a/src/app/pages/RuntimeBlocksPage/index.tsx
+++ b/src/app/pages/RuntimeBlocksPage/index.tsx
@@ -86,7 +86,8 @@ export const RuntimeBlocksPage: FC = () => {
       <SubPageCard
         title={t('blocks.latest')}
         action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
-        noPadding={tableView === TableLayout.Vertical}
+        // noPadding={tableView === TableLayout.Vertical}
+        noPadding
       >
         {tableView === TableLayout.Horizontal && (
           <RuntimeBlocks

--- a/src/app/pages/TransactionsPage/index.tsx
+++ b/src/app/pages/TransactionsPage/index.tsx
@@ -92,7 +92,8 @@ export const TransactionsPage: FC = () => {
       <SubPageCard
         title={t('transactions.latest')}
         action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
-        noPadding={tableView === TableLayout.Vertical}
+        // noPadding={tableView === TableLayout.Vertical}
+        noPadding
       >
         {tableView === TableLayout.Horizontal && (
           <Transactions


### PR DESCRIPTION
Need preview URL for Don to show differences between vertical data we are showing
sample hardcoded for mobile block and tx lists with vertical overrides

current prod 
![Screenshot from 2024-02-02 12-58-20](https://github.com/oasisprotocol/explorer/assets/891392/5c09695d-71e7-45aa-a420-de0483292b15)

vs 1:1 with horizontal table (we can always add prop isVisible to table cell)
![Screenshot from 2024-02-02 12-58-50](https://github.com/oasisprotocol/explorer/assets/891392/ecae3ff9-5b2c-471e-8f3b-37835f519991)
