### PR TITLE
Consensus Snapshot cards tweaks

### DIFF
--- a/.changelog/1284.trivial.md
+++ b/.changelog/1284.trivial.md
@@ -1,0 +1,1 @@
+Consensus Snaphot cards tweaks

--- a/src/app/components/ProgressBar/index.tsx
+++ b/src/app/components/ProgressBar/index.tsx
@@ -35,3 +35,12 @@ export const ProgressBar = styled(LinearProgress)(() => ({
   height: '12px',
   width: '85px',
 }))
+
+export const BrandProgressBar = styled(LinearProgress)(() => ({
+  [`&.${linearProgressClasses.determinate} > .${linearProgressClasses.bar1Determinate}`]: {
+    backgroundColor: COLORS.brandDark,
+  },
+  borderColor: COLORS.grayLight,
+  backgroundColor: COLORS.grayLight,
+  height: '12px',
+}))

--- a/src/app/components/Snapshots/SnapshotCard.tsx
+++ b/src/app/components/Snapshots/SnapshotCard.tsx
@@ -61,7 +61,13 @@ export const SnapshotCard: FC<SnapshotCardProps> = ({
             }}
           >
             <Box>{badge}</Box>
-            <Typography variant="h2" sx={{ fontWeight: 'fontWeightRegular' }}>
+            <Typography
+              variant="h2"
+              sx={{
+                fontWeight: 400,
+                flex: 1,
+              }}
+            >
               {label}
             </Typography>
           </Box>

--- a/src/app/components/Snapshots/SnapshotCard.tsx
+++ b/src/app/components/Snapshots/SnapshotCard.tsx
@@ -93,6 +93,10 @@ export const SnapshotTextCard: FC<SnapshotTextCardProps> = ({ children, label, t
             fontSize: '32px',
             fontWeight: 700,
             color: COLORS.brandDark,
+            flex: 1,
+            textAlign: 'center',
+            paddingLeft: 4,
+            paddingRight: 4,
           }}
         >
           {children}

--- a/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
+++ b/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
@@ -13,7 +13,7 @@ export const SnapshotCardDurationLabel: FC<SnapshotCardLabelProps> = ({ label, v
   }
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 3 }}>
       <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>{label}</Typography>
       <Typography sx={{ fontSize: 'inherit' }}>{value.toLocaleString()}</Typography>
     </Box>

