### PR TITLE
Fix keyboard accessibility of layer picker component

### DIFF
--- a/.changelog/1291.trivial.md
+++ b/.changelog/1291.trivial.md
@@ -1,0 +1,1 @@
+Fix keyboard accessibility of layer picker component

--- a/src/app/components/LayerPicker/LayerDetails.tsx
+++ b/src/app/components/LayerPicker/LayerDetails.tsx
@@ -85,9 +85,10 @@ export const StyledButton = styled(Button)(({ theme }) => ({
   fontSize: 24,
   color: COLORS.brandDark,
   fontWeight: 700,
-  '&&:hover, &&:active': {
+  '&&:hover, &&:active, &&:focus-visible': {
     color: COLORS.brandDark,
     textDecoration: 'none',
+    borderRadius: 0,
   },
 }))
 

--- a/src/app/components/LayerPicker/LayerMenu.tsx
+++ b/src/app/components/LayerPicker/LayerMenu.tsx
@@ -82,6 +82,7 @@ export const LayerMenuItem: FC<LayerMenuItemProps> = ({
         setSelectedLayer(layer)
       }}
       selected={activeLayerSelection}
+      tabIndex={activeLayerSelection ? 0 : -1}
     >
       <ListItemText>
         {labels[layer]}

--- a/src/app/components/LayerPicker/NetworkMenu.tsx
+++ b/src/app/components/LayerPicker/NetworkMenu.tsx
@@ -41,6 +41,7 @@ export const NetworkMenuItem: FC<NetworkMenuItemProps> = ({
         setHoveredNetwork(undefined)
       }}
       selected={activeNetworkSelection}
+      tabIndex={activeNetworkSelection ? 0 : -1}
       onClick={() => {
         setSelectedNetwork(network)
       }}


### PR DESCRIPTION
enable tab + arrows nav within network and layer menus