### PR TITLE
Add extension slots for custom routes and footer links

### DIFF
--- a/.changelog/1345.trivial.md
+++ b/.changelog/1345.trivial.md
@@ -1,0 +1,1 @@
+Add extension slots for custom routes and footer link

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -11,6 +11,7 @@ import { AppendMobileSearch } from '../AppendMobileSearch'
 import { SearchScope } from '../../../types/searchScope'
 import { api, github } from '../../utils/externalLinks'
 import { ReopenAnalyticsConsentButton } from 'app/components/AnalyticsConsent'
+import { CustomFooter } from '../../config/CustomFooter'
 
 const FooterBox = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -66,6 +67,7 @@ export const Footer: FC<FooterProps> = ({ scope, mobileSearchAction }) => {
                 {!hasMobileAction && ' | '}
               </Box>
               <Box>{currentYear}</Box>
+              <CustomFooter tablet />
             </StyledTypography>
           </AppendMobileSearch>
         ) : (
@@ -141,6 +143,11 @@ export const Footer: FC<FooterProps> = ({ scope, mobileSearchAction }) => {
                   </Link>
                 </Typography>
               </StyledLinksGroup>
+            </StyledBox>
+            <StyledBox>
+              <Typography variant="footer">
+                <CustomFooter />
+              </Typography>
             </StyledBox>
             <Typography variant="footer">
               {t('footer.title')} | <ReopenAnalyticsConsentButton /> | {currentYear}

--- a/src/app/config/CustomFooter.tsx
+++ b/src/app/config/CustomFooter.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+// import { Link as RouterLink } from 'react-router-dom'
+// import Link from '@mui/material/Link'
+// import { useTheme } from '@mui/material/styles'
+
+/**
+ * This is extension point that can be used by 3rd parties to add custom links to the footer of the app
+ */
+export const CustomFooter: FC<{ tablet?: boolean }> = () => null
+
+// export const CustomFooter: FC<{ tablet?: boolean }> = ({ tablet }) => {
+//   const theme = useTheme()
+//   return (
+//     <>
+//       {tablet && <span>| </span>}
+//       <Link component={RouterLink} to={'/custom'} sx={{ color: theme.palette.layout.main }}>
+//         Custom
+//       </Link>
+//     </>
+//   )
+// }

--- a/src/app/config/customRoutes.tsx
+++ b/src/app/config/customRoutes.tsx
@@ -1,0 +1,6 @@
+import { RouteObject } from 'react-router-dom'
+
+/**
+ * This is extension point that can be used by 3rd parties to add custom routes to the app
+ */
+export const customRoutes: RouteObject[] = []

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -57,6 +57,7 @@ import { useConsensusAccountDetailsProps } from './app/pages/ConsensusAccountDet
 import { ConsensusAccountTransactionsCard } from './app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard'
 import { FC, useEffect } from 'react'
 import { AnalyticsConsentProvider } from './app/components/AnalyticsConsent'
+import { customRoutes } from './app/config/customRoutes'
 
 const NetworkSpecificPart = () => (
   <ThemeByNetwork isRootTheme={true} network={useRequiredScopeParam().network}>
@@ -297,6 +298,7 @@ export const routes: RouteObject[] = [
           },
         ],
       },
+      ...customRoutes,
     ],
   },
 ]


### PR DESCRIPTION
Following the [suggestion](https://github.com/oasisprotocol/explorer/pull/1307#discussion_r1507204787) of @buberdds, this PR adds extension slots for adding custom links to the footer, and routes to the router, so that if a 3rd party (i.e. a fork) wants to add custom pages, it can do it in a way that minimizes the change of merge conflicts.