--- a/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
+++ b/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
@@ -13,7 +13,7 @@ export const ConsensusSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
   return (
     <Snapshot title={t('consensusSnapshot.title')} scope={scope}>
       <StyledGrid item xs={22} md={5}>
-        <SnapshotEpoch />
+        <SnapshotEpoch scope={scope} />
       </StyledGrid>
       <StyledGrid item xs={22} md={6}>
         <SnapshotValidators scope={scope} />

--- a/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
+++ b/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
@@ -11,7 +11,7 @@ export const ConsensusSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
 
   return (
-    <Snapshot title={t('consensusSnapshot')} scope={scope}>
+    <Snapshot title={t('consensusSnapshot.title')} scope={scope}>
       <StyledGrid item xs={22} md={5}>
         <SnapshotEpoch />
       </StyledGrid>

--- a/src/app/pages/ConsensusDashboardPage/SnapshotDelegators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotDelegators.tsx
@@ -1,13 +1,18 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
+import { useScreenSize } from '../../hooks/useScreensize'
 
 export const SnapshotDelegators: FC = () => {
   const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+  // TODO: provide delegators number when API is ready
+  const delegators = undefined
 
   return (
     <SnapshotTextCard title={t('validator.delegators')}>
-      {/* TODO: provide delegators number when API is ready */}-
+      <Box sx={{ pb: isMobile ? 3 : 5 }}>{delegators}</Box>
     </SnapshotTextCard>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
@@ -2,15 +2,25 @@ import { FC } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
 import { useGetStatus } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
+import { BrandProgressBar } from '../../components/ProgressBar'
+
+const StyledBox = styled(Box)(({ theme }) => ({
+  marginTop: `-${theme.spacing(3)}`,
+  marginBottom: theme.spacing(3),
+}))
 
 export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const statusQuery = useGetStatus(scope.network)
   const blockHeight = statusQuery?.data?.data.latest_block
+  // TODO: provide epoch number when API is ready
+  const epoch = undefined
+  const percentageValue = undefined
 
   return (
     <SnapshotTextCard
@@ -35,7 +45,22 @@ export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
         )
       }
     >
-      {/* TODO: provide epoch number when API is ready */}-
+      {epoch && (
+        <>
+          {percentageValue && (
+            <StyledBox>
+              <BrandProgressBar value={percentageValue} variant="determinate" />
+            </StyledBox>
+          )}
+          <Box gap={3} sx={{ display: 'flex', alignItems: 'baseline' }}>
+            {/* TODO: remove casting when real types are available, validate percentageValue formatting  */}
+            {(epoch as number).toLocaleString()}
+            {percentageValue && (
+              <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>({percentageValue})</Typography>
+            )}
+          </Box>
+        </>
+      )}
     </SnapshotTextCard>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
@@ -1,12 +1,40 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { useGetStatus } from '../../../oasis-nexus/api'
+import { SearchScope } from '../../../types/searchScope'
+import { COLORS } from '../../../styles/theme/colors'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 
-export const SnapshotEpoch: FC = () => {
+export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
+  const statusQuery = useGetStatus(scope.network)
+  const blockHeight = statusQuery?.data?.data.latest_block
 
   return (
-    <SnapshotTextCard title={t('currentEpoch')}>
+    <SnapshotTextCard
+      title={t('currentEpoch')}
+      label={
+        blockHeight && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+            <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>
+              <Trans
+                t={t}
+                i18nKey="consensusSnapshot.blockHeight"
+                components={{
+                  BlockHeight: (
+                    <Typography component="span" sx={{ fontSize: '24px', color: COLORS.grayExtraDark }}>
+                      {blockHeight.toLocaleString()}
+                    </Typography>
+                  ),
+                }}
+              />
+            </Typography>
+          </Box>
+        )
+      }
+    >
       {/* TODO: provide epoch number when API is ready */}-
     </SnapshotTextCard>
   )

--- a/src/app/pages/ConsensusDashboardPage/SnapshotStaked.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotStaked.tsx
@@ -1,13 +1,49 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { COLORS } from '../../../styles/theme/colors'
+import { RoundedBalance } from '../../components/RoundedBalance'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 
 export const SnapshotStaked: FC = () => {
   const { t } = useTranslation()
+  //  TODO: provide label and staked values when API is ready, validate percentageValue formatting
+  const staked = undefined
+  const percentageValue = undefined
 
   return (
-    <SnapshotTextCard title={t('validator.staked')}>
-      {/* TODO: provide label and staked values when API is ready */}-
+    <SnapshotTextCard
+      title={t('validator.staked')}
+      label={
+        percentageValue && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+            <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>
+              <Trans
+                t={t}
+                i18nKey="consensusSnapshot.totalCirculation"
+                components={{
+                  StakedPercentage: (
+                    <Typography component="span" sx={{ fontSize: '24px', color: COLORS.grayExtraDark }}>
+                      {t('common.valuePair', {
+                        value: percentageValue,
+                        formatParams: {
+                          value: {
+                            style: 'percent',
+                            maximumFractionDigits: 2,
+                          } satisfies Intl.NumberFormatOptions,
+                        },
+                      })}
+                    </Typography>
+                  ),
+                }}
+              />
+            </Typography>
+          </Box>
+        )
+      }
+    >
+      {staked && <RoundedBalance value={staked} />}
     </SnapshotTextCard>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/SnapshotValidators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotValidators.tsx
@@ -39,15 +39,17 @@ export const SnapshotValidators: FC<{ scope: SearchScope }> = ({ scope }) => {
 
   return (
     <SnapshotCard title={t('validator.listTitle')}>
-      <PieChart
-        compact
-        data={countValidatorsState(t, validators)}
-        dataKey="value"
-        formatters={{
-          data: (value: number) => value.toLocaleString(),
-          label: (status: string) => t('validator.groupStatus', { status }),
-        }}
-      />
+      {!!validators?.length && (
+        <PieChart
+          compact
+          data={countValidatorsState(t, validators)}
+          dataKey="value"
+          formatters={{
+            data: (value: number) => value.toLocaleString(),
+            label: (status: string) => t('validator.groupStatus', { status }),
+          }}
+        />
+      )}
     </SnapshotCard>
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -148,6 +148,7 @@
     }
   },
   "consensusSnapshot": {
+    "blockHeight": "Block Height <BlockHeight />",
     "title": "Consensus Snapshot",
     "totalCirculation": "This is <StakedPercentage /> of the total circulation"
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -147,7 +147,10 @@
       "explainVerificationDelay": "If you have just verified a contract, it should take a few minutes to update here."
     }
   },
-  "consensusSnapshot": "Consensus Snapshot",
+  "consensusSnapshot": {
+    "title": "Consensus Snapshot",
+    "totalCirculation": "This is <StakedPercentage /> of the total circulation"
+  },
   "currentEpoch": "Current Epoch",
   "dapps": {
     "wrose": {


### PR DESCRIPTION
Add more details to Consensus snapshot cards

with mocked data:
![Screenshot from 2024-02-22 13-31-00](https://github.com/oasisprotocol/explorer/assets/891392/cb2d1977-7623-4093-8671-1bb2355e777c)
