### PR TITLE
Tune links and hashes

### DIFF
--- a/.changelog/1290.trivial.md
+++ b/.changelog/1290.trivial.md
@@ -1,0 +1,1 @@
+Update how links and hashes are displayed on mobile

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -1,40 +1,108 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
 import Link from '@mui/material/Link'
-import { TrimLinkLabel } from '../TrimLinkLabel'
 import { RouteUtils } from '../../utils/route-utils'
+import InfoIcon from '@mui/icons-material/Info'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
 import { SearchScope } from '../../../types/searchScope'
+import { trimLongString } from '../../utils/trimLongString'
+import { MaybeWithTooltip } from '../AdaptiveTrimmer/MaybeWithTooltip'
+import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 
-export const AccountLink: FC<{
-  scope: SearchScope
-  address: string
-  alwaysTrim?: boolean
+const WithTypographyAndLink: FC<{
+  to: string
   plain?: boolean
-}> = ({ scope, address, alwaysTrim, plain }) => {
-  const { isTablet } = useScreenSize()
-  const to = RouteUtils.getAccountRoute(scope, address)
+  mobile?: boolean
+  children: ReactNode
+}> = ({ children, to, plain, mobile }) => {
   return (
     <Typography
       variant="mono"
       component="span"
-      sx={
-        plain
+      sx={{
+        ...(mobile
+          ? {
+              maxWidth: '100%',
+              overflowX: 'hidden',
+            }
+          : {}),
+        ...(plain
           ? { color: COLORS.grayExtraDark, fontWeight: 400 }
-          : { color: COLORS.brandDark, fontWeight: 700 }
-      }
+          : { color: COLORS.brandDark, fontWeight: 700 }),
+      }}
     >
-      {alwaysTrim || isTablet ? (
-        <TrimLinkLabel label={address} to={to} />
-      ) : plain ? (
-        address
+      {plain ? (
+        children
       ) : (
         <Link component={RouterLink} to={to}>
-          {address}
+          {children}
         </Link>
       )}
     </Typography>
+  )
+}
+
+export const AccountLink: FC<{
+  scope: SearchScope
+  address: string
+
+  /**
+   * Should we always trim the text to a short line?
+   */
+  alwaysTrim?: boolean
+
+  /**
+   * Plain mode? (No link required)
+   */
+  plain?: boolean
+
+  /**
+   * Any extra tooltips to display
+   *
+   * (Besides the content necessary because of potential shortening)
+   */
+  extraTooltip?: ReactNode
+}> = ({ scope, address, alwaysTrim, plain, extraTooltip }) => {
+  const { isTablet } = useScreenSize()
+  const to = RouteUtils.getAccountRoute(scope, address)
+
+  const tooltipPostfix = extraTooltip ? (
+    <>
+      <InfoIcon />
+      {extraTooltip}
+    </>
+  ) : undefined
+
+  // Are we in a table?
+  if (alwaysTrim) {
+    // In a table, we only ever want one short line
+
+    return (
+      <WithTypographyAndLink to={to} plain={plain}>
+        <MaybeWithTooltip title={address}>{trimLongString(address, 6, 6)}</MaybeWithTooltip>
+      </WithTypographyAndLink>
+    )
+  }
+
+  if (!isTablet) {
+    // Details in desktop mode.
+    // We want one long line, with name and address.
+
+    return (
+      <WithTypographyAndLink to={to} plain={plain}>
+        <MaybeWithTooltip title={tooltipPostfix}>{address} </MaybeWithTooltip>
+      </WithTypographyAndLink>
+    )
+  }
+
+  // We need to show the data in details mode on mobile.
+  // We want two lines, one for name (if available), one for address
+  // Both line adaptively shortened to fill available space
+  return (
+    <WithTypographyAndLink to={to} plain={plain} mobile>
+      <AdaptiveTrimmer text={address} strategy="middle" extraTooltip={extraTooltip} />
+    </WithTypographyAndLink>
   )
 }

--- a/src/app/components/Account/ContractCreatorInfo.tsx
+++ b/src/app/components/Account/ContractCreatorInfo.tsx
@@ -14,7 +14,11 @@ import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import { useScreenSize } from '../../hooks/useScreensize'
 
-const TxSender: FC<{ scope: SearchScope; txHash: string }> = ({ scope, txHash }) => {
+const TxSender: FC<{ scope: SearchScope; txHash: string; alwaysTrim?: boolean }> = ({
+  scope,
+  txHash,
+  alwaysTrim,
+}) => {
   const { t } = useTranslation()
   if (scope.layer === Layer.consensus) {
     throw AppErrors.UnsupportedLayer
@@ -31,7 +35,7 @@ const TxSender: FC<{ scope: SearchScope; txHash: string }> = ({ scope, txHash })
       }}
     />
   ) : senderAddress ? (
-    <AccountLink scope={scope} address={senderAddress} alwaysTrim />
+    <AccountLink scope={scope} address={senderAddress} alwaysTrim={alwaysTrim} />
   ) : (
     t('common.missing')
   )
@@ -41,7 +45,8 @@ export const ContractCreatorInfo: FC<{
   scope: SearchScope
   isLoading?: boolean
   creationTxHash: string | undefined
-}> = ({ scope, isLoading, creationTxHash }) => {
+  alwaysTrim?: boolean
+}> = ({ scope, isLoading, creationTxHash, alwaysTrim }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -59,9 +64,9 @@ export const ContractCreatorInfo: FC<{
         minWidth: '25%',
       }}
     >
-      <TxSender scope={scope} txHash={creationTxHash} />
+      <TxSender scope={scope} txHash={creationTxHash} alwaysTrim={alwaysTrim} />
       <Box>{t('contract.createdAt')}</Box>
-      <TransactionLink scope={scope} hash={creationTxHash} alwaysTrim />
+      <TransactionLink scope={scope} hash={creationTxHash} alwaysTrim={alwaysTrim} />
     </Box>
   )
 }
@@ -69,7 +74,8 @@ export const ContractCreatorInfo: FC<{
 export const DelayedContractCreatorInfo: FC<{
   scope: SearchScope
   contractOasisAddress: string | undefined
-}> = ({ scope, contractOasisAddress }) => {
+  alwaysTrim?: boolean
+}> = ({ scope, contractOasisAddress, alwaysTrim }) => {
   const accountQuery = useGetRuntimeAccountsAddress(
     scope.network,
     scope.layer as Runtime,
@@ -82,6 +88,11 @@ export const DelayedContractCreatorInfo: FC<{
   const creationTxHash = contract?.eth_creation_tx || contract?.creation_tx
 
   return (
-    <ContractCreatorInfo scope={scope} isLoading={accountQuery.isLoading} creationTxHash={creationTxHash} />
+    <ContractCreatorInfo
+      scope={scope}
+      isLoading={accountQuery.isLoading}
+      creationTxHash={creationTxHash}
+      alwaysTrim={alwaysTrim}
+    />
   )
 }

--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -100,6 +100,7 @@ export const Account: FC<AccountProps> = ({ account, token, isLoading, tokenPric
                 <ContractCreatorInfo
                   scope={account}
                   creationTxHash={contract.eth_creation_tx || contract.creation_tx}
+                  alwaysTrim
                 />
               </dd>
             </>

--- a/src/app/components/AccountList/index.tsx
+++ b/src/app/components/AccountList/index.tsx
@@ -39,7 +39,7 @@ export const AccountList: FC<AccountListProps> = ({ isLoading, limit, pagination
         key: 'size',
       },
       {
-        content: <AccountLink scope={account} address={account.address} />,
+        content: <AccountLink scope={account} address={account.address} alwaysTrim />,
         key: 'address',
       },
       ...(verbose

--- a/src/app/components/AdaptiveTrimmer/AdaptiveTrimmer.tsx
+++ b/src/app/components/AdaptiveTrimmer/AdaptiveTrimmer.tsx
@@ -1,0 +1,140 @@
+import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import InfoIcon from '@mui/icons-material/Info'
+import { trimLongString } from '../../utils/trimLongString'
+import { MaybeWithTooltip } from './MaybeWithTooltip'
+
+type AdaptiveTrimmerProps = {
+  text: string | undefined
+  strategy: 'middle' | 'end'
+  extraTooltip?: ReactNode
+}
+
+/**
+ * Display content, potentially shortened as needed.
+ *
+ * This component will do automatic detection of available space,
+ * and determine the best way to display content accordingly.
+ */
+export const AdaptiveTrimmer: FC<AdaptiveTrimmerProps> = ({ text = '', strategy = 'end', extraTooltip }) => {
+  // Initial setup
+  const fullLength = text.length
+  const textRef = useRef<HTMLDivElement | null>(null)
+
+  // Data about the currently rendered version
+  const [currentContent, setCurrentContent] = useState('')
+  const [currentLength, setCurrentLength] = useState(0)
+
+  // Known good - this fits
+  const [largestKnownGood, setLargestKnownGood] = useState(0)
+
+  // Known bad - this doesn't fit
+  const [smallestKnownBad, setSmallestKnownBad] = useState(fullLength + 1)
+
+  // Are we exploring our possibilities now?
+  const [inDiscovery, setInDiscovery] = useState(false)
+
+  const attemptContent = useCallback((content: string, length: number) => {
+    setCurrentContent(content)
+    setCurrentLength(length)
+  }, [])
+
+  const attemptShortenedContent = useCallback(
+    (length: number) => {
+      const content =
+        strategy === 'middle'
+          ? trimLongString(text, Math.floor(length / 2) - 1, Math.floor(length / 2) - 1)!
+          : trimLongString(text, length, 0)!
+
+      attemptContent(content, length)
+    },
+    [strategy, text, attemptContent],
+  )
+
+  const initDiscovery = useCallback(() => {
+    setLargestKnownGood(0)
+    setSmallestKnownBad(fullLength + 1)
+    attemptContent(text, fullLength)
+    setInDiscovery(true)
+  }, [text, fullLength, attemptContent])
+
+  useEffect(() => {
+    initDiscovery()
+    const handleResize = () => {
+      initDiscovery()
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [initDiscovery])
+
+  useEffect(() => {
+    if (inDiscovery) {
+      if (!textRef.current) {
+        return
+      }
+      const isOverflow = textRef.current.scrollWidth > textRef.current.clientWidth
+
+      if (isOverflow) {
+        // This is too much
+
+        // Update known bad length
+        const newSmallestKnownBad = Math.min(currentLength, smallestKnownBad)
+        setSmallestKnownBad(newSmallestKnownBad)
+
+        // We should try something smaller
+        attemptShortenedContent(Math.floor((largestKnownGood + newSmallestKnownBad) / 2))
+      } else {
+        // This is OK
+
+        // Update known good length
+        const newLargestKnownGood = Math.max(currentLength, largestKnownGood)
+        setLargestKnownGood(currentLength)
+
+        if (currentLength === fullLength) {
+          // The whole thing fits, so we are good.
+          setInDiscovery(false)
+        } else {
+          if (currentLength + 1 === smallestKnownBad) {
+            // This the best we can do, for now
+            setInDiscovery(false)
+          } else {
+            // So far, so good, but we should try something longer
+            attemptShortenedContent(Math.floor((newLargestKnownGood + smallestKnownBad) / 2))
+          }
+        }
+      }
+    }
+  }, [inDiscovery, currentLength, largestKnownGood, smallestKnownBad, attemptShortenedContent, fullLength])
+
+  if (!text) return null
+
+  const title =
+    currentLength !== fullLength ? (
+      <Box>
+        <Box>{text}</Box>
+        {extraTooltip && (
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+            <InfoIcon />
+            {extraTooltip}
+          </Box>
+        )}
+      </Box>
+    ) : (
+      extraTooltip
+    )
+
+  return (
+    <Box
+      ref={textRef}
+      sx={{
+        overflow: 'hidden',
+        maxWidth: '100%',
+      }}
+    >
+      <MaybeWithTooltip title={title} spanSx={{ whiteSpace: 'nowrap' }}>
+        {currentContent}
+      </MaybeWithTooltip>
+    </Box>
+  )
+}

--- a/src/app/components/AdaptiveTrimmer/MaybeWithTooltip.tsx
+++ b/src/app/components/AdaptiveTrimmer/MaybeWithTooltip.tsx
@@ -1,0 +1,65 @@
+import { FC, ReactNode } from 'react'
+import Tooltip from '@mui/material/Tooltip'
+import Box from '@mui/material/Box'
+import { SxProps } from '@mui/material/styles'
+
+type MaybeWithTooltipProps = {
+  /**
+   * Do we want to show the tooltip?
+   *
+   * Default is true
+   */
+  tooltipWanted?: boolean
+
+  /**
+   * What should be the content of the tooltip?
+   *
+   * Undefined means no tooltip
+   */
+  title?: ReactNode
+
+  /**
+   * Any extra styles to apply to the span
+   */
+  spanSx?: SxProps
+
+  /**
+   * The content to show
+   */
+  children: ReactNode
+}
+
+/**
+ * A component to display some content with or without a tooltip
+ */
+export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({
+  tooltipWanted = true,
+  title,
+  children,
+  spanSx,
+}) =>
+  tooltipWanted && !!title ? (
+    <Tooltip
+      placement="top"
+      title={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {title}
+        </Box>
+      }
+    >
+      <Box component="span" sx={spanSx}>
+        {children}
+      </Box>
+    </Tooltip>
+  ) : (
+    <Box component="span" sx={spanSx}>
+      {children}
+    </Box>
+  )

--- a/src/app/components/Blocks/BlockLink.tsx
+++ b/src/app/components/Blocks/BlockLink.tsx
@@ -7,6 +7,7 @@ import { RouteUtils } from '../../utils/route-utils'
 import { TrimLinkLabel } from '../TrimLinkLabel'
 import { SearchScope } from '../../../types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 
 export const BlockLink: FC<{ scope: SearchScope; height: number }> = ({ scope, height }) => (
   <Typography variant="mono">
@@ -23,15 +24,34 @@ export const BlockHashLink: FC<{
   alwaysTrim?: boolean
 }> = ({ scope, hash, height, alwaysTrim }) => {
   const { isTablet } = useScreenSize()
-  return (
-    <Typography variant="mono">
-      {isTablet || alwaysTrim ? (
-        <TrimLinkLabel label={hash} to={RouteUtils.getBlockRoute(scope, height)} />
-      ) : (
-        <Link component={RouterLink} to={RouteUtils.getBlockRoute(scope, height)}>
+  const to = RouteUtils.getBlockRoute(scope, height)
+
+  if (alwaysTrim) {
+    // Table view
+    return (
+      <Typography variant="mono">
+        <TrimLinkLabel label={hash} to={to} />
+      </Typography>
+    )
+  }
+
+  if (!isTablet) {
+    // Desktop view
+    return (
+      <Typography variant="mono">
+        <Link component={RouterLink} to={to}>
           {hash}
         </Link>
-      )}
+      </Typography>
+    )
+  }
+
+  // Mobile view
+  return (
+    <Typography variant="mono" sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
+      <Link component={RouterLink} to={to}>
+        <AdaptiveTrimmer text={hash} strategy="middle" />
+      </Link>
     </Typography>
   )
 }

--- a/src/app/components/StyledDescriptionList/index.tsx
+++ b/src/app/components/StyledDescriptionList/index.tsx
@@ -61,6 +61,8 @@ export const StyledDescriptionList = styled(InlineDescriptionList, {
     color: COLORS.brandExtraDark,
     overflowWrap: 'anywhere',
     alignItems: 'center',
+    maxWidth: '100%',
+    overflowX: 'hidden',
   },
   ...(standalone && {
     '&&': {

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -53,7 +53,11 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
         {
           key: 'address',
           content: (
-            <AccountLink scope={holder} address={holder.eth_holder_address || holder.holder_address} />
+            <AccountLink
+              scope={holder}
+              address={holder.eth_holder_address || holder.holder_address}
+              alwaysTrim
+            />
           ),
         },
         {

--- a/src/app/components/Tokens/TokenList.tsx
+++ b/src/app/components/Tokens/TokenList.tsx
@@ -107,7 +107,11 @@ export const TokenList = (props: TokensProps) => {
         {
           content: (
             <span>
-              <AccountLink scope={token} address={token.eth_contract_addr ?? token.contract_addr} />
+              <AccountLink
+                scope={token}
+                address={token.eth_contract_addr ?? token.contract_addr}
+                alwaysTrim
+              />
               <CopyToClipboard value={token.eth_contract_addr ?? token.contract_addr} />
             </span>
           ),

--- a/src/app/components/Tokens/TokenTransfers.tsx
+++ b/src/app/components/Tokens/TokenTransfers.tsx
@@ -186,7 +186,7 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
                     {trimLongString(fromAddress)}
                   </Typography>
                 ) : (
-                  <AccountLink scope={transfer} address={fromAddress} alwaysTrim={true} />
+                  <AccountLink scope={transfer} address={fromAddress} alwaysTrim />
                 )}
 
                 <StyledCircle>
@@ -210,7 +210,7 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
               {trimLongString(toAddress)}
             </Typography>
           ) : (
-            <AccountLink scope={transfer} address={toAddress} alwaysTrim={true} />
+            <AccountLink scope={transfer} address={toAddress} alwaysTrim />
           ),
         },
         ...(differentTokens

--- a/src/app/components/Tokens/TokenTransfers.tsx
+++ b/src/app/components/Tokens/TokenTransfers.tsx
@@ -116,7 +116,7 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
   ownAddress,
 }) => {
   const { t } = useTranslation()
-  const { isMobile } = useScreenSize()
+  const { isTablet } = useScreenSize()
   const tableColumns: TableColProps[] = [
     { key: 'hash', content: t('common.hash') },
     { key: 'block', content: t('common.block') },
@@ -139,7 +139,7 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
           content: (
             <TransactionLink
               scope={transfer}
-              alwaysTrim={isMobile}
+              alwaysTrim={isTablet}
               hash={transfer.eth_tx_hash || transfer.tx_hash!}
             />
           ),

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -1,11 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import { Transaction } from '../../../oasis-nexus/api'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { RoundedBalance } from '../../components/RoundedBalance'
-import { trimLongString } from '../../utils/trimLongString'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { BlockLink } from '../Blocks/BlockLink'
 import { AccountLink } from '../Account/AccountLink'
@@ -65,7 +63,7 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
         key: 'success',
       },
       {
-        content: <TransactionLink scope={transaction} alwaysTrim={true} hash={transaction.hash} />,
+        content: <TransactionLink scope={transaction} alwaysTrim hash={transaction.hash} />,
         key: 'hash',
       },
       {
@@ -96,19 +94,12 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
                     pr: 3,
                   }}
                 >
-                  {!!ownAddress && transaction.sender === ownAddress ? (
-                    <Typography
-                      variant="mono"
-                      component="span"
-                      sx={{
-                        fontWeight: 700,
-                      }}
-                    >
-                      {trimLongString(transaction.sender)}
-                    </Typography>
-                  ) : (
-                    <AccountLink scope={transaction} address={transaction.sender} alwaysTrim={true} />
-                  )}
+                  <AccountLink
+                    scope={transaction}
+                    address={transaction.sender}
+                    alwaysTrim
+                    plain={!!ownAddress && transaction.sender === ownAddress}
+                  />
                 </Box>
               ),
               key: 'from',

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -14,8 +14,6 @@ import { TablePaginationProps } from '../Table/TablePagination'
 import { BlockLink } from '../Blocks/BlockLink'
 import { AccountLink } from '../Account/AccountLink'
 import { TransactionLink } from './TransactionLink'
-import { trimLongString } from '../../utils/trimLongString'
-import Typography from '@mui/material/Typography'
 import { doesAnyOfTheseLayersSupportEncryptedTransactions } from '../../../types/layers'
 import { TransactionEncryptionStatus } from '../TransactionEncryptionStatus'
 import { Age } from '../Age'
@@ -104,11 +102,7 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
           : []),
         {
           content: (
-            <TransactionLink
-              scope={transaction}
-              alwaysTrim={true}
-              hash={transaction.eth_hash || transaction.hash}
-            />
+            <TransactionLink scope={transaction} alwaysTrim hash={transaction.eth_hash || transaction.hash} />
           ),
           key: 'hash',
         },
@@ -139,24 +133,15 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
                       pr: 3,
                     }}
                   >
-                    {!!ownAddress &&
-                    (transaction.sender_0_eth === ownAddress || transaction.sender_0 === ownAddress) ? (
-                      <Typography
-                        variant="mono"
-                        component="span"
-                        sx={{
-                          fontWeight: 700,
-                        }}
-                      >
-                        {trimLongString(transaction.sender_0_eth || transaction.sender_0)}
-                      </Typography>
-                    ) : (
-                      <AccountLink
-                        scope={transaction}
-                        address={transaction.sender_0_eth || transaction.sender_0}
-                        alwaysTrim={true}
-                      />
-                    )}
+                    <AccountLink
+                      scope={transaction}
+                      address={transaction.sender_0_eth || transaction.sender_0}
+                      alwaysTrim
+                      plain={
+                        !!ownAddress &&
+                        (transaction.sender_0_eth === ownAddress || transaction.sender_0 === ownAddress)
+                      }
+                    />
                     {targetAddress && (
                       <StyledCircle>
                         <ArrowForwardIcon fontSize="inherit" />
@@ -168,19 +153,14 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
               },
               {
                 content: targetAddress ? (
-                  !!ownAddress && (transaction.to_eth === ownAddress || transaction.to === ownAddress) ? (
-                    <Typography
-                      variant="mono"
-                      component="span"
-                      sx={{
-                        fontWeight: 700,
-                      }}
-                    >
-                      {trimLongString(targetAddress)}
-                    </Typography>
-                  ) : (
-                    <AccountLink scope={transaction} address={targetAddress} alwaysTrim={true} />
-                  )
+                  <AccountLink
+                    scope={transaction}
+                    address={targetAddress}
+                    alwaysTrim
+                    plain={
+                      !!ownAddress && (transaction.to_eth === ownAddress || transaction.to === ownAddress)
+                    }
+                  />
                 ) : null,
                 key: 'to',
               },

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -1,33 +1,88 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
+import InfoIcon from '@mui/icons-material/Info'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { TrimLinkLabel } from '../TrimLinkLabel'
 import { RouteUtils } from '../../utils/route-utils'
 import { SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
+import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
+import { MaybeWithTooltip } from '../AdaptiveTrimmer/MaybeWithTooltip'
+import { trimLongString } from '../../utils/trimLongString'
+import Box from '@mui/material/Box'
+
+const WithTypographyAndLink: FC<{ children: ReactNode; plain?: boolean; mobile?: boolean; to: string }> = ({
+  children,
+  plain,
+  mobile,
+  to,
+}) => (
+  <Typography
+    variant="mono"
+    component="span"
+    sx={{
+      ...(plain ? { color: COLORS.grayExtraDark, fontWeight: 400 } : {}),
+      ...(mobile ? { maxWidth: '85%' } : {}),
+    }}
+  >
+    {plain ? (
+      children
+    ) : (
+      <Link component={RouterLink} to={to}>
+        {children}
+      </Link>
+    )}
+  </Typography>
+)
 
 export const TransactionLink: FC<{
   alwaysTrim?: boolean
   scope: SearchScope
   hash: string
   plain?: boolean
-}> = ({ alwaysTrim, hash, scope, plain }) => {
-  const { isMobile } = useScreenSize()
+  extraTooltip?: ReactNode
+}> = ({ alwaysTrim, hash, scope, plain, extraTooltip }) => {
+  const { isTablet } = useScreenSize()
   const to = RouteUtils.getTransactionRoute(scope, hash)
+  const tooltipPostfix = extraTooltip ? (
+    <Box sx={{ display: 'flex', alignContent: 'center', gap: 2 }}>
+      <InfoIcon />
+      {extraTooltip}
+    </Box>
+  ) : undefined
 
+  if (alwaysTrim) {
+    // Table mode
+    return (
+      <WithTypographyAndLink plain={plain} to={to}>
+        <MaybeWithTooltip
+          title={
+            <Box>
+              {hash}
+              {tooltipPostfix}
+            </Box>
+          }
+        >
+          {trimLongString(hash, 6, 6)}
+        </MaybeWithTooltip>
+      </WithTypographyAndLink>
+    )
+  }
+
+  if (!isTablet) {
+    // Desktop mode
+    return (
+      <WithTypographyAndLink plain={plain} to={to}>
+        <MaybeWithTooltip title={tooltipPostfix}>{hash}</MaybeWithTooltip>
+      </WithTypographyAndLink>
+    )
+  }
+
+  // Mobile mode
   return (
-    <Typography variant="mono" sx={{ ...(plain ? { color: COLORS.grayExtraDark, fontWeight: 400 } : {}) }}>
-      {alwaysTrim || isMobile ? (
-        <TrimLinkLabel label={hash} to={to} plain={plain} />
-      ) : plain ? (
-        hash
-      ) : (
-        <Link component={RouterLink} to={to}>
-          {hash}
-        </Link>
-      )}
-    </Typography>
+    <WithTypographyAndLink mobile plain={plain} to={to}>
+      <AdaptiveTrimmer text={hash} strategy="middle" extraTooltip={extraTooltip} />
+    </WithTypographyAndLink>
   )
 }

--- a/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountNFTCollectionCard.tsx
@@ -44,7 +44,7 @@ export const AccountNFTCollectionCard: FC<AccountDetailsContext> = ({ scope, add
             isFetched &&
             firstToken && (
               <Box sx={{ display: 'flex', alignItems: 'flex-start', paddingY: 3 }}>
-                <AccountLink scope={scope} address={firstToken?.eth_contract_addr} />
+                <AccountLink scope={scope} address={firstToken?.eth_contract_addr} alwaysTrim />
                 <CopyToClipboard value={firstToken?.eth_contract_addr} />
               </Box>
             )

--- a/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/AccountDetailsPage/AccountTokensCard.tsx
@@ -30,10 +30,14 @@ type AccountTokensCardProps = AccountDetailsContext & {
 
 export const accountTokenContainerId = 'tokens'
 
-export const ContractLink: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const ContractLink: FC<{ scope: SearchScope; address: string; alwaysTrim?: boolean }> = ({
+  scope,
+  address,
+  alwaysTrim,
+}) => {
   return (
     <Box sx={{ display: 'flex', alignContent: 'center' }}>
-      <AccountLink scope={scope} address={address} />
+      <AccountLink scope={scope} address={address} alwaysTrim={alwaysTrim} />
       <CopyToClipboard value={address} />
     </Box>
   )
@@ -79,7 +83,11 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, account, 
       {
         content: (
           <LinkableDiv id={item.token_contract_addr_eth ?? item.token_contract_addr}>
-            <ContractLink scope={scope} address={item.token_contract_addr_eth ?? item.token_contract_addr} />
+            <ContractLink
+              scope={scope}
+              address={item.token_contract_addr_eth ?? item.token_contract_addr}
+              alwaysTrim
+            />
           </LinkableDiv>
         ),
         key: 'hash',

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceTitleCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceTitleCard.tsx
@@ -66,7 +66,7 @@ export const InstanceTitleCard: FC<InstanceTitleCardProps> = ({ isFetched, isLoa
               }}
             >
               <VerificationIcon address_eth={token.eth_contract_addr} verified={token.is_verified} noLink />
-              <AccountLink scope={scope} address={displayAddress!} />
+              <AccountLink scope={scope} address={displayAddress!} alwaysTrim />
               <CopyToClipboard value={displayAddress!} />
             </Box>
           </Box>

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -270,24 +270,21 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('common.from')}</dt>
               <dd>
-                <TransactionInfoTooltip
-                  label={
+                <AccountLink
+                  scope={transaction}
+                  address={
+                    from ||
+                    ((isOasisAddressFormat ? transaction?.sender_0_eth : transaction?.sender_0) as string)
+                  }
+                  plain={!from}
+                  extraTooltip={
                     from
                       ? isOasisAddressFormat
                         ? t('transaction.tooltips.senderTooltipOasis')
                         : t('transaction.tooltips.senderTooltipEth')
                       : t('transaction.tooltips.senderTooltipUnavailable')
                   }
-                >
-                  <AccountLink
-                    scope={transaction}
-                    address={
-                      from ||
-                      ((isOasisAddressFormat ? transaction?.sender_0_eth : transaction?.sender_0) as string)
-                    }
-                    plain={!from}
-                  />
-                </TransactionInfoTooltip>
+                />
                 {from && <CopyToClipboard value={from} />}
               </dd>
             </>
@@ -297,21 +294,18 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('common.to')}</dt>
               <dd>
-                <TransactionInfoTooltip
-                  label={
+                <AccountLink
+                  scope={transaction}
+                  address={to || ((isOasisAddressFormat ? transaction?.to_eth : transaction?.to) as string)}
+                  plain={!to}
+                  extraTooltip={
                     to
                       ? isOasisAddressFormat
                         ? t('transaction.tooltips.recipientTooltipOasis')
                         : t('transaction.tooltips.recipientTooltipEth')
                       : t('transaction.tooltips.recipientTooltipUnavailable')
                   }
-                >
-                  <AccountLink
-                    scope={transaction}
-                    address={to || ((isOasisAddressFormat ? transaction?.to_eth : transaction?.to) as string)}
-                    plain={!to}
-                  />
-                </TransactionInfoTooltip>
+                />
                 {to && <CopyToClipboard value={to} />}
               </dd>
             </>

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, useState } from 'react'
+import { FC, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -20,7 +20,6 @@ import Alert from '@mui/material/Alert'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { AppErrors } from '../../../types/errors'
 import { TextSkeleton } from '../../components/Skeleton'
-import Box from '@mui/material/Box'
 import { BlockLink } from '../../components/Blocks/BlockLink'
 import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { TransactionEvents } from '../../components/Transactions/TransactionEvents'
@@ -30,8 +29,6 @@ import { getNameForTicker, Ticker } from '../../../types/ticker'
 import { AllTokenPrices, useAllTokenPrices } from '../../../coin-gecko/api'
 import { CurrentFiatValue } from './CurrentFiatValue'
 import { AddressSwitch, AddressSwitchOption } from '../../components/AddressSwitch'
-import InfoIcon from '@mui/icons-material/Info'
-import Tooltip from '@mui/material/Tooltip'
 import { TransactionEncrypted, TransactionNotEncrypted } from '../../components/TransactionEncryptionStatus'
 import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
@@ -145,23 +142,6 @@ export type TransactionDetailRuntimeBlock = RuntimeTransaction & {
   markAsNew?: boolean
 }
 
-const TransactionInfoTooltip: FC<PropsWithChildren<{ label: string }>> = ({ label, children }) => {
-  return (
-    <Tooltip
-      arrow
-      placement="top"
-      title={
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <InfoIcon />
-          {label}
-        </Box>
-      }
-    >
-      <Box>{children}</Box>
-    </Tooltip>
-  )
-}
-
 export const RuntimeTransactionDetailView: FC<{
   isLoading?: boolean
   transaction: TransactionDetailRuntimeBlock | undefined
@@ -213,23 +193,21 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('common.hash')}</dt>
               <dd>
-                <TransactionInfoTooltip
-                  label={
+                <TransactionLink
+                  scope={transaction}
+                  hash={
+                    hash || ((isOasisAddressFormat ? transaction?.eth_hash : transaction?.hash) as string)
+                  }
+                  plain={!hash}
+                  extraTooltip={
                     hash
                       ? isOasisAddressFormat
                         ? t('transaction.tooltips.txTooltipOasis')
                         : t('transaction.tooltips.txTooltipEth')
                       : t('transaction.tooltips.txTooltipHashUnavailable')
                   }
-                >
-                  <TransactionLink
-                    scope={transaction}
-                    hash={
-                      hash || ((isOasisAddressFormat ? transaction?.eth_hash : transaction?.hash) as string)
-                    }
-                    plain={!hash}
-                  />
-                </TransactionInfoTooltip>
+                />
+
                 {hash && <CopyToClipboard value={hash} />}
               </dd>
             </>

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -66,8 +66,9 @@ export const NFTInstanceLink: FC<NFTLinkProps> = ({ scope, instance }) => {
 type NFTOwnerLinkProps = {
   scope: SearchScope
   owner: string
+  alwaysTrim?: boolean
 }
-export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner }) => {
+export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner, alwaysTrim }) => {
   const { t } = useTranslation()
 
   return (
@@ -76,7 +77,7 @@ export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner }) => {
         i18nKey="nft.ownerLink"
         t={t}
         components={{
-          OwnerLink: <AccountLink scope={scope} address={owner} alwaysTrim={true} />,
+          OwnerLink: <AccountLink scope={scope} address={owner} alwaysTrim={alwaysTrim} />,
         }}
       />
     </StyledTypography>

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -69,7 +69,11 @@ export const TokenDetailsCard: FC<{ scope: SearchScope; address: string; searchT
 
             <dt>{t('contract.creator')}</dt>
             <dd>
-              <DelayedContractCreatorInfo scope={token} contractOasisAddress={token.contract_addr} />
+              <DelayedContractCreatorInfo
+                scope={token}
+                contractOasisAddress={token.contract_addr}
+                alwaysTrim
+              />
             </dd>
 
             <dt>{t('common.balance')} </dt>

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -25,7 +25,11 @@ export const TokenTitleCard: FC<{ scope: SearchScope; address: string; searchTer
           {token && (
             <>
               <VerificationIcon address_eth={token.eth_contract_addr} verified={token.is_verified} noLink />
-              <AccountLink scope={token} address={token.eth_contract_addr || token.contract_addr} />
+              <AccountLink
+                scope={token}
+                address={token.eth_contract_addr || token.contract_addr}
+                alwaysTrim
+              />
               <CopyToClipboard value={token.eth_contract_addr || token.contract_addr} />
             </>
           )}


### PR DESCRIPTION
@donouwens wrote:

> **TX details, mobile view:**
> we should use the space in the row more to minimise the chance of needing to truncate.

Up to now, on mobile, we were always truncating hashes to a fixed length (the same as in tables).

With this change, we can now display them adaptively, that is, taking up all the space that is available.

| Component |Before | After| Points of interest |
|  ---- | ----- | ---- | ---- |
| TX details on mobile | ![image](https://github.com/oasisprotocol/explorer/assets/2093792/eaeeb2a2-4348-495e-bbbb-84c8a122c483) |  ![image](https://github.com/oasisprotocol/explorer/assets/2093792/e57e6dd2-59b9-4416-b22d-cc97447cdcf2) | Fixed lost space and clashing tooltips for "From" and "To" |
| Account details on mobile | ![image](https://github.com/oasisprotocol/explorer/assets/2093792/1f15fe45-0983-4fad-8383-f3db69cc4742)  |  ![image](https://github.com/oasisprotocol/explorer/assets/2093792/1e0856cd-5470-4ba3-aa43-ed5d04487ab6)  | Fixed lost space for address  |

A similar change has also been implemented for block hash links and other similar things.