### PR TITLE
Fix root error element crashing "must be used within AnalyticsContext"

### DIFF
--- a/.changelog/1366.bugfix.md
+++ b/.changelog/1366.bugfix.md
@@ -1,0 +1,1 @@
+Fix root error element crashing because it's outside AnalyticsContext

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -85,7 +85,11 @@ const RedirectToDashboard: FC = () => {
 
 export const routes: RouteObject[] = [
   {
-    errorElement: <RoutingErrorPage />,
+    errorElement: (
+      <AnalyticsConsentProvider>
+        <RoutingErrorPage />
+      </AnalyticsConsentProvider>
+    ),
     element: (
       <AnalyticsConsentProvider>
         <ScrollRestoration />


### PR DESCRIPTION
https://explorer.dev.oasis.io/err
crashes with "Error: must be used within AnalyticsContext"

http://localhost:1234/err
shows Not Found
