### PR TITLE
Improve phrasing of error messages on reverted transactions

### DIFF
--- a/.changelog/1296.trivial.md
+++ b/.changelog/1296.trivial.md
@@ -1,0 +1,1 @@
+Improve phrasing of error messages on reverted transactions

--- a/src/app/components/StatusIcon/index.tsx
+++ b/src/app/components/StatusIcon/index.tsx
@@ -8,6 +8,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import HelpIcon from '@mui/icons-material/Help'
 import { TxError } from '../../../oasis-nexus/api'
 import Tooltip from '@mui/material/Tooltip'
+import { useTxErrorMessage } from '../../hooks/useTxErrorMessage'
 
 type TxStatus = 'unknown' | 'success' | 'failure'
 
@@ -81,7 +82,7 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText }) =>
     success: t('common.success'),
     failure: t('common.failed'),
   }
-  const errorMessage = error ? `${error.message} (${t('errors.code')} ${error.code})` : undefined
+  const errorMessage = useTxErrorMessage(error)
 
   if (withText) {
     return (

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -3,5 +3,12 @@ import { TxError } from '../../oasis-nexus/api'
 
 export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
   const { t } = useTranslation()
-  return error ? `${error.message} (${t('errors.code')} ${error.code})` : undefined
+  if (!error) return undefined
+  if (error.module === 'evm' && error.code === 8 && !error.message) {
+    // EVM reverted, with missing error message
+    return `${t('errors.revertedWithoutMessage')} (${t('errors.code')} ${error.code})`
+  } else {
+    // Anything else
+    return `${error.message} (${t('errors.code')} ${error.code})`
+  }
 }

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -1,0 +1,7 @@
+import { useTranslation } from 'react-i18next'
+import { TxError } from '../../oasis-nexus/api'
+
+export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
+  const { t } = useTranslation()
+  return error ? `${error.message} (${t('errors.code')} ${error.code})` : undefined
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -223,6 +223,7 @@
     "validateURL": "Please validate provided URL",
     "validateURLOrGoToFirstPage": "Please check the URL or <FirstPageLink />.",
     "invalidUrl": "Invalid URL",
+    "revertedWithoutMessage": "reverted without a message",
     "storage": "Access to browser storage denied"
   },
   "footer": {


### PR DESCRIPTION
As discussed in chat, for EVM errors, we want to add back the "Reverted:" prefix in case of error code 8.
Also, on missing messages, say "Reverted without e massage."