### PR TITLE
Fix oasis address links even when toggled to ETH addresses

### DIFF
--- a/.changelog/1329.bugfix.md
+++ b/.changelog/1329.bugfix.md
@@ -1,0 +1,1 @@
+Fix oasis address links even when toggled to ETH addresses

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -11,16 +11,15 @@ export const AccountLink: FC<{
   scope: SearchScope
   address: string
   alwaysTrim?: boolean
-  plain?: boolean
-}> = ({ scope, address, alwaysTrim, plain }) => {
+}> = ({ scope, address, alwaysTrim }) => {
   const { isTablet } = useScreenSize()
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
     <Typography variant="mono" component="span">
       {alwaysTrim || isTablet ? (
-        <TrimLinkLabel label={address} to={to} plain={plain} />
+        <TrimLinkLabel label={address} to={to} />
       ) : (
-        <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
+        <Link component={RouterLink} to={to}>
           {address}
         </Link>
       )}

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -5,7 +5,6 @@ import Link from '@mui/material/Link'
 import { TrimLinkLabel } from '../TrimLinkLabel'
 import { RouteUtils } from '../../utils/route-utils'
 import Typography from '@mui/material/Typography'
-import { COLORS } from '../../../styles/theme/colors'
 import { SearchScope } from '../../../types/searchScope'
 
 export const AccountLink: FC<{
@@ -17,21 +16,11 @@ export const AccountLink: FC<{
   const { isTablet } = useScreenSize()
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
-    <Typography
-      variant="mono"
-      component="span"
-      sx={
-        plain
-          ? { color: COLORS.grayExtraDark, fontWeight: 400 }
-          : { color: COLORS.brandDark, fontWeight: 700 }
-      }
-    >
+    <Typography variant="mono" component="span">
       {alwaysTrim || isTablet ? (
-        <TrimLinkLabel label={address} to={to} />
-      ) : plain ? (
-        address
+        <TrimLinkLabel label={address} to={to} plain={plain} />
       ) : (
-        <Link component={RouterLink} to={to}>
+        <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
           {address}
         </Link>
       )}

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -218,11 +218,7 @@ export const RuntimeEventDetails: FC<{
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <dt>{t('runtimeEvent.fields.owner')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.owner}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.owner} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && (
                 <CopyToClipboard value={event.body.owner} />
               )}
@@ -247,22 +243,14 @@ export const RuntimeEventDetails: FC<{
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.from}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.from} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && (
                 <CopyToClipboard value={event.body.from} />
               )}
             </dd>
             <dt>{t('common.to')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.to}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.to} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && <CopyToClipboard value={event.body.to} />}
             </dd>
             <dt>{t('runtimeEvent.fields.amount')}</dt>
@@ -283,22 +271,14 @@ export const RuntimeEventDetails: FC<{
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.from}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.from} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && (
                 <CopyToClipboard value={event.body.from} />
               )}
             </dd>
             <dt>{t('common.to')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.to}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.to} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && <CopyToClipboard value={event.body.to} />}
             </dd>
             <dt>{t('runtimeEvent.fields.amount')}</dt>
@@ -319,22 +299,14 @@ export const RuntimeEventDetails: FC<{
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.from}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.from} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && (
                 <CopyToClipboard value={event.body.from} />
               )}
             </dd>
             <dt>{t('common.to')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.to}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.to} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && <CopyToClipboard value={event.body.to} />}
             </dd>
             <dt>{t('runtimeEvent.fields.activeShares')}</dt>
@@ -354,22 +326,14 @@ export const RuntimeEventDetails: FC<{
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.from}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.from} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && (
                 <CopyToClipboard value={event.body.from} />
               )}
             </dd>
             <dt>{t('common.to')}</dt>
             <dd>
