### PR TITLE
Fix a bug in mobile layer selector

### DIFF
--- a/.changelog/1260.trivial.md
+++ b/.changelog/1260.trivial.md
@@ -1,0 +1,1 @@
+Fix a bug in mobile layer selector

--- a/src/app/components/LayerPicker/index.tsx
+++ b/src/app/components/LayerPicker/index.tsx
@@ -127,12 +127,7 @@ const LayerPickerContent: FC<LayerPickerContentProps> = ({ isOutOfDate, onClose,
               </TabletBackButton>
             )}
           </div>
-          <MobileNetworkButton
-            isOutOfDate={isOutOfDate}
-            network={network}
-            layer={layer}
-            onClick={handleConfirm}
-          />
+          <MobileNetworkButton isOutOfDate={isOutOfDate} network={network} layer={layer} onClick={onClose} />
         </TabletActionBar>
       )}
       <Divider />


### PR DESCRIPTION
When opening the layer selector on mobile,
there is button in the top right, showing the
originally selected layer.

Clicking on this button should bring the user back to the originally selected layer, but instead, currently it confirms the current (new) selection.

This change fixes that.