### PR TITLE
Add support for ordering network proposal votes

### DIFF
--- a/.changelog/1356.feature.md
+++ b/.changelog/1356.feature.md
@@ -1,0 +1,1 @@
+Display the votes on the network proposal details page

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
 import Link from '@mui/material/Link'
@@ -10,11 +10,17 @@ import { SearchScope } from '../../../types/searchScope'
 export const AccountLink: FC<{
   scope: SearchScope
   address: string
+  title?: ReactNode
   alwaysTrim?: boolean
-}> = ({ scope, address, alwaysTrim }) => {
+}> = ({ scope, address, title, alwaysTrim }) => {
   const { isTablet } = useScreenSize()
   const to = RouteUtils.getAccountRoute(scope, address)
-  return (
+
+  return title ? (
+    <Link component={RouterLink} to={to}>
+      {title}
+    </Link>
+  ) : (
     <Typography variant="mono" component="span">
       {alwaysTrim || isTablet ? (
         <TrimLinkLabel label={address} to={to} />

--- a/src/app/components/Proposals/ProposalVoteIndicator.tsx
+++ b/src/app/components/Proposals/ProposalVoteIndicator.tsx
@@ -1,0 +1,77 @@
+import { FC } from 'react'
+import { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import CancelIcon from '@mui/icons-material/Cancel'
+import RemoveCircleIcon from '@mui/icons-material/RemoveCircle'
+import { styled } from '@mui/material/styles'
+import { COLORS } from '../../../styles/theme/colors'
+import { ProposalVoteValue } from '../../../types/vote'
+
+const StyledBox = styled(Box)(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 3,
+  flex: 1,
+  borderRadius: 10,
+  padding: theme.spacing(2, 2, 2, '10px'),
+  fontSize: '12px',
+  minWidth: '85px',
+}))
+
+const StyledIcon = styled(Box)({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontSize: '18px',
+})
+
+const getStatuses = (t: TFunction) => ({
+  [ProposalVoteValue.abstain]: {
+    backgroundColor: COLORS.lightSilver,
+    icon: RemoveCircleIcon,
+    iconColor: COLORS.grayMedium,
+    label: t('networkProposal.vote.abstain'),
+    textColor: COLORS.grayExtraDark,
+  },
+  [ProposalVoteValue.yes]: {
+    backgroundColor: COLORS.honeydew,
+    icon: CheckCircleIcon,
+    iconColor: COLORS.eucalyptus,
+    label: t('networkProposal.vote.yes'),
+    textColor: COLORS.grayExtraDark,
+  },
+  [ProposalVoteValue.no]: {
+    backgroundColor: COLORS.linen,
+    icon: CancelIcon,
+    iconColor: COLORS.errorIndicatorBackground,
+    label: t('networkProposal.vote.no'),
+    textColor: COLORS.grayExtraDark,
+  },
+})
+
+type ProposalVoteIndicatorProps = {
+  vote: ProposalVoteValue
+}
+
+export const ProposalVoteIndicator: FC<ProposalVoteIndicatorProps> = ({ vote }) => {
+  const { t } = useTranslation()
+
+  if (!ProposalVoteValue[vote]) {
+    return null
+  }
+
+  const statusConfig = getStatuses(t)[vote]
+  const IconComponent = statusConfig.icon
+
+  return (
+    <StyledBox sx={{ backgroundColor: statusConfig.backgroundColor, color: statusConfig.textColor }}>
+      {statusConfig.label}
+      <StyledIcon sx={{ color: statusConfig.iconColor }}>
+        <IconComponent color="inherit" fontSize="inherit" />
+      </StyledIcon>
+    </StyledBox>
+  )
+}

--- a/src/app/components/Proposals/VoteTypePills.tsx
+++ b/src/app/components/Proposals/VoteTypePills.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Typography from '@mui/material/Typography'
+import { COLORS } from '../../../styles/theme/colors'
+import { ProposalVoteValue, VoteType } from '../../../types/vote'
+
+type VoteTypePillsProps = {
+  handleChange: (voteType: VoteType) => void
+  value?: VoteType
+}
+
+export const VoteTypePills: FC<VoteTypePillsProps> = ({ handleChange, value }) => {
+  const { t } = useTranslation()
+  const options: { label: string; value: VoteType }[] = [
+    {
+      label: t('networkProposal.vote.all'),
+      value: 'any',
+    },
+    {
+      label: t('networkProposal.vote.yes'),
+      value: ProposalVoteValue.yes,
+    },
+    {
+      label: t('networkProposal.vote.abstain'),
+      value: ProposalVoteValue.abstain,
+    },
+    {
+      label: t('networkProposal.vote.no'),
+      value: ProposalVoteValue.no,
+    },
+  ]
+
+  return (
+    <>
+      {options.map(option => {
+        const selected = option.value === value
+        return (
+          <Chip
+            key={option.value}
+            onClick={() => handleChange(option.value)}
+            clickable
+            color="secondary"
+            label={
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Typography component="span" sx={{ fontSize: 16 }}>
+                  {option.label}
+                </Typography>
+              </Box>
+            }
+            sx={{
+              mr: 3,
+              borderColor: COLORS.brandMedium,
+              backgroundColor: selected ? COLORS.brandMedium : COLORS.brandMedium15,
+              color: selected ? COLORS.white : COLORS.grayExtraDark,
+            }}
+            variant={selected ? 'outlined-selected' : 'outlined'}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/src/app/components/Proposals/VoterSearchBar.tsx
+++ b/src/app/components/Proposals/VoterSearchBar.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import TextField from '@mui/material/TextField'
+import SearchIcon from '@mui/icons-material/Search'
+import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import InputAdornment from '@mui/material/InputAdornment'
+import { COLORS } from '../../../styles/theme/colors'
+import { SearchVariant } from '../Search'
+import { useTranslation } from 'react-i18next'
+import IconButton from '@mui/material/IconButton'
+
+export interface SearchBarProps {
+  variant: SearchVariant
+  value: string
+  onChange: (value: string) => void
+}
+
+export const VoterSearchBar: FC<SearchBarProps> = ({ variant, value, onChange }) => {
+  const { t } = useTranslation()
+  const startAdornment = variant === 'button' && (
+    <InputAdornment
+      position="start"
+      disablePointerEvents // Pass clicks through, so it focuses the input
+    >
+      <SearchIcon sx={{ color: COLORS.grayDark }} />
+    </InputAdornment>
+  )
+
+  const onClearValue = () => onChange('')
+
+  const endAdornment = (
+    <InputAdornment position="end">
+      <>
+        {value && (
+          <IconButton color="inherit" onClick={onClearValue}>
+            <HighlightOffIcon />
+          </IconButton>
+        )}
+      </>
+    </InputAdornment>
+  )
+
+  return (
+    <>
+      <TextField
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        InputProps={{
+          inputProps: {
+            sx: {
+              p: 0,
+              marginRight: 2,
+            },
+          },
+          startAdornment,
+          endAdornment,
+        }}
+        placeholder={t('networkProposal.searchForVoters')}
+        // FormHelperTextProps={{
+        //   component: 'div', // replace p with div tag
+        //   sx: {
+        //     marginTop: 0,
+        //     marginBottom: 0,
+        //     marginLeft: variant === 'button' ? '48px' : '17px',
+        //     marginRight: variant === 'button' ? '48px' : '17px',
+        //   },
+        // }}
+      />
+    </>
+  )
+}

--- a/src/app/components/Table/PaginationEngine.ts
+++ b/src/app/components/Table/PaginationEngine.ts
@@ -7,15 +7,52 @@ export interface SimplePaginationEngine {
   linkToPage: (pageNumber: number) => To
 }
 
+/**
+ * The data returned by a comprehensive pagination engine to the data consumer component
+ */
 export interface PaginatedResults<Item> {
+  /**
+   * Control interface that can be plugged to a Table's `pagination` prop
+   */
   tablePaginationProps: TablePaginationProps
+
+  /**
+   * The data provided to the data consumer in the current window
+   */
   data: Item[] | undefined
+
+  /**
+   * Is the data set still loading from the server?
+   */
+  isLoading: boolean
 }
 
+/**
+ * A Comprehensive PaginationEngine sits between the server and the consumer of the data and does transformations
+ *
+ * Specifically, the interface for loading the data and the one for the data consumers are decoupled.
+ */
 export interface ComprehensivePaginationEngine<Item, QueryResult extends List> {
-  selectedPage: number
-  offsetForQuery: number
-  limitForQuery: number
-  paramsForQuery: { offset: number; limit: number }
-  getResults: (queryResult: QueryResult | undefined, key?: keyof QueryResult) => PaginatedResults<Item>
+  /**
+   * The currently selected page from the data consumer's POV
+   */
+  selectedPageForClient: number
+
+  /**
+   * Parameters for data to be loaded from the server
+   */
+  paramsForServer: { offset: number; limit: number }
+
+  /**
+   * Get the current data/state info for the data consumer component.
+   *
+   * @param isLoading Is the data still being loaded from the server?
+   * @param queryResult the data coming in the server, requested according to this engine's specs, including metadata
+   * @param key The field where the actual records can be found within queryResults
+   */
+  getResults: (
+    isLoading: boolean,
+    queryResult: QueryResult | undefined,
+    key?: keyof QueryResult,
+  ) => PaginatedResults<Item>
 }

--- a/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
+++ b/src/app/components/Table/useComprehensiveSearchParamsPagination.ts
@@ -64,11 +64,9 @@ export function useComprehensiveSearchParamsPagination<Item, QueryResult extends
   }
 
   return {
-    selectedPage,
-    offsetForQuery: offset,
-    limitForQuery: limit,
-    paramsForQuery,
-    getResults: (queryResult, key) => {
+    selectedPageForClient: selectedPage,
+    paramsForServer: paramsForQuery,
+    getResults: (isLoading, queryResult, key) => {
       const data = queryResult
         ? key
           ? (queryResult[key] as Item[])
@@ -85,6 +83,7 @@ export function useComprehensiveSearchParamsPagination<Item, QueryResult extends
       return {
         tablePaginationProps: tableProps,
         data: filteredData,
+        isLoading,
       }
     },
     // tableProps,

--- a/src/app/components/Validators/DeferredValidatorLink.tsx
+++ b/src/app/components/Validators/DeferredValidatorLink.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react'
+import { Network } from '../../../types/network'
+import { Layer, Validator } from '../../../oasis-nexus/api'
+import { SearchScope } from '../../../types/searchScope'
+import { ValidatorLink } from './ValidatorLink'
+
+export const DeferredValidatorLink: FC<{
+  network: Network
+  address: string
+  validator: Validator | undefined
+  isError: boolean
+}> = ({ network, address, validator, isError }) => {
+  const scope: SearchScope = { network, layer: Layer.consensus }
+
+  if (isError) {
+    console.log('Warning: failed to look up validators!')
+  }
+
+  return <ValidatorLink address={address} network={scope.network} name={validator?.media?.name} />
+}

--- a/src/app/components/Validators/DeferredValidatorLink.tsx
+++ b/src/app/components/Validators/DeferredValidatorLink.tsx
@@ -9,12 +9,20 @@ export const DeferredValidatorLink: FC<{
   address: string
   validator: Validator | undefined
   isError: boolean
-}> = ({ network, address, validator, isError }) => {
+  highlightedPart?: string | undefined
+}> = ({ network, address, validator, isError, highlightedPart }) => {
   const scope: SearchScope = { network, layer: Layer.consensus }
 
   if (isError) {
     console.log('Warning: failed to look up validators!')
   }
 
-  return <ValidatorLink address={address} network={scope.network} name={validator?.media?.name} />
+  return (
+    <ValidatorLink
+      address={address}
+      network={scope.network}
+      name={validator?.media?.name}
+      highlightedPart={highlightedPart}
+    />
+  )
 }

--- a/src/app/components/Validators/ValidatorImage.tsx
+++ b/src/app/components/Validators/ValidatorImage.tsx
@@ -4,6 +4,8 @@ import ImageNotSupportedIcon from '@mui/icons-material/ImageNotSupported'
 import { hasValidProtocol } from '../../utils/url'
 import { COLORS } from 'styles/theme/colors'
 import { Circle } from '../Circle'
+import { HighlightedText } from '../HighlightedText'
+import Box from '@mui/material/Box'
 
 const StyledImage = styled('img')({
   width: '28px',
@@ -15,9 +17,10 @@ type ValidatorImageProps = {
   address: string
   name: string | undefined
   logotype: string | undefined
+  highlightedPart?: string | undefined
 }
 
-export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotype }) => {
+export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotype, highlightedPart }) => {
   return (
     <>
       {logotype && hasValidProtocol(logotype) ? (
@@ -27,6 +30,13 @@ export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotyp
           <ImageNotSupportedIcon sx={{ color: COLORS.grayMedium, fontSize: 18 }} />
         </Circle>
       )}
+      {name ? (
+        <Box sx={{ display: 'inline' }}>
+          <HighlightedText text={name} pattern={highlightedPart} />
+        </Box>
+      ) : (
+        address
+      )}{' '}
     </>
   )
 }

--- a/src/app/components/Validators/ValidatorLink.tsx
+++ b/src/app/components/Validators/ValidatorLink.tsx
@@ -7,23 +7,37 @@ import { RouteUtils } from '../../utils/route-utils'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
 import { Network } from '../../../types/network'
+import { HighlightedText } from '../HighlightedText'
 
 type ValidatorLinkProps = {
   address: string
   name?: string
   network: Network
   alwaysTrim?: boolean
+  highlightedPart?: string
 }
 
-export const ValidatorLink: FC<ValidatorLinkProps> = ({ address, name, network, alwaysTrim }) => {
+export const ValidatorLink: FC<ValidatorLinkProps> = ({
+  address,
+  name,
+  network,
+  alwaysTrim,
+  highlightedPart,
+}) => {
   const { isTablet } = useScreenSize()
   const to = RouteUtils.getValidatorRoute(network, address)
   return (
     <Typography variant="mono" component="span" sx={{ color: COLORS.brandDark, fontWeight: 700 }}>
       {isTablet ? (
-        <TabletValidatorLink address={address} name={name} to={to} />
+        <TabletValidatorLink address={address} name={name} to={to} highlightedPart={highlightedPart} />
       ) : (
-        <DesktopValidatorLink address={address} alwaysTrim={alwaysTrim} name={name} to={to} />
+        <DesktopValidatorLink
+          address={address}
+          alwaysTrim={alwaysTrim}
+          name={name}
+          to={to}
+          highlightedPart={highlightedPart}
+        />
       )}
     </Typography>
   )
@@ -42,6 +56,7 @@ type TabletValidatorLinkProps = {
   address: string
   name?: string
   to: string
+  highlightedPart?: string // TODO: add support for highlighting on tablet
 }
 
 const TabletValidatorLink: FC<TabletValidatorLinkProps> = ({ address, name, to }) => {
@@ -55,13 +70,19 @@ type DesktopValidatorLinkProps = TabletValidatorLinkProps & {
   alwaysTrim?: boolean
 }
 
-const DesktopValidatorLink: FC<DesktopValidatorLinkProps> = ({ address, name, to, alwaysTrim }) => {
+const DesktopValidatorLink: FC<DesktopValidatorLinkProps> = ({
+  address,
+  name,
+  to,
+  alwaysTrim,
+  highlightedPart,
+}) => {
   if (alwaysTrim) {
     return <TrimLinkLabel label={address} to={to} />
   }
   return (
     <Link component={RouterLink} to={to}>
-      {name ?? address}
+      {name ? <HighlightedText text={name} pattern={highlightedPart} /> : address}
     </Link>
   )
 }

--- a/src/app/components/Validators/ValidatorLink.tsx
+++ b/src/app/components/Validators/ValidatorLink.tsx
@@ -61,7 +61,7 @@ const DesktopValidatorLink: FC<DesktopValidatorLinkProps> = ({ address, name, to
   }
   return (
     <Link component={RouterLink} to={to}>
-      {name || address}
+      {name ?? address}
     </Link>
   )
 }

--- a/src/app/hooks/useBooleanFlagInUrl.ts
+++ b/src/app/hooks/useBooleanFlagInUrl.ts
@@ -1,0 +1,21 @@
+import { useSearchParams } from 'react-router-dom'
+import { UrlSettingOptions } from './useStringInUrl'
+
+export const useBooleanFlagInUrl = (param: string, defaultValue: boolean) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const valueString = searchParams.get(param)?.toLowerCase()
+  const value = valueString === 'true' ? true : valueString === 'false' ? false : defaultValue
+  const setValue = (newValue: boolean, options: UrlSettingOptions = {}) => {
+    const { replace, preventScrollReset = true, deleteParams = [] } = options
+    if (newValue === defaultValue) {
+      searchParams.delete(param)
+    } else {
+      searchParams.set(param, newValue.toString())
+    }
+    deleteParams.forEach(p => searchParams.delete(p))
+    setSearchParams(searchParams, { replace, preventScrollReset })
+  }
+
+  const toggleValue = () => setValue(!value)
+  return { value, setValue, toggleValue }
+}

--- a/src/app/hooks/useStringInUrl.ts
+++ b/src/app/hooks/useStringInUrl.ts
@@ -1,0 +1,38 @@
+import { useSearchParams } from 'react-router-dom'
+
+export type UrlSettingOptions = {
+  /**
+   * Should we replace the current state in the history, instead of appending a new state?
+   *
+   * Default is false
+   */
+  replace?: boolean
+
+  /**
+   * Should we block scrolling to the top?
+   *
+   * Default is true
+   */
+  preventScrollReset?: boolean
+
+  /**
+   * Should we delete some other params while setting this one?
+   */
+  deleteParams?: string[]
+}
+
+export const useStringInUrl = (paramName: string, defaultValue: string = '') => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const value = searchParams.get(paramName) ?? defaultValue
+  const setValue = (newValue: string, options: UrlSettingOptions = {}) => {
+    const { replace, preventScrollReset = true, deleteParams = [] } = options
+    if (newValue === defaultValue) {
+      searchParams.delete(paramName)
+    } else {
+      searchParams.set(paramName, newValue)
+    }
+    deleteParams.forEach(p => searchParams.delete(p))
+    setSearchParams(searchParams, { replace, preventScrollReset })
+  }
+  return { value, setValue }
+}

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -1,0 +1,111 @@
+import { FC } from 'react'
+import { useParams } from 'react-router-dom'
+import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { SubPageCard } from '../../components/SubPageCard'
+import { TablePaginationProps } from '../../components/Table/TablePagination'
+import { useTranslation } from 'react-i18next'
+import { Table, TableCellAlign, TableColProps } from '../../components/Table'
+import { ExtendedVote, ProposalVoteValue } from '../../../types/vote'
+import { PAGE_SIZE, useAllVotes, useDisplayedVotes, useWantedVoteType } from './hooks'
+import { ProposalVoteIndicator } from '../../components/Proposals/ProposalVoteIndicator'
+import { DeferredValidatorLink } from '../../components/Validators/DeferredValidatorLink'
+import { CardHeaderWithResponsiveActions } from '../../components/CardHeaderWithResponsiveActions'
+import { VoteTypePills } from '../../components/Proposals/VoteTypePills'
+import { AppErrors } from '../../../types/errors'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+
+type ProposalVotesProps = {
+  isLoading: boolean
+  votes: ExtendedVote[] | undefined
+  limit: number
+  pagination: TablePaginationProps
+}
+
+const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, limit, pagination }) => {
+  const { t } = useTranslation()
+  const scope = useRequiredScopeParam()
+
+  const tableColumns: TableColProps[] = [
+    { key: 'index', content: <></>, width: '50px' },
+    { key: 'voter', content: t('common.voter'), align: TableCellAlign.Left },
+    { key: 'vote', content: t('common.vote'), align: TableCellAlign.Right },
+  ]
+  const tableRows = votes?.map(vote => {
+    return {
+      key: `vote-${vote.index}`,
+      data: [
+        {
+          key: 'index',
+          content: `#${vote.index}`,
+        },
+        {
+          key: 'voter',
+          content: (
+            <DeferredValidatorLink
+              network={scope.network}
+              address={vote.address}
+              isError={vote.haveValidatorsFailed}
+              validator={vote.validator}
+            />
+          ),
+        },
+        {
+          key: 'vote',
+          content: <ProposalVoteIndicator vote={vote.vote as ProposalVoteValue} />,
+          align: TableCellAlign.Right,
+        },
+      ],
+    }
+  })
+  return (
+    <Table
+      name={t('common.votes')}
+      columns={tableColumns}
+      rows={tableRows}
+      rowsNumber={limit}
+      isLoading={isLoading}
+      pagination={pagination}
+    />
+  )
+}
+
+export const ProposalVotesView: FC = () => {
+  const { network } = useRequiredScopeParam()
+  const proposalId = parseInt(useParams().proposalId!, 10)
+
+  const { isLoading } = useAllVotes(network, proposalId)
+  const displayedVotes = useDisplayedVotes(network, proposalId)
+
+  if (!isLoading && displayedVotes.tablePaginationProps.selectedPage > 1 && !displayedVotes.data?.length) {
+    throw AppErrors.PageDoesNotExist
+  }
+
+  return (
+    <ProposalVotes
+      isLoading={isLoading}
+      votes={displayedVotes.data}
+      limit={PAGE_SIZE}
+      pagination={displayedVotes.tablePaginationProps}
+    />
+  )
+}
+
+export const ProposalVotesCard: FC = () => {
+  const { t } = useTranslation()
+
+  const { wantedVoteType, setWantedVoteType } = useWantedVoteType()
+
+  return (
+    <SubPageCard>
+      <CardHeaderWithResponsiveActions
+        action={<VoteTypePills handleChange={setWantedVoteType} value={wantedVoteType} />}
+        disableTypography
+        component="h3"
+        title={t('common.votes')}
+      />
+      <ErrorBoundary light={true}>
+        <ProposalVotesView />
+      </ErrorBoundary>
+    </SubPageCard>
+  )
+}

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -6,13 +6,21 @@ import { TablePaginationProps } from '../../components/Table/TablePagination'
 import { useTranslation } from 'react-i18next'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { ExtendedVote, ProposalVoteValue } from '../../../types/vote'
-import { PAGE_SIZE, useAllVotes, useDisplayedVotes, useWantedVoteType } from './hooks'
+import {
+  PAGE_SIZE,
+  useAllVotes,
+  useDisplayedVotes,
+  useVoterSearch,
+  useVoterSearchPattern,
+  useWantedVoteType,
+} from './hooks'
 import { ProposalVoteIndicator } from '../../components/Proposals/ProposalVoteIndicator'
 import { DeferredValidatorLink } from '../../components/Validators/DeferredValidatorLink'
 import { CardHeaderWithResponsiveActions } from '../../components/CardHeaderWithResponsiveActions'
 import { VoteTypePills } from '../../components/Proposals/VoteTypePills'
 import { AppErrors } from '../../../types/errors'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { VoterSearchBar } from '../../components/Proposals/VoterSearchBar'
 
 type ProposalVotesProps = {
   isLoading: boolean
@@ -24,6 +32,8 @@ type ProposalVotesProps = {
 const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, limit, pagination }) => {
   const { t } = useTranslation()
   const scope = useRequiredScopeParam()
+
+  const voterNameFragment = useVoterSearchPattern()
 
   const tableColumns: TableColProps[] = [
     { key: 'index', content: <></>, width: '50px' },
@@ -46,6 +56,7 @@ const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, limit, pagina
               address={vote.address}
               isError={vote.haveValidatorsFailed}
               validator={vote.validator}
+              highlightedPart={voterNameFragment}
             />
           ),
         },
@@ -94,11 +105,17 @@ export const ProposalVotesCard: FC = () => {
   const { t } = useTranslation()
 
   const { wantedVoteType, setWantedVoteType } = useWantedVoteType()
+  const { voterSearchInput, setVoterSearchPattern } = useVoterSearch()
 
   return (
     <SubPageCard>
       <CardHeaderWithResponsiveActions
-        action={<VoteTypePills handleChange={setWantedVoteType} value={wantedVoteType} />}
+        action={
+          <>
+            <VoterSearchBar variant={'button'} value={voterSearchInput} onChange={setVoterSearchPattern} />
+            <VoteTypePills handleChange={setWantedVoteType} value={wantedVoteType} />
+          </>
+        }
         disableTypography
         component="h3"
         title={t('common.votes')}

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -4,12 +4,13 @@ import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { SubPageCard } from '../../components/SubPageCard'
 import { TablePaginationProps } from '../../components/Table/TablePagination'
 import { useTranslation } from 'react-i18next'
+import SwapVertIcon from '@mui/icons-material/SwapVert'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { ExtendedVote, ProposalVoteValue } from '../../../types/vote'
 import {
   PAGE_SIZE,
-  useAllVotes,
   useDisplayedVotes,
+  useOrder,
   useVoterSearch,
   useVoterSearchPattern,
   useWantedVoteType,
@@ -34,9 +35,12 @@ const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, limit, pagina
   const scope = useRequiredScopeParam()
 
   const voterNameFragment = useVoterSearchPattern()
+  const { toggleReverse: toggleReverseOrder } = useOrder()
+
+  const OrderTrigger: FC = () => <SwapVertIcon onClick={toggleReverseOrder} />
 
   const tableColumns: TableColProps[] = [
-    { key: 'index', content: <></>, width: '50px' },
+    { key: 'index', content: <OrderTrigger />, width: '50px' },
     { key: 'voter', content: t('common.voter'), align: TableCellAlign.Left },
     { key: 'vote', content: t('common.vote'), align: TableCellAlign.Right },
   ]
@@ -84,16 +88,19 @@ export const ProposalVotesView: FC = () => {
   const { network } = useRequiredScopeParam()
   const proposalId = parseInt(useParams().proposalId!, 10)
 
-  const { isLoading } = useAllVotes(network, proposalId)
   const displayedVotes = useDisplayedVotes(network, proposalId)
 
-  if (!isLoading && displayedVotes.tablePaginationProps.selectedPage > 1 && !displayedVotes.data?.length) {
+  if (
+    !displayedVotes.isLoading &&
+    displayedVotes.tablePaginationProps.selectedPage > 1 &&
+    !displayedVotes.data?.length
+  ) {
     throw AppErrors.PageDoesNotExist
   }
 
   return (
     <ProposalVotes
-      isLoading={isLoading}
+      isLoading={displayedVotes.isLoading}
       votes={displayedVotes.data}
       limit={PAGE_SIZE}
       pagination={displayedVotes.tablePaginationProps}

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -1,0 +1,154 @@
+import {
+  List,
+  useGetConsensusProposalsProposalIdVotes,
+  useGetConsensusValidators,
+} from '../../../oasis-nexus/api'
+import { Network } from '../../../types/network'
+import {
+  ExtendedVote,
+  getFilterForVoteType,
+  getRandomVote,
+  ProposalVoteValue,
+  VoteFilter,
+  VoteType,
+} from '../../../types/vote'
+import { useClientSidePagination } from '../../components/Table/useClientSidePagination'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
+import { useStringInUrl } from '../../hooks/useStringInUrl'
+
+export type AllVotesData = List & {
+  isLoading: boolean
+  isError: boolean
+  loadedVotes: ExtendedVote[]
+}
+
+const DEBUG_MODE = true // TODO disable debug mode before merging
+
+const voteTable: Record<string, ProposalVoteValue> = {}
+
+const getRandomVoteFor = (address: string) => {
+  const storedVote = voteTable[address]
+  if (storedVote) return storedVote
+  const newVote = getRandomVote()
+  voteTable[address] = newVote
+  return newVote
+}
+
+const useValidatorMap = (network: Network) => {
+  const { data, isLoading, isError } = useGetConsensusValidators(network)
+  return {
+    isLoading,
+    isError,
+    map: (data as any)?.data.map ?? new Map(),
+  }
+}
+
+export const useAllVotes = (network: Network, proposalId: number): AllVotesData => {
+  const query = useGetConsensusProposalsProposalIdVotes(network, proposalId)
+  const {
+    map: validators,
+    isLoading: areValidatorsLoading,
+    isError: haveValidatorsFailed,
+  } = useValidatorMap(network)
+  const { isLoading, isError, data } = query
+
+  const extendedVotes = (data?.data.votes || []).map(
+    (vote, index): ExtendedVote => ({
+      ...vote,
+      index: index + 1,
+      areValidatorsLoading,
+      haveValidatorsFailed,
+      validator: validators.get(vote.address),
+    }),
+  )
+
+  return {
+    isLoading,
+    isError,
+    loadedVotes: DEBUG_MODE
+      ? extendedVotes.map(v => ({ ...v, vote: getRandomVoteFor(v.address) })) || []
+      : extendedVotes,
+    total_count: data?.data.total_count ?? 0,
+    is_total_count_clipped: data?.data.is_total_count_clipped ?? false,
+  }
+}
+
+export type VoteStats = {
+  isLoading: boolean
+  isError: boolean
+
+  /**
+   * Did we manage to get all data from the server?
+   */
+  isComplete: boolean
+
+  /**
+   * The results of counting the votes
+   */
+  tally: Record<ProposalVoteValue, bigint>
+
+  /**
+   * The total number of (valid) votes
+   */
+  allVotesCount: number
+
+  /**
+   * The total amount of valid votes (considering the shares)
+   */
+  allVotesPower: bigint
+}
+
+export const useVoteStats = (network: Network, proposalId: number): VoteStats => {
+  const { isLoading, isError, loadedVotes, total_count, is_total_count_clipped } = useAllVotes(
+    network,
+    proposalId,
+  )
+  const tally: Record<ProposalVoteValue, bigint> = {
+    yes: 0n,
+    no: 0n,
+    abstain: 0n,
+  }
+  // TODO: instead of 1n, we should add the power of the vote, but that data is not available yet.
+  loadedVotes.forEach(vote => (tally[vote.vote as ProposalVoteValue] += 1n))
+  const allVotesCount = loadedVotes.length
+  const allVotesPower = tally.yes + tally.no + tally.abstain
+  const isComplete = !isError && loadedVotes.length === total_count && !is_total_count_clipped
+  return {
+    isLoading,
+    isError,
+    isComplete,
+    tally,
+    allVotesCount,
+    allVotesPower,
+  }
+}
+
+export const useWantedVoteType = () => {
+  const { value, setValue } = useStringInUrl('vote', 'any')
+
+  return {
+    wantedVoteType: value as VoteType,
+    setWantedVoteType: (newType: VoteType) => setValue(newType, { deleteParams: ['page'] }),
+  }
+}
+
+const useWantedVoteFilter = (): VoteFilter => getFilterForVoteType(useWantedVoteType().wantedVoteType)
+
+export const PAGE_SIZE = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+
+export const useDisplayedVotes = (network: Network, proposalId: number) => {
+  const filter = useWantedVoteFilter()
+
+  const pagination = useClientSidePagination<ExtendedVote, AllVotesData>({
+    paramName: 'page',
+    clientPageSize: PAGE_SIZE,
+    serverPageSize: 1000,
+    filter,
+  })
+
+  // Get all the votes
+  const allVotes = useAllVotes(network, proposalId)
+
+  // Get the section of the votes that we should display in the table
+  return pagination.getResults(allVotes)
+}

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -132,7 +132,30 @@ export const useWantedVoteType = () => {
   }
 }
 
-const useWantedVoteFilter = (): VoteFilter => getFilterForVoteType(useWantedVoteType().wantedVoteType)
+export const useVoterSearch = () => {
+  const { value, setValue } = useStringInUrl('voter')
+  return {
+    voterSearchInput: value,
+    setVoterSearchPattern: (newValue: string) => setValue(newValue, { deleteParams: ['page'] }),
+  }
+}
+
+export const useVoterSearchPattern = () => {
+  const { voterSearchInput } = useVoterSearch()
+  return voterSearchInput.length < 3 ? undefined : voterSearchInput
+}
+
+const useWantedVoteFilter = (): VoteFilter => {
+  const typeFilter = getFilterForVoteType(useWantedVoteType().wantedVoteType)
+  const voterSearchPattern = useVoterSearchPattern()
+
+  if (!voterSearchPattern) {
+    return typeFilter
+  } else {
+    return (vote: ExtendedVote) =>
+      typeFilter(vote) && !!vote.validator?.media?.name?.toLowerCase().includes(voterSearchPattern)
+  }
+}
 
 export const PAGE_SIZE = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -72,8 +72,7 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
     network,
     layer, // This is OK since consensus has been handled separately
     {
-      offset: pagination.offsetForQuery,
-      limit: pagination.limitForQuery,
+      ...pagination.paramsForServer,
       type: RuntimeEventType.evmlog,
       // The following is the hex-encoded signature for Transfer(address,address,uint256)
       evm_log_signature: 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
@@ -88,16 +87,16 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
 
   const { isFetched, isLoading, data } = query
 
-  const results = pagination.getResults(data?.data)
+  const results = pagination.getResults(isLoading, data?.data)
 
-  if (isFetched && pagination.selectedPage > 1 && !results.data?.length) {
+  if (isFetched && pagination.selectedPageForClient > 1 && !results.data?.length) {
     throw AppErrors.PageDoesNotExist
   }
 
   return {
     isLoading,
     isFetched,
-    results: pagination.getResults(data?.data),
+    results: pagination.getResults(isLoading, data?.data),
   }
 }
 

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -72,7 +72,8 @@ export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRu
     network,
     layer, // This is OK since consensus has been handled separately
     {
-      ...pagination.paramsForQuery,
+      offset: pagination.offsetForQuery,
+      limit: pagination.limitForQuery,
       type: RuntimeEventType.evmlog,
       // The following is the hex-encoded signature for Transfer(address,address,uint256)
       evm_log_signature: 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -88,6 +88,7 @@
     "hash": "Hash",
     "height": "Height",
     "hide": "Hide",
+    "invalidVotes": "Invalid votes",
     "loadMore": "Load more",
     "lessThanAmount": "&lt; {{value, number}} <TickerLink />",
     "method": "Method",
@@ -140,6 +141,9 @@
     "valueInTokenWithLink": "{{value, number}} <TickerLink />",
     "view": "View",
     "viewAll": "View all",
+    "vote": "Vote",
+    "voter": "Voter",
+    "votes": "Votes",
     "paraTimeOnline": "ParaTime Online",
     "paraTimeOutOfDate": "ParaTime Out of date",
     "mainnet": "Mainnet",
@@ -182,6 +186,7 @@
     "create": "Created",
     "createTooltip": "Voting created on epoch shown.",
     "deposit": "Deposit",
+    "failedToLoadAllVotes": "Failed to load all the votes, number might be incomplete!",
     "handler": "Title",
     "id": "ID",
     "listTitle": "Network Change Proposals",
@@ -195,7 +200,14 @@
       "upgrade": "Upgrade",
       "parameterUpgrade": "Parameter upgrade",
       "cancellation": "Cancellation"
-    }
+    },
+    "vote": {
+      "yes": "Yes",
+      "no": "No",
+      "abstain": "Abstained",
+      "all": "All votes"
+    },
+    "searchForVoters": "Search for voters"
   },
   "nft": {
     "accountCollection": "ERC-721 Tokens",

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -905,15 +905,19 @@ export const useGetConsensusValidators: typeof generated.useGetConsensusValidato
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.ValidatorList, headers, status) => {
           if (status !== 200) return data
+          const validators = data.validators.map(validator => {
+            return {
+              ...validator,
+              escrow: fromBaseUnits(validator.escrow, consensusDecimals),
+              ticker,
+            }
+          })
+          const map = new Map<string, generated.Validator>()
+          validators.forEach(validator => map.set(validator.entity_address, validator))
           return {
             ...data,
-            validators: data.validators.map(validator => {
-              return {
-                ...validator,
-                escrow: fromBaseUnits(validator.escrow, consensusDecimals),
-                ticker,
-              }
-            }),
+            validators,
+            map,
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -1,0 +1,38 @@
+import { ProposalVote, Validator } from '../oasis-nexus/api'
+
+export type ProposalVoteValue = (typeof ProposalVoteValue)[keyof typeof ProposalVoteValue]
+
+/**
+ * Valid vote types for network proposals
+ *
+ * Based on https://github.com/oasisprotocol/nexus/blob/main/storage/oasis/nodeapi/api.go#L199
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ProposalVoteValue = {
+  yes: 'yes',
+  no: 'no',
+  abstain: 'abstain',
+} as const
+
+export const getRandomVote = (): ProposalVoteValue =>
+  [ProposalVoteValue.yes, ProposalVoteValue.no, ProposalVoteValue.abstain][Math.floor(Math.random() * 3)]
+
+export type VoteType = ProposalVoteValue | 'any'
+
+export type ExtendedVote = ProposalVote & {
+  index: number
+  areValidatorsLoading: boolean
+  haveValidatorsFailed: boolean
+  validator?: Validator
+}
+
+export type VoteFilter = (vote: ExtendedVote) => boolean
+
+const voteFilters: Record<VoteType, VoteFilter> = {
+  any: () => true,
+  yes: vote => vote.vote === ProposalVoteValue.yes,
+  no: vote => vote.vote === ProposalVoteValue.no,
+  abstain: vote => vote.vote === ProposalVoteValue.abstain,
+}
+
+export const getFilterForVoteType = (voteType: VoteType): VoteFilter => voteFilters[voteType]


### PR DESCRIPTION
This is built on top of #1356, #1357 and #1358.

Makes it possible to change the order of display of the proposal votes.