### PR TITLE
Make sure to clean RPC balance when required

### DIFF
--- a/.changelog/1374.bugfix.md
+++ b/.changelog/1374.bugfix.md
@@ -1,0 +1,1 @@
+Fix account search sometimes returning wrong data on repeated search

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -396,6 +396,7 @@ export const useGetRuntimeAccountsAddress: typeof generated.useGetRuntimeAccount
   useEffect(() => {
     // Trigger only if the account has been fetched from Nexus and is not a contract and has eth address
     if (!runtimeAccount || !!runtimeAccount.evm_contract || !runtimeAccount.address_eth) {
+      setRpcAccountBalance(null)
       return
     }
 


### PR DESCRIPTION
We always need to forget the previously loaded
RPC balance info, even when the newly
loaded account doesn't have a new RPC balance.

Fixes #1369.