### PR TITLE
Actually zoom in on mobile when consensus circle is selected

### DIFF
--- a/.changelog/1404.trivial.md
+++ b/.changelog/1404.trivial.md
@@ -1,0 +1,1 @@
+Actually zoom in on mobile when consensus circle is selected

--- a/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
+++ b/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
@@ -38,7 +38,11 @@ export abstract class GraphUtils {
           y: 1.1 * height,
         }
       case Layer.consensus:
-        return initialValue
+        return {
+          scale: 2.4,
+          x: 0.65 * width,
+          y: 0.65 * height,
+        }
       default:
         exhaustedTypeWarning('Unexpected layer', layer)
         return initialValue


### PR DESCRIPTION
When selecting the "consensus" circle in the graph browser (on mobile), it should zoom it.

For context, see [here](https://github.com/oasisprotocol/explorer/pull/1401/files#r1595173633).