### PR TITLE
Add named accounts

### DIFF
--- a/.changelog/1398.feature.md
+++ b/.changelog/1398.feature.md
@@ -1,0 +1,1 @@
+Initial support for named accounts

--- a/src/app/components/Account/index.tsx
+++ b/src/app/components/Account/index.tsx
@@ -33,6 +33,7 @@ type RuntimeAccountDataProps = {
   isLoading: boolean
   tokenPrices: AllTokenPrices
   showLayer?: boolean
+  highlightedPartOfName: string | undefined
 }
 
 export const RuntimeAccountData: FC<RuntimeAccountDataProps> = ({
@@ -41,6 +42,7 @@ export const RuntimeAccountData: FC<RuntimeAccountDataProps> = ({
   isLoading,
   tokenPrices,
   showLayer,
+  highlightedPartOfName,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -76,7 +78,7 @@ export const RuntimeAccountData: FC<RuntimeAccountDataProps> = ({
             <AccountAvatar account={account} />
           </StyledListTitleWithAvatar>
           <dd>
-            <AccountLink scope={account} address={address!} />
+            <AccountLink scope={account} address={address!} highlightedPartOfName={highlightedPartOfName} />
             <CopyToClipboard value={address!} />
           </dd>
 
@@ -175,6 +177,7 @@ export type ConsensusAccountDataProps = {
   isLoading?: boolean
   showLayer?: boolean
   standalone?: boolean
+  highlightedPartOfName?: string | undefined
 }
 
 export const ConsensusAccountData: FC<ConsensusAccountDataProps> = ({
@@ -182,6 +185,7 @@ export const ConsensusAccountData: FC<ConsensusAccountDataProps> = ({
   isLoading,
   showLayer,
   standalone,
+  highlightedPartOfName,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -205,7 +209,11 @@ export const ConsensusAccountData: FC<ConsensusAccountDataProps> = ({
         </Box>
       </StyledListTitleWithAvatar>
       <dd>
-        <AccountLink scope={account} address={account.address} />
+        <AccountLink
+          scope={account}
+          address={account.address}
+          highlightedPartOfName={highlightedPartOfName}
+        />
         <CopyToClipboard value={account.address} />
       </dd>
       <dt>

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -119,7 +119,7 @@ const EvmEventParamData: FC<{
     // TODO: handle more EVM types
     case 'address':
       return address ? (
-        <AccountLink address={address} scope={scope} alwaysTrimOnTable={alwaysTrimOnTable} />
+        <AccountLink address={address} scope={scope} alwaysTrimOnTablet={alwaysTrimOnTable} />
       ) : null
     case 'uint256':
       // TODO: format with BigNumber

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -119,6 +119,11 @@ export const validateAndNormalize = {
       return searchTerm.toLowerCase()
     }
   },
+  accountNameFragment: (searchTerm: string) => {
+    if (searchTerm?.length >= textSearchMininumLength) {
+      return searchTerm.toLowerCase()
+    }
+  },
 } satisfies { [name: string]: (searchTerm: string) => string | undefined }
 
 export function isSearchValid(searchTerm: string) {

--- a/src/app/data/named-accounts.ts
+++ b/src/app/data/named-accounts.ts
@@ -1,0 +1,51 @@
+import { Network } from '../../types/network'
+import { Account, Layer, Runtime, RuntimeAccount } from '../../oasis-nexus/api'
+
+export type AccountMetadata = {
+  address: string
+  name?: string
+  description?: string
+}
+
+export type AccountMetadataInfo = {
+  metadata?: AccountMetadata
+  isLoading: boolean
+  isError: boolean
+}
+
+export type AccountMap = Map<string, AccountMetadata>
+
+export type AccountData = {
+  map: AccountMap
+  list: AccountMetadata[]
+}
+
+export type AccountNameSearchMatch = {
+  network: Network
+  layer: Layer
+  address: string
+}
+
+export type AccountNameSearchRuntimeMatch = {
+  network: Network
+  layer: Runtime
+  address: string
+}
+
+export type AccountNameSearchConsensusMatch = {
+  network: Network
+  layer: typeof Layer.consensus
+  address: string
+}
+
+export type AccountNameSearchResults = {
+  results: (Account | RuntimeAccount)[] | undefined
+  isLoading: boolean
+  isError: boolean
+}
+
+export type AccountNameSearchRuntimeResults = {
+  results: RuntimeAccount[] | undefined
+  isLoading: boolean
+  isError: boolean
+}

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -1,0 +1,147 @@
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+import {
+  Layer,
+  useGetConsensusAccountsAddresses,
+  useGetRuntimeAccountsAddresses,
+} from '../../oasis-nexus/api'
+import { Network } from '../../types/network'
+import {
+  AccountData,
+  AccountMap,
+  AccountMetadata,
+  AccountMetadataInfo,
+  AccountNameSearchConsensusMatch,
+  AccountNameSearchMatch,
+  AccountNameSearchResults,
+  AccountNameSearchRuntimeMatch,
+} from './named-accounts'
+import { hasTextMatch } from '../components/HighlightedText/text-matching'
+
+const dataSources: Record<Network, Partial<Record<Layer, string>>> = {
+  [Network.mainnet]: {
+    [Layer.consensus]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_consensus.json',
+    [Layer.emerald]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_paratime.json',
+    [Layer.sapphire]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_paratime.json',
+  },
+  [Network.testnet]: {
+    [Layer.consensus]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_consensus.json',
+    [Layer.emerald]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_paratime.json',
+    [Layer.sapphire]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_paratime.json',
+  },
+}
+
+const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise<AccountData> => {
+  const url = dataSources[network][layer]
+  if (!url) throw new Error('No data available for this layer')
+  const response = await axios.get(url)
+  if (response.status !== 200) throw new Error("Couldn't load names")
+  if (!response.data) throw new Error("Couldn't load names")
+  // console.log('Response data is', response.data)
+  const map: AccountMap = new Map()
+  const list: AccountMetadata[] = []
+  Array.from(response.data).forEach((entry: any) => {
+    const metadata: AccountMetadata = {
+      address: entry.Address,
+      name: entry.Name,
+      description: entry.Description,
+    }
+    // Register the metadata in its native form
+    list.push(metadata)
+    map.set(metadata.address, metadata)
+  })
+  return {
+    map,
+    list,
+  }
+}
+
+export const useOasisAccountsMetadata = (
+  network: Network,
+  layer: Layer,
+  queryOptions: { enabled: boolean },
+) => {
+  return useQuery(['oasisAccounts', network, layer], () => getOasisAccountsMetadata(network, layer), {
+    enabled: queryOptions.enabled,
+    staleTime: Infinity,
+  })
+}
+
+export const useOasisAccountMetadata = (
+  network: Network,
+  layer: Layer,
+  address: string,
+  queryOptions: { enabled: boolean },
+): AccountMetadataInfo => {
+  const { isLoading, isError, error, data: allData } = useOasisAccountsMetadata(network, layer, queryOptions)
+  if (isError) {
+    console.log('Failed to load Oasis account metadata', error)
+  }
+  return {
+    metadata: allData?.map.get(address),
+    isLoading,
+    isError,
+  }
+}
+
+export const useSearchForOasisAccountsByName = (
+  network: Network,
+  layer: Layer,
+  nameFragment: string,
+  queryOptions: { enabled: boolean },
+): AccountNameSearchResults => {
+  const {
+    isLoading: isMetadataLoading,
+    isError: isMetadataError,
+    error: metadataError,
+    data: namedAccounts,
+  } = useOasisAccountsMetadata(network, layer, queryOptions)
+  if (isMetadataError) {
+    console.log('Failed to load Oasis account metadata', metadataError)
+  }
+
+  const textMatcher =
+    nameFragment && queryOptions.enabled
+      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+      : () => false
+
+  const matches =
+    namedAccounts?.list.filter(textMatcher).map(
+      (account): AccountNameSearchMatch => ({
+        network,
+        layer,
+        address: account.address,
+      }),
+    ) ?? []
+
+  const consensusMatches = layer === Layer.consensus ? (matches as AccountNameSearchConsensusMatch[]) : []
+  const runtimeMatches = layer === Layer.consensus ? [] : (matches as AccountNameSearchRuntimeMatch[])
+
+  const {
+    isLoading: areConsensusAccountsLoading,
+    isError: areConsensusAccountsError,
+    data: consensusResults,
+  } = useGetConsensusAccountsAddresses(consensusMatches, {
+    enabled: queryOptions.enabled && !isMetadataLoading && !isMetadataError,
+  })
+
+  const {
+    isLoading: areRuntimeAccountsLoading,
+    isError: areRuntimeAccountsError,
+    data: runtimeResults,
+  } = useGetRuntimeAccountsAddresses(runtimeMatches, {
+    enabled: queryOptions.enabled && !isMetadataLoading && !isMetadataError,
+  })
+
+  return {
+    isLoading: isMetadataLoading || areConsensusAccountsLoading || areRuntimeAccountsLoading,
+    isError: isMetadataError || areConsensusAccountsError || areRuntimeAccountsError,
+    results: [...consensusResults, ...runtimeResults],
+  }
+}

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -87,8 +87,6 @@ export const useSearchForPontusXAccountsByName = (
           }),
         )
 
-  if (matches?.length) console.log('PontusX matches to load:', matches)
-
   const {
     isLoading: areAccountsLoading,
     isError: areAccountsError,

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -1,0 +1,105 @@
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+import {
+  AccountMetadata,
+  AccountMap,
+  AccountMetadataInfo,
+  AccountNameSearchRuntimeMatch,
+  AccountNameSearchRuntimeResults,
+} from './named-accounts'
+import { Layer, useGetRuntimeAccountsAddresses } from '../../oasis-nexus/api'
+import { Network } from '../../types/network'
+import { hasTextMatch } from '../components/HighlightedText/text-matching'
+import { getOasisAddress } from '../utils/helpers'
+
+const DATA_SOURCE_URL = 'https://raw.githubusercontent.com/deltaDAO/mvg-portal/main/pontusxAddresses.json'
+
+const getPontusXAccountsMetadata = async () => {
+  const response = await axios.get(DATA_SOURCE_URL)
+  if (response.status !== 200) throw new Error("Couldn't load names")
+  if (!response.data) throw new Error("Couldn't load names")
+  const map: AccountMap = new Map()
+  const list: AccountMetadata[] = []
+  Object.entries(response.data).forEach(([evmAddress, name]) => {
+    const account: AccountMetadata = {
+      address: getOasisAddress(evmAddress),
+      name: name as string,
+    }
+    map.set(evmAddress, account)
+    list.push(account)
+  })
+  return {
+    map,
+    list,
+  }
+}
+
+export const usePontusXAccountsMetadata = (queryOptions: { enabled: boolean }) => {
+  return useQuery(['pontusXNames'], getPontusXAccountsMetadata, {
+    enabled: queryOptions.enabled,
+    staleTime: Infinity,
+  })
+}
+
+export const usePontusXAccountMetadata = (
+  address: string,
+  queryOptions: { enabled: boolean },
+): AccountMetadataInfo => {
+  const { isLoading, isError, error, data: allData } = usePontusXAccountsMetadata(queryOptions)
+  if (isError) {
+    console.log('Failed to load Pontus-X account names', error)
+  }
+  return {
+    metadata: allData?.map.get(address),
+    isLoading,
+    isError,
+  }
+}
+
+export const useSearchForPontusXAccountsByName = (
+  network: Network,
+  nameFragment: string,
+  queryOptions: { enabled: boolean },
+): AccountNameSearchRuntimeResults => {
+  const {
+    isLoading: isMetadataLoading,
+    isError: isMetadataError,
+    error: metadataError,
+    data: namedAccounts,
+  } = usePontusXAccountsMetadata(queryOptions)
+  if (isMetadataError) {
+    console.log('Failed to load Pontus-X account names', metadataError)
+  }
+
+  const textMatcher =
+    nameFragment && queryOptions.enabled
+      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+      : () => false
+
+  const matches =
+    isMetadataLoading || isMetadataLoading
+      ? undefined
+      : namedAccounts?.list.filter(textMatcher).map(
+          (account): AccountNameSearchRuntimeMatch => ({
+            network,
+            layer: Layer.pontusx,
+            address: account.address,
+          }),
+        )
+
+  if (matches?.length) console.log('PontusX matches to load:', matches)
+
+  const {
+    isLoading: areAccountsLoading,
+    isError: areAccountsError,
+    data: results,
+  } = useGetRuntimeAccountsAddresses(matches, {
+    enabled: queryOptions.enabled && !isMetadataLoading && !isMetadataError,
+  })
+
+  return {
+    isLoading: isMetadataLoading || areAccountsLoading,
+    isError: isMetadataError || areAccountsError,
+    results,
+  }
+}

--- a/src/app/hooks/__mocks__/useAccountMetadata.ts
+++ b/src/app/hooks/__mocks__/useAccountMetadata.ts
@@ -1,0 +1,2 @@
+export const useAccountMetadata = () => ({ loading: false })
+export const useSearchForAccountsByName = () => ({ isLoading: false, results: [] })

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -1,0 +1,41 @@
+import { SearchScope } from '../../types/searchScope'
+import { Layer } from '../../oasis-nexus/api'
+import { usePontusXAccountMetadata, useSearchForPontusXAccountsByName } from '../data/pontusx-account-names'
+import { AccountMetadataInfo, AccountNameSearchResults } from '../data/named-accounts'
+import { useOasisAccountMetadata, useSearchForOasisAccountsByName } from '../data/oasis-account-names'
+import { getOasisAddress } from '../utils/helpers'
+
+/**
+ * Find out the metadata for an account
+ *
+ * This is the entry point that should be used by the application,
+ * since this function also includes caching.
+ */
+export const useAccountMetadata = (scope: SearchScope, address: string): AccountMetadataInfo => {
+  const isPontusX = scope.layer === Layer.pontusx
+  const pontusXData = usePontusXAccountMetadata(address, { enabled: isPontusX })
+  const oasisData = useOasisAccountMetadata(scope.network, scope.layer, getOasisAddress(address), {
+    enabled: !isPontusX,
+  })
+  return isPontusX ? pontusXData : oasisData
+}
+
+export const useSearchForAccountsByName = (
+  scope: SearchScope,
+  nameFragment = '',
+): AccountNameSearchResults => {
+  const isValidPontusXSearch = scope.layer === Layer.pontusx && !!nameFragment
+  const pontusXResults = useSearchForPontusXAccountsByName(scope.network, nameFragment, {
+    enabled: isValidPontusXSearch,
+  })
+  const isValidOasisSearch = scope.layer !== Layer.pontusx && !!nameFragment
+  const oasisResults = useSearchForOasisAccountsByName(scope.network, scope.layer, nameFragment, {
+    enabled: isValidOasisSearch,
+  })
+  return {
+    isLoading:
+      (isValidPontusXSearch && pontusXResults.isLoading) || (isValidOasisSearch && oasisResults.isLoading),
+    isError: (isValidPontusXSearch && pontusXResults.isError) || (isValidOasisSearch && oasisResults.isError),
+    results: [...(pontusXResults.results ?? []), ...(oasisResults.results ?? [])],
+  }
+}

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
@@ -13,18 +13,25 @@ type ConsensusAccountDetailsCardProps = {
   account: Account | undefined
   isError: boolean
   isLoading: boolean
+  highlightedPartOfName?: string | undefined
 }
 
 export const ConsensusAccountDetailsCard: FC<ConsensusAccountDetailsCardProps> = ({
   account,
   isError,
   isLoading,
+  highlightedPartOfName,
 }) => {
   const { t } = useTranslation()
 
   return (
     <SubPageCard featured isLoadingTitle={isLoading} title={t('account.title')} mainTitle>
-      <ConsensusAccountDetailsView isError={isError} isLoading={isLoading} account={account} />
+      <ConsensusAccountDetailsView
+        isError={isError}
+        isLoading={isLoading}
+        account={account}
+        highlightedPartOfName={highlightedPartOfName}
+      />
     </SubPageCard>
   )
 }

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsView.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsView.tsx
@@ -13,6 +13,7 @@ export const ConsensusAccountDetailsView: FC<ConsensusAccountDetailsViewProps> =
   isLoading,
   showLayer,
   standalone,
+  highlightedPartOfName,
 }) => {
   const { t } = useTranslation()
 
@@ -24,6 +25,7 @@ export const ConsensusAccountDetailsView: FC<ConsensusAccountDetailsViewProps> =
       account={account}
       showLayer={showLayer}
       standalone={standalone}
+      highlightedPartOfName={highlightedPartOfName}
     />
   )
 }

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -18,7 +18,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const { network } = scope
-  const { address } = useLoaderData() as AddressLoaderData
+  const { address, searchTerm } = useLoaderData() as AddressLoaderData
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
   const account = data?.data
@@ -27,7 +27,12 @@ export const ConsensusAccountDetailsPage: FC = () => {
 
   return (
     <PageLayout>
-      <ConsensusAccountDetailsCard account={account} isError={isError} isLoading={isLoading} />
+      <ConsensusAccountDetailsCard
+        account={account}
+        isError={isError}
+        isLoading={isLoading}
+        highlightedPartOfName={searchTerm}
+      />
       <Grid container spacing={4} sx={{ mb: isMobile ? 4 : 5 }}>
         <Grid item xs={12} md={6}>
           <BalanceDistribution account={account} isLoading={isLoading} />

--- a/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsCard.tsx
@@ -12,6 +12,7 @@ type RuntimeAccountDetailsProps = {
   account: RuntimeAccount | undefined
   token: EvmToken | undefined
   tokenPrices: AllTokenPrices
+  highlightedPartOfName?: string | undefined
 }
 
 export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
@@ -21,6 +22,7 @@ export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
   account,
   token,
   tokenPrices,
+  highlightedPartOfName,
 }) => {
   const { t } = useTranslation()
   return (
@@ -36,6 +38,7 @@ export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
         account={account}
         token={token}
         tokenPrices={tokenPrices}
+        highlightedPartOfName={highlightedPartOfName}
       />
     </SubPageCard>
   )

--- a/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsView.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsView.tsx
@@ -12,7 +12,8 @@ export const RuntimeAccountDetailsView: FC<{
   token?: EvmToken
   tokenPrices: AllTokenPrices
   showLayer?: boolean
-}> = ({ isLoading, isError, account, token, tokenPrices, showLayer }) => {
+  highlightedPartOfName?: string | undefined
+}> = ({ isLoading, isError, account, token, tokenPrices, showLayer, highlightedPartOfName }) => {
   const { t } = useTranslation()
   return isError ? (
     <CardEmptyState label={t('account.cantLoadDetails')} />
@@ -23,6 +24,7 @@ export const RuntimeAccountDetailsView: FC<{
       isLoading={isLoading}
       tokenPrices={tokenPrices}
       showLayer={showLayer}
+      highlightedPartOfName={highlightedPartOfName}
     />
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -32,7 +32,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
 
   const scope = useRequiredScopeParam()
-  const { address } = useLoaderData() as AddressLoaderData
+  const { address, searchTerm } = useLoaderData() as AddressLoaderData
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, isContract)
@@ -62,6 +62,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
         account={account}
         token={token}
         tokenPrices={tokenPrices}
+        highlightedPartOfName={searchTerm}
       />
       <DappBanner scope={scope} ethAddress={account?.address_eth} />
       <RouterTabs

--- a/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
@@ -18,19 +18,21 @@ import { HideMoreResults, ShowMoreResults } from './notifications'
 import { getThemesForNetworks } from '../../../styles/theme'
 import { orderByLayer } from '../../../types/layers'
 import { useRedirectIfSingleResult } from './useRedirectIfSingleResult'
+import { SearchParams } from '../../components/Search/search-utils'
 
 export const GlobalSearchResultsView: FC<{
-  searchTerm: string
+  searchParams: SearchParams
   searchResults: SearchResults
   isPotentiallyIncomplete: boolean // Some of the searches failed, so we might not see everything // TODO: indicate this on the UI
   tokenPrices: AllTokenPrices
-}> = ({ searchTerm, searchResults, tokenPrices }) => {
+}> = ({ searchParams, searchResults, tokenPrices }) => {
   const { t } = useTranslation()
   const [othersOpen, setOthersOpen] = useState(false)
-  useRedirectIfSingleResult(undefined, searchTerm, searchResults)
+  useRedirectIfSingleResult(undefined, searchParams, searchResults)
 
   const themes = getThemesForNetworks()
   const networkNames = getNetworkNames(t)
+  const { searchTerm } = searchParams
 
   if (fixedNetwork) {
     return (

--- a/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
@@ -22,6 +22,7 @@ import { useRedirectIfSingleResult } from './useRedirectIfSingleResult'
 export const GlobalSearchResultsView: FC<{
   searchTerm: string
   searchResults: SearchResults
+  isPotentiallyIncomplete: boolean // Some of the searches failed, so we might not see everything // TODO: indicate this on the UI
   tokenPrices: AllTokenPrices
 }> = ({ searchTerm, searchResults, tokenPrices }) => {
   const { t } = useTranslation()

--- a/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
@@ -15,14 +15,15 @@ import { NoResultsInScope } from './NoResults'
 import { AllTokenPrices } from '../../../coin-gecko/api'
 import { HideMoreResults, ShowMoreResults } from './notifications'
 import { useRedirectIfSingleResult } from './useRedirectIfSingleResult'
+import { SearchParams } from '../../components/Search/search-utils'
 
 export const ScopedSearchResultsView: FC<{
   wantedScope: SearchScope
-  searchTerm: string
+  searchParams: SearchParams
   searchResults: SearchResults
   isPotentiallyIncomplete: boolean // Some of the searches failed, so we might not see everything // TODO: indicate this on the UI
   tokenPrices: AllTokenPrices
-}> = ({ wantedScope, searchTerm, searchResults, tokenPrices }) => {
+}> = ({ wantedScope, searchParams, searchResults, tokenPrices }) => {
   const { t } = useTranslation()
   const [othersOpen, setOthersOpen] = useState(false)
   const networkNames = getNetworkNames(t)
@@ -33,7 +34,9 @@ export const ScopedSearchResultsView: FC<{
   const otherResults = searchResults.filter(isNotInWantedScope)
   const notificationTheme = themes[otherResults.some(isOnMainnet) ? Network.mainnet : Network.testnet]
 
-  useRedirectIfSingleResult(wantedScope, searchTerm, searchResults)
+  useRedirectIfSingleResult(wantedScope, searchParams, searchResults)
+
+  const { searchTerm } = searchParams
 
   return (
     <>

--- a/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
@@ -20,6 +20,7 @@ export const ScopedSearchResultsView: FC<{
   wantedScope: SearchScope
   searchTerm: string
   searchResults: SearchResults
+  isPotentiallyIncomplete: boolean // Some of the searches failed, so we might not see everything // TODO: indicate this on the UI
   tokenPrices: AllTokenPrices
 }> = ({ wantedScope, searchTerm, searchResults, tokenPrices }) => {
   const { t } = useTranslation()

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -90,6 +90,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
+                highlightedPartOfName={searchTerm}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -98,6 +99,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
+                highlightedPartOfName={searchTerm}
               />
             )
           }
@@ -115,6 +117,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
+              highlightedPartOfName={searchTerm}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}

--- a/src/app/pages/SearchResultsPage/SearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsView.tsx
@@ -10,15 +10,16 @@ import { ScopedSearchResultsView } from './ScopedSearchResultsView'
 import { AllTokenPrices } from '../../../coin-gecko/api'
 import { getFilterForLayer } from '../../../types/layers'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { SearchParams } from '../../components/Search/search-utils'
 
 export const SearchResultsView: FC<{
   wantedScope?: SearchScope
-  searchTerm: string
+  searchParams: SearchParams
   searchResults: SearchResults
   isLoading: boolean
   isPotentiallyIncomplete: boolean
   tokenPrices: AllTokenPrices
-}> = ({ wantedScope, searchTerm, searchResults, isLoading, isPotentiallyIncomplete, tokenPrices }) => {
+}> = ({ wantedScope, searchParams, searchResults, isLoading, isPotentiallyIncomplete, tokenPrices }) => {
   const { isMobile } = useScreenSize()
   return (
     <PageLayout>
@@ -30,14 +31,14 @@ export const SearchResultsView: FC<{
       ) : wantedScope ? (
         <ScopedSearchResultsView
           wantedScope={wantedScope}
-          searchTerm={searchTerm}
+          searchParams={searchParams}
           searchResults={searchResults.filter(getFilterForLayer(wantedScope.layer))}
           isPotentiallyIncomplete={isPotentiallyIncomplete}
           tokenPrices={tokenPrices}
         />
       ) : (
         <GlobalSearchResultsView
-          searchTerm={searchTerm}
+          searchParams={searchParams}
           searchResults={searchResults}
           isPotentiallyIncomplete={isPotentiallyIncomplete}
           tokenPrices={tokenPrices}

--- a/src/app/pages/SearchResultsPage/SearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsView.tsx
@@ -16,8 +16,9 @@ export const SearchResultsView: FC<{
   searchTerm: string
   searchResults: SearchResults
   isLoading: boolean
+  isPotentiallyIncomplete: boolean
   tokenPrices: AllTokenPrices
-}> = ({ wantedScope, searchTerm, searchResults, isLoading, tokenPrices }) => {
+}> = ({ wantedScope, searchTerm, searchResults, isLoading, isPotentiallyIncomplete, tokenPrices }) => {
   const { isMobile } = useScreenSize()
   return (
     <PageLayout>
@@ -31,12 +32,14 @@ export const SearchResultsView: FC<{
           wantedScope={wantedScope}
           searchTerm={searchTerm}
           searchResults={searchResults.filter(getFilterForLayer(wantedScope.layer))}
+          isPotentiallyIncomplete={isPotentiallyIncomplete}
           tokenPrices={tokenPrices}
         />
       ) : (
         <GlobalSearchResultsView
           searchTerm={searchTerm}
           searchResults={searchResults}
+          isPotentiallyIncomplete={isPotentiallyIncomplete}
           tokenPrices={tokenPrices}
         />
       )}

--- a/src/app/pages/SearchResultsPage/__tests__/SearchResultsList.test.tsx
+++ b/src/app/pages/SearchResultsPage/__tests__/SearchResultsList.test.tsx
@@ -10,6 +10,8 @@ import { Network } from '../../../../types/network'
 import { SearchResultsList } from '../SearchResultsList'
 import { Ticker } from '../../../../types/ticker'
 
+jest.mock('../../../hooks/useAccountMetadata')
+
 describe('SearchResultsView', () => {
   beforeEach(() => {
     jest.useFakeTimers()

--- a/src/app/pages/SearchResultsPage/index.tsx
+++ b/src/app/pages/SearchResultsPage/index.tsx
@@ -16,7 +16,7 @@ export const SearchResultsPage: FC = () => {
   return (
     <SearchResultsView
       wantedScope={scope}
-      searchTerm={searchParams.searchTerm}
+      searchParams={searchParams}
       searchResults={results}
       isLoading={isLoading}
       isPotentiallyIncomplete={hasErrors}

--- a/src/app/pages/SearchResultsPage/index.tsx
+++ b/src/app/pages/SearchResultsPage/index.tsx
@@ -9,7 +9,7 @@ import { getFiatCurrencyForScope } from '../../../config'
 export const SearchResultsPage: FC = () => {
   const searchParams = useParamSearch()
   const scope = useScopeParam()
-  const { results, isLoading } = useSearch(scope, searchParams)
+  const { results, isLoading, hasErrors } = useSearch(scope, searchParams)
 
   const tokenPrices = useAllTokenPrices(getFiatCurrencyForScope(scope))
 
@@ -19,6 +19,7 @@ export const SearchResultsPage: FC = () => {
       searchTerm={searchParams.searchTerm}
       searchResults={results}
       isLoading={isLoading}
+      isPotentiallyIncomplete={hasErrors}
       tokenPrices={tokenPrices}
     />
   )

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -6,14 +6,17 @@ import { isItemInScope, SearchScope } from '../../../types/searchScope'
 import { Network } from '../../../types/network'
 import { exhaustedTypeWarning } from '../../../types/errors'
 import { RuntimeAccount } from '../../../oasis-nexus/api'
+import { SearchParams } from '../../components/Search/search-utils'
 
 /** If search only finds one result then redirect to it */
 export function useRedirectIfSingleResult(
   scope: SearchScope | undefined,
-  searchTerm: string,
+  searchParams: SearchParams,
   results: SearchResults,
 ) {
   const navigate = useNavigate()
+
+  const { searchTerm } = searchParams
 
   let shouldRedirect = results.length === 1
 

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -34,7 +34,7 @@ export function useRedirectIfSingleResult(
         redirectTo = RouteUtils.getTransactionRoute(item, item.eth_hash || item.hash)
         break
       case 'account':
-        redirectTo = RouteUtils.getAccountRoute(item, (item as RuntimeAccount).address_eth ?? item.address)
+        redirectTo = `${RouteUtils.getAccountRoute(item, (item as RuntimeAccount).address_eth ?? item.address)}?q=${searchTerm}`
         break
       case 'contract':
         redirectTo = RouteUtils.getAccountRoute(item, item.address_eth ?? item.address)

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -309,8 +309,8 @@ export const useGetConsensusAccountsAddress: typeof generated.useGetConsensusAcc
   return generated.useGetConsensusAccountsAddress(network, address, {
     ...options,
     query: {
-      ...options?.query,
-      queryKey: [network, Layer.consensus, 'accounts', 'byAddress', address],
+      ...(options?.query ?? {}),
+      enabled: !!address && (options?.query?.enabled ?? true),
     },
     request: {
       ...options?.request,
@@ -357,7 +357,6 @@ export const useGetRuntimeAccountsAddress: typeof generated.useGetRuntimeAccount
     query: {
       ...(options?.query ?? {}),
       enabled: !!oasisAddress && (options?.query?.enabled ?? true),
-      queryKey: [network, runtime, 'accounts', 'byAddress', address],
     },
     request: {
       ...options?.request,
@@ -470,8 +469,7 @@ export const useGetRuntimeAccountsAddresses = (
   )
   return {
     isLoading: !!targets?.length && queries.some(query => query.isLoading && query.fetchStatus !== 'idle'),
-    isError: queries.some(query => query.isError),
-    isFetched: !queries.some(query => !query.isFetched),
+    isError: queries.some(query => query.isError) || targets?.length > MAX_LOADED_ADDRESSES,
     data: queries.map(query => query.data?.data).filter(account => !!account) as RuntimeAccount[],
   }
 }
@@ -495,8 +493,7 @@ export const useGetConsensusAccountsAddresses = (
 
   return {
     isLoading: !!targets?.length && queries.some(query => query.isLoading && query.fetchStatus !== 'idle'),
-    isError: queries.some(query => query.isError),
-    isFetched: !queries.some(query => !query.isFetched),
+    isError: queries.some(query => query.isError) || targets?.length > MAX_LOADED_ADDRESSES,
     data: queries.map(query => query.data?.data).filter(account => !!account) as generated.Account[],
   }
 }


### PR DESCRIPTION
- Load metadata about Oasis accounts (available via Nexus).
- Load metadata about Pontus-X accounts 
- Displaying the names
- Support searching for the names.

Some accounts to test with are listed [here](https://github.com/oasisprotocol/nexus/blob/main/account-names/mainnet_paratime.json).