-              <AccountLink
-                address={event.body.to}
-                scope={scope}
-                plain={addressSwitchOption !== AddressSwitchOption.Oasis}
-              />
+              <AccountLink address={event.body.to} scope={scope} />
               {addressSwitchOption === AddressSwitchOption.Oasis && <CopyToClipboard value={event.body.to} />}
             </dd>
             <dt>{t('runtimeEvent.fields.amount')}</dt>

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -11,17 +11,16 @@ export const TransactionLink: FC<{
   alwaysTrim?: boolean
   scope: SearchScope
   hash: string
-  plain?: boolean
-}> = ({ alwaysTrim, hash, scope, plain }) => {
+}> = ({ alwaysTrim, hash, scope }) => {
   const { isMobile } = useScreenSize()
   const to = RouteUtils.getTransactionRoute(scope, hash)
 
   return (
     <Typography variant="mono">
       {alwaysTrim || isMobile ? (
-        <TrimLinkLabel label={hash} to={to} plain={plain} />
+        <TrimLinkLabel label={hash} to={to} />
       ) : (
-        <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
+        <Link component={RouterLink} to={to}>
           {hash}
         </Link>
       )}

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -6,7 +6,6 @@ import { useScreenSize } from '../../hooks/useScreensize'
 import { TrimLinkLabel } from '../TrimLinkLabel'
 import { RouteUtils } from '../../utils/route-utils'
 import { SearchScope } from '../../../types/searchScope'
-import { COLORS } from '../../../styles/theme/colors'
 
 export const TransactionLink: FC<{
   alwaysTrim?: boolean
@@ -18,13 +17,11 @@ export const TransactionLink: FC<{
   const to = RouteUtils.getTransactionRoute(scope, hash)
 
   return (
-    <Typography variant="mono" sx={{ ...(plain ? { color: COLORS.grayExtraDark, fontWeight: 400 } : {}) }}>
+    <Typography variant="mono">
       {alwaysTrim || isMobile ? (
         <TrimLinkLabel label={hash} to={to} plain={plain} />
-      ) : plain ? (
-        hash
       ) : (
-        <Link component={RouterLink} to={to}>
+        <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
           {hash}
         </Link>
       )}

--- a/src/app/components/TrimLinkLabel/index.tsx
+++ b/src/app/components/TrimLinkLabel/index.tsx
@@ -8,37 +8,36 @@ import { tooltipDelay } from '../../../styles/theme'
 type TrimLinkLabelProps = {
   label: string
   to: string
-  plain?: boolean
 }
 
-export const TrimLinkLabel: FC<TrimLinkLabelProps> = ({ label, to, plain }) => {
+export const TrimLinkLabel: FC<TrimLinkLabelProps> = ({ label, to }) => {
   const trimmedLabel = trimLongString(label)
   if (!trimmedLabel) {
     return null
   }
-  return <TrimLink label={label} to={to} trimmedLabel={trimmedLabel} plain={plain} />
+  return <TrimLink label={label} to={to} trimmedLabel={trimmedLabel} />
 }
 
 type TrimEndLinkLabelProps = TrimLinkLabelProps & {
   trimStart: number
 }
 
-export const TrimEndLinkLabel: FC<TrimEndLinkLabelProps> = ({ label, to, plain, trimStart }) => {
+export const TrimEndLinkLabel: FC<TrimEndLinkLabelProps> = ({ label, to, trimStart }) => {
   const trimmedLabel = trimLongString(label, trimStart, 0)
   if (!trimmedLabel) {
     return null
   }
-  return <TrimLink label={label} to={to} trimmedLabel={trimmedLabel} plain={plain} />
+  return <TrimLink label={label} to={to} trimmedLabel={trimmedLabel} />
 }
 
 type TrimLinkProps = TrimLinkLabelProps & {
   trimmedLabel: string
 }
 
-const TrimLink: FC<TrimLinkProps> = ({ label, to, trimmedLabel, plain }) => {
+const TrimLink: FC<TrimLinkProps> = ({ label, to, trimmedLabel }) => {
   return (
     <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-      <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
+      <Link component={RouterLink} to={to}>
         {trimmedLabel}
       </Link>
     </Tooltip>

--- a/src/app/components/TrimLinkLabel/index.tsx
+++ b/src/app/components/TrimLinkLabel/index.tsx
@@ -38,13 +38,9 @@ type TrimLinkProps = TrimLinkLabelProps & {
 const TrimLink: FC<TrimLinkProps> = ({ label, to, trimmedLabel, plain }) => {
   return (
     <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-      {plain ? (
-        <>{trimmedLabel}</>
-      ) : (
-        <Link component={RouterLink} to={to}>
-          {trimmedLabel}
-        </Link>
-      )}
+      <Link component={RouterLink} to={to} sx={{ fontWeight: plain ? 400 : undefined }}>
+        {trimmedLabel}
+      </Link>
     </Tooltip>
   )
 }

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -228,7 +228,6 @@ export const RuntimeTransactionDetailView: FC<{
                     hash={
                       hash || ((isOasisAddressFormat ? transaction?.eth_hash : transaction?.hash) as string)
                     }
-                    plain={!hash}
                   />
                 </TransactionInfoTooltip>
                 {hash && <CopyToClipboard value={hash} />}
@@ -286,7 +285,6 @@ export const RuntimeTransactionDetailView: FC<{
                       from ||
                       ((isOasisAddressFormat ? transaction?.sender_0_eth : transaction?.sender_0) as string)
                     }
-                    plain={!from}
                   />
                 </TransactionInfoTooltip>
                 {from && <CopyToClipboard value={from} />}
@@ -310,7 +308,6 @@ export const RuntimeTransactionDetailView: FC<{
                   <AccountLink
                     scope={transaction}
                     address={to || ((isOasisAddressFormat ? transaction?.to_eth : transaction?.to) as string)}
-                    plain={!to}
                   />
                 </TransactionInfoTooltip>
                 {to && <CopyToClipboard value={to} />}


### PR DESCRIPTION
Makes "plain" links still link to the address. User might not have known they needed to toggle the address format before they could open a "plain" address.

Fixes #1220: oasis addresses in e.g. consensus deposit transactions in EVM runtimes were not clickable in mobile vertical layout of transactions because it is implicitly toggled to ETH addresses (and can't be toggled to Oasis).

| Before | After |
| --- | --- |
| ![localhost_1234_mainnet_sapphire_tx_2c997a87b4f57c0266a780cab8bb1f39b35d37d6c894c79e2a43395b3323ad85 (1)](https://github.com/oasisprotocol/explorer/assets/3758846/b9c3aaf7-a96b-42a0-a8ed-641c6aae5bb7) | ![image](https://github.com/oasisprotocol/explorer/assets/3758846/9c2ec745-a7cb-4b6c-8e6f-0d7ed5a0a8b2) |
| ![localhost_1234_mainnet_sapphire_tx_2c997a87b4f57c0266a780cab8bb1f39b35d37d6c894c79e2a43395b3323ad85 (3)](https://github.com/oasisprotocol/explorer/assets/3758846/e8684808-70fb-426d-b085-e87fbbc9082f) | ![image](https://github.com/oasisprotocol/explorer/assets/3758846/16b265e8-0597-49cf-8106-2be78dbff2f9) |










