### PR TITLE
Fix condition for number of transfer in token details

### DIFF
--- a/.changelog/1228.bugfix.md
+++ b/.changelog/1228.bugfix.md
@@ -1,0 +1,1 @@
+Fix condition for number of transfer in token details

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -72,7 +72,7 @@ export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
                 </dd>
               </>
             )}
-            {nft?.num_transfers && (
+            {typeof nft?.num_transfers === 'number' && !isNaN(nft?.num_transfers) && (
               <>
                 <dt>{t('nft.transfers')}</dt>
                 <dd>{nft.num_transfers.toLocaleString()}</dd>

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -72,7 +72,7 @@ export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
                 </dd>
               </>
             )}
-            {typeof nft?.num_transfers === 'number' && !isNaN(nft?.num_transfers) && (
+            {!!nft?.num_transfers && (
               <>
                 <dt>{t('nft.transfers')}</dt>
                 <dd>{nft.num_transfers.toLocaleString()}</dd>


### PR DESCRIPTION
The newest Nexus deploy revealed UI bug in token instance page
prod 
https://explorer.oasis.io/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/379

fix
https://d5f6a63d.oasis-explorer.pages.dev/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/379

