### PR TITLE
Fix RPC native balance

### DIFF
--- a/.changelog/1338.bugfix.md
+++ b/.changelog/1338.bugfix.md
@@ -1,0 +1,1 @@
+Fix RPC native balance and adds PontusX RPC

--- a/src/app/utils/__tests__/array-utils.test.ts
+++ b/src/app/utils/__tests__/array-utils.test.ts
@@ -1,0 +1,33 @@
+import { ArrayUtils } from '../array-utils'
+
+describe('ArrayUtils', () => {
+  describe('replaceOrAppend', () => {
+    it('should append new item if list is empty', () => {
+      const emptyList: number[] = []
+      const newItem = 1
+      const result = ArrayUtils.replaceOrAppend(emptyList, newItem, (a, b) => a === b)
+
+      expect(result).toEqual([newItem])
+    })
+
+    it('should replace existing item if match found', () => {
+      const list = [
+        { a: 1, b: 2 },
+        { a: 2, b: 3 },
+        { a: 3, b: 4 },
+      ]
+      const newItem = { a: 2, b: 100 }
+      const result = ArrayUtils.replaceOrAppend(list, newItem, ({ a: a1 }, { a: a2 }) => a1 === a2)
+
+      expect(result).toEqual([{ a: 1, b: 2 }, newItem, { a: 3, b: 4 }])
+    })
+
+    it('should append new item if no match found', () => {
+      const list = [1, 2, 3]
+      const newItem = 4
+      const result = ArrayUtils.replaceOrAppend(list, newItem, (a, b) => a === b)
+
+      expect(result).toEqual([...list, newItem])
+    })
+  })
+})

--- a/src/app/utils/array-utils.ts
+++ b/src/app/utils/array-utils.ts
@@ -1,0 +1,14 @@
+export abstract class ArrayUtils {
+  static replaceOrAppend = <T = unknown>(list: T[], listItem: T, compareFn: (a: T, b: T) => boolean) => {
+    const shallowCopy = [...list]
+    const i = list.findIndex(v => compareFn(v, listItem))
+
+    if (i === -1) {
+      shallowCopy.push(listItem)
+    } else {
+      shallowCopy.splice(i, 1, listItem)
+    }
+
+    return shallowCopy
+  }
+}

--- a/src/app/utils/rpc-utils.ts
+++ b/src/app/utils/rpc-utils.ts
@@ -13,6 +13,7 @@ const RPC_ENDPOINTS: Record<Network, Partial<Record<Layer, string>>> = {
   [Network.testnet]: {
     [Layer.emerald]: 'https://testnet.emerald.oasis.dev',
     [Layer.sapphire]: 'https://testnet.sapphire.oasis.dev',
+    [Layer.pontusx]: 'https://rpc.dev.pontus-x.eu/',
   },
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,6 +135,7 @@ const pontusxConfig: LayerConfig = {
     address: 'oasis1qr02702pr8ecjuff2z3es254pw9xl6z2yg9qcc6c',
     blockGasLimit: 15_000_000,
     runtimeId: '0000000000000000000000000000000000000000000000004febe52eb412b421',
+    // Kindly note, the sequence is important as src/app/utils/rpc-utils.ts will utilize the first token.
     tokens: [NativeToken.EUROe, NativeToken.TEST],
     fiatCurrency: 'eur',
   },

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -13,6 +13,7 @@ import {
   NotFoundErrorResponse,
   RuntimeAccount,
   RuntimeEventType,
+  RuntimeSdkBalance,
 } from './generated/api'
 import { fromBaseUnits, getEthAddressForAccount, getAccountSize } from '../app/utils/helpers'
 import { Network } from '../types/network'
@@ -22,6 +23,7 @@ import { useTransformToOasisAddress } from '../app/hooks/useTransformToOasisAddr
 import { useEffect, useState } from 'react'
 import { RpcUtils } from '../app/utils/rpc-utils'
 import { toChecksumAddress } from '@ethereumjs/util'
+import { ArrayUtils } from '../app/utils/array-utils'
 
 export * from './generated/api'
 export type { RuntimeEvmBalance as Token } from './generated/api'
@@ -316,7 +318,7 @@ export const useGetRuntimeAccountsAddress: typeof generated.useGetRuntimeAccount
   address,
   options,
 ) => {
-  const [rpcAccountBalance, setRpcAccountBalance] = useState<string | null>(null)
+  const [rpcAccountBalance, setRpcAccountBalance] = useState<RuntimeSdkBalance | null>(null)
 
   const oasisAddress = useTransformToOasisAddress(address)
 
@@ -415,14 +417,11 @@ export const useGetRuntimeAccountsAddress: typeof generated.useGetRuntimeAccount
     rpcAccountBalance !== null && runtimeAccount
       ? {
           ...runtimeAccount,
-          balances: runtimeAccount.balances?.length
-            ? [
-                {
-                  ...runtimeAccount.balances[0],
-                  balance: rpcAccountBalance,
-                },
-              ]
-            : [],
+          balances: ArrayUtils.replaceOrAppend(
+            runtimeAccount.balances,
+            rpcAccountBalance,
+            (a, b) => a.token_symbol === b.token_symbol,
+          ),
         }
       : runtimeAccount
 


### PR DESCRIPTION
## Description

Fixes RPC bug, in case where there is no native balance returned for an account from Nexus, RPC balance didn't update the account balance, due to `balances` array being empty.

Account to test with: `0x0A400fb7b16760fF1ed77192cFE45cC303BcB980`

## Resources

Previous:
![image](https://github.com/oasisprotocol/explorer/assets/9722540/1c4ca752-ee6e-4e88-8e66-708c8d36f92c)

Current:
![image](https://github.com/oasisprotocol/explorer/assets/9722540/031a9646-b58f-4c90-8f31-e90f33d3a01d)
