### PR TITLE
Bring back tx type description

### DIFF
--- a/.changelog/1363.feature.md
+++ b/.changelog/1363.feature.md
@@ -1,0 +1,5 @@
+Extend functionality of method icons
+
+- bring back type description
+- conditionally truncate descriptions in tables
+- enable tooltip for truncated descriptions

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -14,6 +14,8 @@ import MiscellaneousServicesIcon from '@mui/icons-material/MiscellaneousServices
 import PersonIcon from '@mui/icons-material/Person'
 import PriceChangeIcon from '@mui/icons-material/PriceChange'
 import QuestionMarkIcon from '@mui/icons-material/QuestionMark'
+import Tooltip from '@mui/material/Tooltip'
+import { tooltipDelay } from '../../../styles/theme'
 import { ConsensusTxMethod } from '../../../oasis-nexus/api'
 import { COLORS } from '../../../styles/theme/colors'
 
@@ -47,7 +49,25 @@ export const colorMap = {
 
 const iconRatio = 0.75
 
-export const MethodIcon: FC<MethodIconProps> = ({
+export const MethodIcon: FC<MethodIconProps> = props => {
+  const { label, reverseLabel } = props
+  const showTooltip = label && !reverseLabel
+  // TODO: get requirement when we want to trim label
+  return (
+    <>
+      {showTooltip && (
+        <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
+          <span>
+            <MethodIconContent {...props} />
+          </span>
+        </Tooltip>
+      )}
+      {!showTooltip && <MethodIconContent {...props} />}
+    </>
+  )
+}
+
+const MethodIconContent: FC<MethodIconProps> = ({
   border = true,
   color = 'blue',
   icon,

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -22,6 +22,7 @@ type MethodIconProps = {
   color?: 'blue' | 'green' | 'gray' | 'orange'
   icon: ReactElement
   label?: string
+  reverseLabel?: boolean
   size?: number
 }
 
@@ -51,6 +52,7 @@ export const MethodIcon: FC<MethodIconProps> = ({
   color = 'blue',
   icon,
   label,
+  reverseLabel,
   size = 40,
 }) => {
   const theme = colorMap[color]
@@ -75,7 +77,11 @@ export const MethodIcon: FC<MethodIconProps> = ({
       >
         {cloneElement(icon, { sx: { fontSize: Math.ceil(size * iconRatio) } })}
       </Box>
-      {label && <Typography sx={{ textTransform: 'capitalize' }}>{label}</Typography>}
+      {label && (
+        <Typography sx={{ fontWeight: 'inherit', textTransform: 'capitalize', order: reverseLabel ? -1 : 0 }}>
+          {label}
+        </Typography>
+      )}
     </Box>
   )
 }

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -217,7 +217,7 @@ export const RuntimeEventDetails: FC<{
         <div>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <b>
-              <TokenTransferIcon reverseLabel name={parsedEvmLogName} size={25} />
+              <TokenTransferIcon reverseLabel method={parsedEvmLogName} size={25} />
             </b>
           </Box>
           <br />

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -1,5 +1,6 @@
 import { EvmAbiParam, RuntimeEvent, RuntimeEventType } from '../../../oasis-nexus/api'
 import { FC } from 'react'
+import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { StyledDescriptionList } from '../StyledDescriptionList'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -16,8 +17,9 @@ import { getOasisAddress } from '../../utils/helpers'
 import { exhaustedTypeWarning } from '../../../types/errors'
 import { LongDataDisplay } from '../LongDataDisplay'
 import { parseEvmEvent } from '../../utils/parseEvmEvent'
-import { TokenTransferIcon, TokenTransferLabel } from '../Tokens/TokenTransferIcon'
+import { TokenTransferIcon } from '../Tokens/TokenTransferIcon'
 import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
 import StreamIcon from '@mui/icons-material/Stream'
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
@@ -29,48 +31,69 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import LanIcon from '@mui/icons-material/Lan'
 import LanOutlinedIcon from '@mui/icons-material/LanOutlined'
 import { MethodIcon } from '../ConsensusTransactionMethod'
-import Typography from '@mui/material/Typography'
 
-const eventIconSize = 25
+const getRuntimeEventMethodLabel = (t: TFunction, method: string | undefined) => {
+  switch (method) {
+    case RuntimeEventType.accountstransfer:
+      return t('runtimeEvent.accountstransfer')
+    case RuntimeEventType.evmlog:
+      return t('runtimeEvent.evmLog')
+    case RuntimeEventType.coregas_used:
+      return t('runtimeEvent.gasUsed')
+    case RuntimeEventType.consensus_accountswithdraw:
+      return t('runtimeEvent.consensusWithdrawal')
+    case RuntimeEventType.consensus_accountsdeposit:
+      return t('runtimeEvent.consensusDeposit')
+    case RuntimeEventType.consensus_accountsdelegate:
+      return t('runtimeEvent.consensusDelegate')
+    case RuntimeEventType.consensus_accountsundelegate_start:
+      return t('runtimeEvent.consensusUndelegateStart')
+    case RuntimeEventType.consensus_accountsundelegate_done:
+      return t('runtimeEvent.consensusUndelegateDone')
+    case RuntimeEventType.accountsmint:
+      return t('runtimeEvent.accountsmint')
+    case RuntimeEventType.accountsburn:
+      return t('runtimeEvent.accountsburn')
+    default:
+      return method || t('common.unknown')
+  }
+}
 
 export const EventTypeIcon: FC<{
   eventType: RuntimeEventType
-  eventName: string
-}> = ({ eventType, eventName }) => {
+}> = ({ eventType }) => {
+  const { t } = useTranslation()
+  const label = getRuntimeEventMethodLabel(t, eventType)
+  const props = {
+    border: false,
+    label,
+    reverseLabel: true,
+    size: 25,
+  }
   const eventTypeIcons: Record<RuntimeEventType, React.ReactNode> = {
-    [RuntimeEventType.accountstransfer]: (
-      <MethodIcon border={false} color="green" icon={<ArrowForwardIcon />} size={eventIconSize} />
-    ),
+    [RuntimeEventType.accountstransfer]: <MethodIcon color="green" icon={<ArrowForwardIcon />} {...props} />,
     [RuntimeEventType.evmlog]: <></>,
     [RuntimeEventType.coregas_used]: <></>,
     [RuntimeEventType.consensus_accountswithdraw]: (
-      <MethodIcon color="orange" border={false} icon={<ArrowUpwardIcon />} size={eventIconSize} />
+      <MethodIcon color="orange" icon={<ArrowUpwardIcon />} {...props} />
     ),
     [RuntimeEventType.consensus_accountsdeposit]: (
-      <MethodIcon border={false} color="green" icon={<ArrowDownwardIcon />} size={eventIconSize} />
+      <MethodIcon color="green" icon={<ArrowDownwardIcon />} {...props} />
     ),
-    [RuntimeEventType.consensus_accountsdelegate]: (
-      <MethodIcon border={false} icon={<LanIcon />} size={eventIconSize} />
-    ),
+    [RuntimeEventType.consensus_accountsdelegate]: <MethodIcon icon={<LanIcon />} {...props} />,
     [RuntimeEventType.consensus_accountsundelegate_start]: (
-      <MethodIcon border={false} icon={<LanOutlinedIcon />} size={eventIconSize} />
+      <MethodIcon icon={<LanOutlinedIcon />} {...props} />
     ),
-    [RuntimeEventType.consensus_accountsundelegate_done]: (
-      <MethodIcon border={false} icon={<LanIcon />} size={eventIconSize} />
-    ),
-    [RuntimeEventType.accountsmint]: (
-      <MethodIcon color="green" border={false} icon={<StreamIcon />} size={eventIconSize} />
-    ),
+    [RuntimeEventType.consensus_accountsundelegate_done]: <MethodIcon icon={<LanIcon />} {...props} />,
+    [RuntimeEventType.accountsmint]: <MethodIcon color="green" icon={<StreamIcon />} {...props} />,
     [RuntimeEventType.accountsburn]: (
-      <MethodIcon color="orange" border={false} icon={<LocalFireDepartmentIcon />} size={eventIconSize} />
+      <MethodIcon color="orange" icon={<LocalFireDepartmentIcon />} {...props} />
     ),
   }
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      <b>{eventName}</b>
-      &nbsp;
-      {eventTypeIcons[eventType]}
+      <b>{eventTypeIcons[eventType]}</b>
     </Box>
   )
 }
@@ -138,20 +161,7 @@ export const RuntimeEventDetails: FC<{
 }> = ({ scope, event, addressSwitchOption }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
-  const eventTypeNames: Record<RuntimeEventType, string> = {
-    [RuntimeEventType.accountstransfer]: t('runtimeEvent.accountstransfer'),
-    [RuntimeEventType.evmlog]: t('runtimeEvent.evmLog'),
-    [RuntimeEventType.coregas_used]: t('runtimeEvent.gasUsed'),
-    [RuntimeEventType.consensus_accountswithdraw]: t('runtimeEvent.consensusWithdrawal'),
-    [RuntimeEventType.consensus_accountsdeposit]: t('runtimeEvent.consensusDeposit'),
-    [RuntimeEventType.consensus_accountsdelegate]: t('runtimeEvent.consensusDelegate'),
-    [RuntimeEventType.consensus_accountsundelegate_start]: t('runtimeEvent.consensusUndelegateStart'),
-    [RuntimeEventType.consensus_accountsundelegate_done]: t('runtimeEvent.consensusUndelegateDone'),
-    [RuntimeEventType.accountsmint]: t('runtimeEvent.accountsmint'),
-    [RuntimeEventType.accountsburn]: t('runtimeEvent.accountsburn'),
-  }
-
-  const eventName = eventTypeNames[event.type]
+  const eventName = getRuntimeEventMethodLabel(t, event.type)
   switch (event.type) {
     case RuntimeEventType.coregas_used:
       return (
@@ -206,12 +216,9 @@ export const RuntimeEventDetails: FC<{
       return (
         <div>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            {eventName}: &nbsp;
             <b>
-              <TokenTransferLabel name={parsedEvmLogName} />
+              <TokenTransferIcon reverseLabel name={parsedEvmLogName} size={25} />
             </b>
-            &nbsp;
-            <TokenTransferIcon name={parsedEvmLogName} size={25} />
           </Box>
           <br />
           {event.evm_log_params && event.evm_log_params.length > 0 && (
@@ -253,7 +260,7 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.accountsmint:
       return (
         <div>
-          <EventTypeIcon eventType={event.type} eventName={eventName} />
+          <EventTypeIcon eventType={event.type} />
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <dt>{t('runtimeEvent.fields.owner')}</dt>
             <dd>
@@ -279,7 +286,7 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.consensus_accountswithdraw:
       return (
         <div>
-          <EventTypeIcon eventType={event.type} eventName={eventName} />
+          <EventTypeIcon eventType={event.type} />
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
@@ -313,7 +320,7 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.consensus_accountsdelegate:
       return (
         <div>
-          <EventTypeIcon eventType={event.type} eventName={eventName} />
+          <EventTypeIcon eventType={event.type} />
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
@@ -347,7 +354,7 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.consensus_accountsundelegate_start:
       return (
         <div>
-          <EventTypeIcon eventType={event.type} eventName={eventName} />
+          <EventTypeIcon eventType={event.type} />
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>
@@ -380,7 +387,7 @@ export const RuntimeEventDetails: FC<{
     case RuntimeEventType.consensus_accountsundelegate_done:
       return (
         <div>
-          <EventTypeIcon eventType={event.type} eventName={eventName} />
+          <EventTypeIcon eventType={event.type} />
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.from')}</dt>

--- a/src/app/components/RuntimeEvents/__tests__/matchEventAndTokenTransfersIcons.test.tsx
+++ b/src/app/components/RuntimeEvents/__tests__/matchEventAndTokenTransfersIcons.test.tsx
@@ -4,16 +4,16 @@ import { TokenTransferIcon } from '../../Tokens/TokenTransferIcon'
 
 test('Transfer, burn, and mint icons should match in EventTypeIcon and evm TokenTransferIcon', () => {
   const transfer = render(<EventTypeIcon eventType="accounts.transfer" />).container
-  const evmTransfer = render(<TokenTransferIcon name="Transfer" size={25} />).container
+  const evmTransfer = render(<TokenTransferIcon method="Transfer" size={25} />).container
   expect(transfer.querySelector('svg')?.outerHTML.length).toBeGreaterThan(100)
   expect(transfer.querySelector('svg')?.outerHTML).toEqual(evmTransfer.querySelector('svg')?.outerHTML)
 
   const mint = render(<EventTypeIcon eventType="accounts.mint" />).container
-  const evmMint = render(<TokenTransferIcon name="Minting" size={25} />).container
+  const evmMint = render(<TokenTransferIcon method="Minting" size={25} />).container
   expect(mint.querySelector('svg')?.outerHTML).toEqual(evmMint.querySelector('svg')?.outerHTML)
 
   const burn = render(<EventTypeIcon eventType="accounts.burn" />).container
-  const evmBurn = render(<TokenTransferIcon name="Burning" size={25} />).container
+  const evmBurn = render(<TokenTransferIcon method="Burning" size={25} />).container
   // compare using innerHTML as different dynamic css class is applied to svg element
   expect(burn.querySelector('svg')?.innerHTML).toEqual(evmBurn.querySelector('svg')?.innerHTML)
 })

--- a/src/app/components/RuntimeEvents/__tests__/matchEventAndTokenTransfersIcons.test.tsx
+++ b/src/app/components/RuntimeEvents/__tests__/matchEventAndTokenTransfersIcons.test.tsx
@@ -3,16 +3,16 @@ import { EventTypeIcon } from '../RuntimeEventDetails'
 import { TokenTransferIcon } from '../../Tokens/TokenTransferIcon'
 
 test('Transfer, burn, and mint icons should match in EventTypeIcon and evm TokenTransferIcon', () => {
-  const transfer = render(<EventTypeIcon eventType="accounts.transfer" eventName="Transfer" />).container
+  const transfer = render(<EventTypeIcon eventType="accounts.transfer" />).container
   const evmTransfer = render(<TokenTransferIcon name="Transfer" size={25} />).container
   expect(transfer.querySelector('svg')?.outerHTML.length).toBeGreaterThan(100)
   expect(transfer.querySelector('svg')?.outerHTML).toEqual(evmTransfer.querySelector('svg')?.outerHTML)
 
-  const mint = render(<EventTypeIcon eventType="accounts.mint" eventName="Tokens minted" />).container
+  const mint = render(<EventTypeIcon eventType="accounts.mint" />).container
   const evmMint = render(<TokenTransferIcon name="Minting" size={25} />).container
   expect(mint.querySelector('svg')?.outerHTML).toEqual(evmMint.querySelector('svg')?.outerHTML)
 
-  const burn = render(<EventTypeIcon eventType="accounts.burn" eventName="Tokens burnt" />).container
+  const burn = render(<EventTypeIcon eventType="accounts.burn" />).container
   const evmBurn = render(<TokenTransferIcon name="Burning" size={25} />).container
   // compare using innerHTML as different dynamic css class is applied to svg element
   expect(burn.querySelector('svg')?.innerHTML).toEqual(evmBurn.querySelector('svg')?.innerHTML)

--- a/src/app/components/RuntimeTransactionMethod/index.tsx
+++ b/src/app/components/RuntimeTransactionMethod/index.tsx
@@ -1,8 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TFunction } from 'i18next'
-import Tooltip from '@mui/material/Tooltip'
-import { tooltipDelay } from '../../../styles/theme'
 import TextSnippetIcon from '@mui/icons-material/TextSnippet'
 import FileCopyIcon from '@mui/icons-material/FileCopy'
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
@@ -86,9 +84,5 @@ export const RuntimeTransactionMethod: FC<RuntimeTransactionLabelProps> = ({ met
   const { t } = useTranslation()
   const label = getRuntimeTransactionLabel(t, method)
 
-  return (
-    <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-      <span>{getRuntimeTransactionIcon(method, label)}</span>
-    </Tooltip>
-  )
+  return <>{getRuntimeTransactionIcon(method, label)}</>
 }

--- a/src/app/components/RuntimeTransactionMethod/index.tsx
+++ b/src/app/components/RuntimeTransactionMethod/index.tsx
@@ -33,28 +33,33 @@ const getRuntimeTransactionLabel = (t: TFunction, method: string | undefined) =>
     case 'consensus.Undelegate':
       return t('transactions.method.consensus.undelegate')
     default:
-      return t('transactions.method.unknown', { method })
+      return method || t('common.unknown')
   }
 }
 
-const getRuntimeTransactionIcon = (method: string | undefined) => {
+const getRuntimeTransactionIcon = (method: string | undefined, label: string) => {
+  const props = {
+    border: false,
+    label,
+  }
+
   switch (method) {
     case 'evm.Call':
-      return <MethodIcon border={false} icon={<TextSnippetIcon />} />
+      return <MethodIcon icon={<TextSnippetIcon />} {...props} />
     case 'evm.Create':
-      return <MethodIcon border={false} icon={<FileCopyIcon />} />
+      return <MethodIcon icon={<FileCopyIcon />} {...props} />
     case 'consensus.Deposit':
-      return <MethodIcon border={false} color="green" icon={<ArrowDownwardIcon />} />
+      return <MethodIcon color="green" icon={<ArrowDownwardIcon />} {...props} />
     case 'consensus.Withdraw':
-      return <MethodIcon color="orange" border={false} icon={<ArrowUpwardIcon />} />
+      return <MethodIcon color="orange" icon={<ArrowUpwardIcon />} {...props} />
     case 'consensus.Delegate':
-      return <MethodIcon border={false} icon={<LanIcon />} />
+      return <MethodIcon icon={<LanIcon />} {...props} />
     case 'consensus.Undelegate':
-      return <MethodIcon border={false} icon={<LanOutlinedIcon />} />
+      return <MethodIcon icon={<LanOutlinedIcon />} {...props} />
     case 'accounts.Transfer':
-      return <MethodIcon border={false} color="green" icon={<ArrowForwardIcon />} />
+      return <MethodIcon color="green" icon={<ArrowForwardIcon />} {...props} />
     default:
-      return <MethodIcon border={false} color="gray" icon={<QuestionMarkIcon />} />
+      return <MethodIcon color="gray" icon={<QuestionMarkIcon />} {...props} />
   }
 }
 
@@ -77,24 +82,13 @@ type RuntimeTransactionLabelProps = {
   method?: string
 }
 
-export const RuntimeTransactionLabel: FC<RuntimeTransactionLabelProps> = ({ method }) => {
-  const { t } = useTranslation()
-
-  return <>{getRuntimeTransactionLabel(t, method)}</>
-}
-
 export const RuntimeTransactionMethod: FC<RuntimeTransactionLabelProps> = ({ method }) => {
   const { t } = useTranslation()
+  const label = getRuntimeTransactionLabel(t, method)
 
   return (
-    <Tooltip
-      arrow
-      placement="top"
-      title={getRuntimeTransactionLabel(t, method)}
-      enterDelay={tooltipDelay}
-      enterNextDelay={tooltipDelay}
-    >
-      <span>{getRuntimeTransactionIcon(method)}</span>
+    <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
+      <span>{getRuntimeTransactionIcon(method, label)}</span>
     </Tooltip>
   )
 }

--- a/src/app/components/RuntimeTransactionMethod/index.tsx
+++ b/src/app/components/RuntimeTransactionMethod/index.tsx
@@ -35,10 +35,11 @@ const getRuntimeTransactionLabel = (t: TFunction, method: string | undefined) =>
   }
 }
 
-const getRuntimeTransactionIcon = (method: string | undefined, label: string) => {
+const getRuntimeTransactionIcon = (method: string | undefined, label: string, truncate?: boolean) => {
   const props = {
     border: false,
     label,
+    truncate,
   }
 
   switch (method) {
@@ -78,11 +79,12 @@ type RuntimeTransactionLabelProps = {
    *   - "evm.Call"
    */
   method?: string
+  truncate?: boolean
 }
 
-export const RuntimeTransactionMethod: FC<RuntimeTransactionLabelProps> = ({ method }) => {
+export const RuntimeTransactionMethod: FC<RuntimeTransactionLabelProps> = ({ method, truncate }) => {
   const { t } = useTranslation()
   const label = getRuntimeTransactionLabel(t, method)
 
-  return <>{getRuntimeTransactionIcon(method, label)}</>
+  return <>{getRuntimeTransactionIcon(method, label, truncate)}</>
 }

--- a/src/app/components/Tokens/TokenTransferIcon.tsx
+++ b/src/app/components/Tokens/TokenTransferIcon.tsx
@@ -1,8 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TFunction } from 'i18next'
-import Tooltip from '@mui/material/Tooltip'
-import { tooltipDelay } from '../../../styles/theme'
 import StreamIcon from '@mui/icons-material/Stream'
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import ApprovalIcon from '@mui/icons-material/Approval'
@@ -64,9 +62,5 @@ export const TokenTransferIcon: FC<TokenTransferIconProps> = ({ method, reverseL
   const { t } = useTranslation()
   const label = getTokenTransferLabel(t, method)
 
-  return (
-    <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-      <span>{getTokenTransferIcon(method, label, reverseLabel, size)}</span>
-    </Tooltip>
-  )
+  return <>{getTokenTransferIcon(method, label, reverseLabel, size)}</>
 }

--- a/src/app/components/Tokens/TokenTransferIcon.tsx
+++ b/src/app/components/Tokens/TokenTransferIcon.tsx
@@ -55,18 +55,18 @@ const getTokenTransferIcon = (
 }
 
 interface TokenTransferIconProps {
-  name: string | undefined
+  method: string | undefined
   reverseLabel?: boolean
   size?: number
 }
 
-export const TokenTransferIcon: FC<TokenTransferIconProps> = ({ name, reverseLabel, size }) => {
+export const TokenTransferIcon: FC<TokenTransferIconProps> = ({ method, reverseLabel, size }) => {
   const { t } = useTranslation()
-  const label = getTokenTransferLabel(t, name)
+  const label = getTokenTransferLabel(t, method)
 
   return (
     <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-      <span>{getTokenTransferIcon(name, label, reverseLabel, size)}</span>
+      <span>{getTokenTransferIcon(method, label, reverseLabel, size)}</span>
     </Tooltip>
   )
 }

--- a/src/app/components/Tokens/TokenTransferIcon.tsx
+++ b/src/app/components/Tokens/TokenTransferIcon.tsx
@@ -23,54 +23,50 @@ const getTokenTransferLabel = (t: TFunction, name: string | undefined): string =
     case 'Burning':
       return t('tokens.transferEventType.burning')
     default:
-      return t('tokens.transferEventType.unknown', { name })
+      return name || t('common.unknown')
   }
 }
 
-const getTokenTransferIcon = (name: string | undefined, size?: number) => {
+const getTokenTransferIcon = (
+  name: string | undefined,
+  label: string,
+  reverseLabel?: boolean,
+  size?: number,
+) => {
+  const props = {
+    border: false,
+    label,
+    reverseLabel,
+    size,
+  }
+
   switch (name) {
     case 'Transfer':
-      return <MethodIcon border={false} color="green" icon={<ArrowForwardIcon />} size={size} />
+      return <MethodIcon color="green" icon={<ArrowForwardIcon />} {...props} />
     case 'Approval':
-      return <MethodIcon color="green" border={false} icon={<ApprovalIcon />} size={size} />
+      return <MethodIcon color="green" icon={<ApprovalIcon />} {...props} />
     case 'Minting':
-      return <MethodIcon color="green" border={false} icon={<StreamIcon />} size={size} />
+      return <MethodIcon color="green" icon={<StreamIcon />} {...props} />
     case 'Burning':
-      return <MethodIcon color="orange" border={false} icon={<LocalFireDepartmentIcon />} />
+      return <MethodIcon color="orange" icon={<LocalFireDepartmentIcon />} {...props} />
     default:
-      return <MethodIcon border={false} color="gray" icon={<QuestionMarkIcon />} size={size} />
+      return <MethodIcon color="gray" icon={<QuestionMarkIcon />} {...props} />
   }
 }
 
-interface TokenTransferLabelProps {
-  /**
-   * The event name
-   */
+interface TokenTransferIconProps {
   name: string | undefined
-}
-
-export const TokenTransferLabel: FC<TokenTransferLabelProps> = ({ name }) => {
-  const { t } = useTranslation()
-
-  return <>{getTokenTransferLabel(t, name)}</>
-}
-
-interface TokenTransferIconProps extends TokenTransferLabelProps {
+  reverseLabel?: boolean
   size?: number
 }
 
-export const TokenTransferIcon: FC<TokenTransferIconProps> = ({ name, size }) => {
+export const TokenTransferIcon: FC<TokenTransferIconProps> = ({ name, reverseLabel, size }) => {
   const { t } = useTranslation()
+  const label = getTokenTransferLabel(t, name)
 
   return (
-    <Tooltip
-      arrow
-      placement="top"
-      title={getTokenTransferLabel(t, name)}
-      enterDelay={tooltipDelay}
-      enterNextDelay={tooltipDelay}
-    >
-      <span>{getTokenTransferIcon(name, size)}</span>
+    <Tooltip arrow placement="top" title={label} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
+      <span>{getTokenTransferIcon(name, label, reverseLabel, size)}</span>
     </Tooltip>
   )
 }

--- a/src/app/components/Tokens/TokenTransfers.tsx
+++ b/src/app/components/Tokens/TokenTransfers.tsx
@@ -157,7 +157,7 @@ export const TokenTransfers: FC<TokenTransfersProps> = ({
         {
           key: 'type',
           align: TableCellAlign.Center,
-          content: <TokenTransferIcon name={parsedEvmLogName} />,
+          content: <TokenTransferIcon method={parsedEvmLogName} />,
         },
 
         {

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -80,7 +80,7 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
       ...(verbose
         ? [
             {
-              content: <ConsensusTransactionMethod method={transaction.method} />,
+              content: <ConsensusTransactionMethod method={transaction.method} truncate />,
               key: 'method',
             },
             {

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -77,7 +77,7 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
     { key: 'age', content: t('common.age'), align: TableCellAlign.Right },
     ...(verbose
       ? [
-          { key: 'type', content: t('common.type'), align: TableCellAlign.Center },
+          { key: 'type', content: t('common.type') },
           { key: 'from', content: t('common.from'), width: '150px' },
           { key: 'to', content: t('common.to'), width: '150px' },
           { key: 'txnFee', content: t('common.transactionFee'), align: TableCellAlign.Right, width: '250px' },
@@ -124,7 +124,6 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
         ...(verbose
           ? [
               {
-                align: TableCellAlign.Center,
                 content: <RuntimeTransactionMethod method={transaction.method} />,
                 key: 'type',
               },

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -124,7 +124,7 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
         ...(verbose
           ? [
               {
-                content: <RuntimeTransactionMethod method={transaction.method} />,
+                content: <RuntimeTransactionMethod method={transaction.method} truncate />,
                 key: 'type',
               },
               {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -349,8 +349,7 @@
       "approval": "Approval",
       "minting": "Minting",
       "burning": "Burning",
-      "unavailable": "Unknown token transfer event",
-      "unknown": "Unknown: {{name}}"
+      "unavailable": "Unknown token transfer event"
     },
     "type": "Token Type"
   },
@@ -393,7 +392,6 @@
       "beaconPVSSReveal": "PVSSReveal",
       "beaconVRFProve": "VRFProve",
       "unavailable": "Malformed transaction, method unavailable",
-      "unknown": "Unknown: {{method}}",
       "accounts": {
         "transfer": "Transfer"
       },

--- a/src/stories/Icons.stories.tsx
+++ b/src/stories/Icons.stories.tsx
@@ -99,7 +99,7 @@ const EventsTemplate: StoryFn = () => {
           gap={4}
           sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: 4 }}
         >
-          <EventTypeIcon eventType={method} eventName="" />
+          <EventTypeIcon eventType={method} />
           <Typography sx={{ color: COLORS.grayMedium, fontSize: '12px' }}>({method})</Typography>
         </Box>
       ))}

--- a/src/stories/Icons.stories.tsx
+++ b/src/stories/Icons.stories.tsx
@@ -71,14 +71,14 @@ const storyTokensMethods = ['Transfer', 'Approval', 'Minting', 'Burning']
 const TokensTemplate: StoryFn = () => {
   return (
     <Box>
-      {storyTokensMethods.map(name => (
+      {storyTokensMethods.map(method => (
         <Box
-          key={name}
+          key={method}
           gap={4}
           sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: 4 }}
         >
-          <TokenTransferIcon name={name} />
-          <Typography sx={{ color: COLORS.grayMedium, fontSize: '12px' }}>({name})</Typography>
+          <TokenTransferIcon method={method} />
+          <Typography sx={{ color: COLORS.grayMedium, fontSize: '12px' }}>({method})</Typography>
         </Box>
       ))}
     </Box>


### PR DESCRIPTION
https://app.clickup.com/t/8693ckxvd

- truncate method label in tables and enable tooltip conditionally  
- enable truncate prop for Runtime and Conensus tx lists (we can change to long labels only), Token labels are short so omitting prop there

random test url: https://aeb2e2e1.oasis-explorer.pages.dev/mainnet/sapphire/address/0x8Bba8906467831962Ed5E524F4Bc47733CBF3b27



