### PR TITLE
Bring back type safety in LearningMaterials

### DIFF
--- a/.changelog/1264.trivial.md
+++ b/.changelog/1264.trivial.md
@@ -1,0 +1,1 @@
+Bring back type safety in LearningMaterials

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -118,7 +118,7 @@ const getContent = (t: TFunction) => {
         },
       },
     },
-  } satisfies SpecifiedPerEnabledRuntime<LayerContent | undefined>
+  } satisfies SpecifiedPerEnabledRuntime<LayerContent>
 }
 
 export const LearningMaterials: FC<{ scope: SearchScope }> = ({ scope }) => {


### PR DESCRIPTION
Reverted part of d668a436955a1f1b0459f7410ace53662c679b82 after d4c0776eca07b7a00799200f7acae63a88463a19

Fixes part of https://github.com/oasisprotocol/explorer/issues/1263