### PR TITLE
Fix the "zoom out" button

### DIFF
--- a/.changelog/1413.bugfix.md
+++ b/.changelog/1413.bugfix.md
@@ -1,0 +1,1 @@
+Fix the "zoom out" button

--- a/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
+++ b/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
@@ -1,11 +1,11 @@
 import { ScaleToOptions } from 'react-quick-pinch-zoom'
 import { Layer } from '../../../../../oasis-nexus/api'
 import { exhaustedTypeWarning } from '../../../../../types/errors'
-import { SelectorLayer, UniverseLayer } from '../ParaTimeSelector'
+import { SelectorArea, UniverseArea } from '../ParaTimeSelector'
 
 export abstract class GraphUtils {
   static getScaleTo(
-    layer: SelectorLayer,
+    area: SelectorArea,
     { width, height }: { width?: number; height?: number },
   ): ScaleToOptions {
     const initialValue = {
@@ -18,7 +18,7 @@ export abstract class GraphUtils {
       return initialValue
     }
 
-    switch (layer) {
+    switch (area) {
       case Layer.emerald:
         return {
           scale: 2.4,
@@ -31,10 +31,6 @@ export abstract class GraphUtils {
           x: 1.2 * width,
           y: 0.7 * height,
         }
-      case Layer.pontusx:
-        // TODO: update this if/when we want to display this layer
-        // We meed this case here since this switch/case is declared to be exhaustive.
-        return initialValue
       case Layer.sapphire:
         return {
           scale: 2.4,
@@ -47,10 +43,10 @@ export abstract class GraphUtils {
           x: 0.65 * width,
           y: 0.65 * height,
         }
-      case UniverseLayer:
+      case UniverseArea:
         return initialValue
       default:
-        exhaustedTypeWarning('Unexpected layer', layer)
+        exhaustedTypeWarning('Unexpected area', area)
         return initialValue
     }
   }

--- a/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
+++ b/src/app/pages/HomePage/Graph/Graph/graph-utils.ts
@@ -1,9 +1,13 @@
 import { ScaleToOptions } from 'react-quick-pinch-zoom'
 import { Layer } from '../../../../../oasis-nexus/api'
 import { exhaustedTypeWarning } from '../../../../../types/errors'
+import { SelectorLayer, UniverseLayer } from '../ParaTimeSelector'
 
 export abstract class GraphUtils {
-  static getScaleTo(layer: Layer, { width, height }: { width?: number; height?: number }): ScaleToOptions {
+  static getScaleTo(
+    layer: SelectorLayer,
+    { width, height }: { width?: number; height?: number },
+  ): ScaleToOptions {
     const initialValue = {
       scale: 1,
       x: 0,
@@ -43,6 +47,8 @@ export abstract class GraphUtils {
           x: 0.65 * width,
           y: 0.65 * height,
         }
+      case UniverseLayer:
+        return initialValue
       default:
         exhaustedTypeWarning('Unexpected layer', layer)
         return initialValue

--- a/src/app/pages/HomePage/Graph/Graph/index.tsx
+++ b/src/app/pages/HomePage/Graph/Graph/index.tsx
@@ -19,6 +19,7 @@ import { COLORS } from '../../../../../styles/theme/testnet/colors'
 import { useTranslation } from 'react-i18next'
 import { useConsensusFreshness, useRuntimeFreshness } from '../../../../components/OfflineBanner/hook'
 import { SearchScope } from '../../../../../types/searchScope'
+import { SelectorLayer } from '../ParaTimeSelector'
 
 interface GraphBaseProps {
   disabled?: boolean
@@ -29,14 +30,14 @@ interface GraphProps extends GraphBaseProps {
   network: Network
   scale: number
   // TODO: Consider moving this to a state management solution
-  selectedLayer?: Layer
+  selectedLayer?: SelectorLayer
   setSelectedLayer: (value: Layer) => void
   setActiveMobileGraphTooltip: (layer: { current: Layer | null }) => void
   isZoomedIn: boolean
 }
 
 interface GraphStyledProps extends GraphBaseProps {
-  selectedLayer?: Layer
+  selectedLayer?: SelectorLayer
   hoveredLayer: Layer | null
 }
 

--- a/src/app/pages/HomePage/Graph/Graph/index.tsx
+++ b/src/app/pages/HomePage/Graph/Graph/index.tsx
@@ -19,7 +19,7 @@ import { COLORS } from '../../../../../styles/theme/testnet/colors'
 import { useTranslation } from 'react-i18next'
 import { useConsensusFreshness, useRuntimeFreshness } from '../../../../components/OfflineBanner/hook'
 import { SearchScope } from '../../../../../types/searchScope'
-import { SelectorLayer } from '../ParaTimeSelector'
+import { SelectorArea, UniverseArea } from '../ParaTimeSelector'
 
 interface GraphBaseProps {
   disabled?: boolean
@@ -30,23 +30,23 @@ interface GraphProps extends GraphBaseProps {
   network: Network
   scale: number
   // TODO: Consider moving this to a state management solution
-  selectedLayer?: SelectorLayer
-  setSelectedLayer: (value: Layer) => void
-  setActiveMobileGraphTooltip: (layer: { current: Layer | null }) => void
+  selectedArea?: SelectorArea
+  setSelectedArea: (value: SelectorArea) => void
+  setActiveMobileGraphTooltip: (area: { current: SelectorArea | null }) => void
   isZoomedIn: boolean
 }
 
 interface GraphStyledProps extends GraphBaseProps {
-  selectedLayer?: SelectorLayer
+  selectedArea?: SelectorArea
   hoveredLayer: Layer | null
 }
 
 const GraphStyled = styled('svg', {
   shouldForwardProp: prop =>
-    !(['disabled', 'transparent', 'selectedLayer', 'hoveredLayer'] as (keyof GraphStyledProps)[]).includes(
+    !(['disabled', 'transparent', 'selectedArea', 'hoveredLayer'] as (keyof GraphStyledProps)[]).includes(
       prop as keyof GraphStyledProps,
     ),
-})<GraphStyledProps>(({ theme, disabled, transparent, selectedLayer, hoveredLayer }) => ({
+})<GraphStyledProps>(({ theme, disabled, transparent, selectedArea, hoveredLayer }) => ({
   position: 'absolute',
   left: '50%',
   top: '45%',
@@ -67,9 +67,9 @@ const GraphStyled = styled('svg', {
     cursor: 'pointer',
   },
   path: {
-    ...(selectedLayer && selectedLayer !== Layer.consensus
+    ...(selectedArea && selectedArea !== Layer.consensus && selectedArea !== UniverseArea
       ? {
-          [`&:not(.${selectedLayer})`]: {
+          [`&:not(.${selectedArea})`]: {
             opacity: 0.5,
           },
           '&.status-icon': {
@@ -85,9 +85,9 @@ const GraphStyled = styled('svg', {
     'ellipse:last-child': {
       display: 'none',
     },
-    ...(selectedLayer && selectedLayer !== Layer.consensus
+    ...(selectedArea && selectedArea !== Layer.consensus && selectedArea !== UniverseArea
       ? {
-          [`&:not([id=${selectedLayer}-circle])`]: {
+          [`&:not([id=${selectedArea}-circle])`]: {
             opacity: 0.5,
           },
         }
@@ -261,9 +261,9 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
   {
     disabled = false,
     transparent = false,
-    selectedLayer,
+    selectedArea,
     network,
-    setSelectedLayer,
+    setSelectedArea,
     scale,
     setActiveMobileGraphTooltip,
     isZoomedIn,
@@ -294,7 +294,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
     return !RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer)
   }
 
-  const disabledMap: Partial<Record<Layer, boolean>> = {
+  const disabledMap: Partial<Record<SelectorArea, boolean>> = {
     [Layer.emerald]: isLayerDisabled(Layer.emerald),
     [Layer.consensus]: isLayerDisabled(Layer.consensus),
     [Layer.cipher]: isLayerDisabled(Layer.cipher),
@@ -303,25 +303,26 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
 
   const enabledLayers: Layer[] = useMemo(() => RouteUtils.getAllLayersForNetwork(network).enabled, [network])
 
-  const onSelectLayer = (layer: Layer) => {
-    if (isMobile && (isZoomedIn || layer === Layer.consensus)) {
-      setSelectedLayer(layer)
-      setActiveMobileGraphTooltip({ current: layer })
+  const onSelectArea = (area: SelectorArea) => {
+    if (isMobile && (isZoomedIn || area === Layer.consensus)) {
+      setSelectedArea(area)
+      setActiveMobileGraphTooltip({ current: area })
 
       return
     }
 
     if (
-      ((!isMobile && !isZoomedIn) || layer === selectedLayer) &&
-      RouteUtils.getAllLayersForNetwork(network).enabled.includes(layer)
+      ((!isMobile && !isZoomedIn) || area === selectedArea) &&
+      area !== UniverseArea &&
+      RouteUtils.getAllLayersForNetwork(network).enabled.includes(area)
     ) {
-      navigate(RouteUtils.getDashboardRoute({ network, layer }))
+      navigate(RouteUtils.getDashboardRoute({ network, layer: area }))
 
       return
     }
 
-    if (!disabledMap[layer]) {
-      setSelectedLayer(layer)
+    if (!disabledMap[area]) {
+      setSelectedArea(area)
     }
   }
 
@@ -393,7 +394,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         preserveAspectRatio="xMidYMid slice"
         ref={ref}
         className={network}
-        selectedLayer={selectedLayer}
+        selectedArea={selectedArea}
         hoveredLayer={hoveredLayer}
       >
         <path
@@ -540,7 +541,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.emerald}-circle`}
           aria-disabled={disabledMap[Layer.emerald]}
-          onClick={() => onSelectLayer(Layer.emerald)}
+          onClick={() => onSelectArea(Layer.emerald)}
           filter={graphTheme.emeraldCircleFilter}
           {...preventDoubleClick}
           {...handleHover(Layer.emerald, setHoveredLayer)}
@@ -561,7 +562,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.emerald}-label`}
           aria-disabled={disabledMap[Layer.emerald]}
-          onClick={() => onSelectLayer(Layer.emerald)}
+          onClick={() => onSelectArea(Layer.emerald)}
           {...preventDoubleClick}
           {...handleHover(Layer.emerald, setHoveredLayer)}
         >
@@ -597,7 +598,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.sapphire}-circle`}
           aria-disabled={disabledMap[Layer.sapphire]}
-          onClick={() => onSelectLayer(Layer.sapphire)}
+          onClick={() => onSelectArea(Layer.sapphire)}
           filter={graphTheme.sapphireCircleFilter}
           {...preventDoubleClick}
           {...handleHover(Layer.sapphire, setHoveredLayer)}
@@ -618,7 +619,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.sapphire}-label`}
           aria-disabled={disabledMap[Layer.sapphire]}
-          onClick={() => onSelectLayer(Layer.sapphire)}
+          onClick={() => onSelectArea(Layer.sapphire)}
           {...preventDoubleClick}
           {...handleHover(Layer.sapphire, setHoveredLayer)}
         >
@@ -652,7 +653,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         </g>
         <g
           id={`${Layer.consensus}-circle`}
-          onClick={() => onSelectLayer(Layer.consensus)}
+          onClick={() => onSelectArea(Layer.consensus)}
           aria-disabled={disabledMap[Layer.consensus]}
           {...handleHover(Layer.consensus, setHoveredLayer)}
         >
@@ -695,7 +696,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.consensus}-label`}
           aria-disabled={disabledMap[Layer.consensus]}
-          onClick={() => onSelectLayer(Layer.consensus)}
+          onClick={() => onSelectArea(Layer.consensus)}
           {...preventDoubleClick}
           {...handleHover(Layer.consensus, setHoveredLayer)}
         >
@@ -730,7 +731,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           filter={graphTheme.cipherCircleFilter}
           aria-disabled={disabledMap[Layer.cipher]}
-          onClick={() => onSelectLayer(Layer.cipher)}
+          onClick={() => onSelectArea(Layer.cipher)}
           id={`${Layer.cipher}-circle`}
           {...preventDoubleClick}
           {...handleHover(Layer.cipher, setHoveredLayer)}
@@ -751,7 +752,7 @@ const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (
         <g
           id={`${Layer.cipher}-label`}
           aria-disabled={disabledMap[Layer.cipher]}
-          onClick={() => onSelectLayer(Layer.cipher)}
+          onClick={() => onSelectArea(Layer.cipher)}
           {...preventDoubleClick}
           {...handleHover(Layer.cipher, setHoveredLayer)}
         >

--- a/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
+++ b/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
@@ -19,7 +19,7 @@ import Fade from '@mui/material/Fade'
 import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import { zIndexHomePage } from '../../index'
-import { SelectorLayer, UniverseLayer } from '../ParaTimeSelector'
+import { SelectorArea, UniverseArea } from '../ParaTimeSelector'
 
 interface GraphTooltipStyledProps {
   isMobile: boolean
@@ -117,7 +117,7 @@ const MobileGraphTooltip = styled(Box)(({ theme }) => ({
 
 interface GraphTooltipMobileProps {
   network: Network
-  layer: SelectorLayer
+  area: SelectorArea
   onClose: (e?: MouseEvent) => void
 }
 
@@ -141,7 +141,7 @@ const layerTooltipBodyCaption = (t: TFunction, layer: Layer, enabled: boolean, o
       : t('common.paraTimeOnline')
 }
 
-const useLayerTooltipMap = (network: Network): Partial<Record<SelectorLayer, TooltipInfo>> => {
+const useAreaTooltipMap = (network: Network): Partial<Record<SelectorArea, TooltipInfo>> => {
   const isSapphireEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.sapphire)
   const isEmeraldEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.emerald)
   const isCipherEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.cipher)
@@ -207,10 +207,10 @@ const useLayerTooltipMap = (network: Network): Partial<Record<SelectorLayer, Too
 interface GraphTooltipHeaderProps {
   disabled: boolean
   network: Network
-  layer: SelectorLayer
+  area: SelectorArea
 }
 
-const GraphTooltipHeader: FC<GraphTooltipHeaderProps> = ({ disabled, network, layer }) => {
+const GraphTooltipHeader: FC<GraphTooltipHeaderProps> = ({ disabled, network, area }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const icons = getNetworkIcons({ size: 38 })
@@ -227,7 +227,7 @@ const GraphTooltipHeader: FC<GraphTooltipHeaderProps> = ({ disabled, network, la
             color={COLORS.white}
             sx={{ fontSize: '10px', position: 'absolute', bottom: '10px' }}
           >
-            {layer === Layer.consensus ? t('home.tooltip.openConsensus') : t('home.tooltip.openParatime')}
+            {area === Layer.consensus ? t('home.tooltip.openConsensus') : t('home.tooltip.openParatime')}
           </Typography>
         </>
       )}
@@ -274,11 +274,11 @@ const GraphTooltipBody: FC<GraphTooltipBodyProps> = ({ title, caption, body, dis
   )
 }
 
-export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, layer, onClose }) => {
+export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, area, onClose }) => {
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
-  const tooltip = useLayerTooltipMap(network)[layer]
+  const tooltip = useAreaTooltipMap(network)[area]
   if (!tooltip) return
   const { body, disabled, failing } = tooltip
 
@@ -286,10 +286,10 @@ export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, layer
     if (disabled) {
       return
     }
-    if (layer === UniverseLayer) {
+    if (area === UniverseArea) {
       return
     }
-    navigate(RouteUtils.getDashboardRoute({ network, layer }))
+    navigate(RouteUtils.getDashboardRoute({ network, layer: area }))
   }
 
   return (
@@ -301,7 +301,7 @@ export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, layer
             <CloseIcon fontSize="medium" sx={{ color: COLORS.white }} aria-label={t('home.tooltip.close')} />
           </IconButton>
           <GraphTooltipStyled disabled={disabled} isMobile={isMobile} onClick={navigateTo}>
-            <GraphTooltipHeader disabled={disabled} network={network} layer={layer} />
+            <GraphTooltipHeader disabled={disabled} network={network} area={area} />
             <GraphTooltipBody {...body} disabled={disabled} failing={failing} />
           </GraphTooltipStyled>
         </MobileGraphTooltip>

--- a/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
+++ b/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
@@ -19,6 +19,7 @@ import Fade from '@mui/material/Fade'
 import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import { zIndexHomePage } from '../../index'
+import { SelectorLayer, UniverseLayer } from '../ParaTimeSelector'
 
 interface GraphTooltipStyledProps {
   isMobile: boolean
@@ -116,7 +117,7 @@ const MobileGraphTooltip = styled(Box)(({ theme }) => ({
 
 interface GraphTooltipMobileProps {
   network: Network
-  layer: Layer
+  layer: SelectorLayer
   onClose: (e?: MouseEvent) => void
 }
 
@@ -140,7 +141,7 @@ const layerTooltipBodyCaption = (t: TFunction, layer: Layer, enabled: boolean, o
       : t('common.paraTimeOnline')
 }
 
-const useLayerTooltipMap = (network: Network): Partial<Record<Layer, TooltipInfo>> => {
+const useLayerTooltipMap = (network: Network): Partial<Record<SelectorLayer, TooltipInfo>> => {
   const isSapphireEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.sapphire)
   const isEmeraldEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.emerald)
   const isCipherEnabled = RouteUtils.getAllLayersForNetwork(network).enabled.includes(Layer.cipher)
@@ -206,7 +207,7 @@ const useLayerTooltipMap = (network: Network): Partial<Record<Layer, TooltipInfo
 interface GraphTooltipHeaderProps {
   disabled: boolean
   network: Network
-  layer: Layer
+  layer: SelectorLayer
 }
 
 const GraphTooltipHeader: FC<GraphTooltipHeaderProps> = ({ disabled, network, layer }) => {
@@ -285,7 +286,9 @@ export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, layer
     if (disabled) {
       return
     }
-
+    if (layer === UniverseLayer) {
+      return
+    }
     navigate(RouteUtils.getDashboardRoute({ network, layer }))
   }
 

--- a/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
+++ b/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
@@ -152,11 +152,16 @@ interface ParaTimeSelectorProps extends ParaTimeSelectorBaseProps {
 
 const localStore = storage()
 
-// This is a special layer used to indicate that we should zoom out,
+// This is a special area used to indicate that we should zoom out,
 // and see the whole universe.
-export const UniverseLayer = 'Universe'
+export const UniverseArea = 'Universe'
 
-export type SelectorLayer = Layer | typeof UniverseLayer
+export type SelectorArea =
+  | typeof UniverseArea
+  | typeof Layer.consensus
+  | typeof Layer.cipher
+  | typeof Layer.emerald
+  | typeof Layer.sapphire
 
 const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   disabled,
@@ -174,13 +179,11 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   const exploreBtnTextTranslated = t('home.exploreBtnText')
   const { network, setNetwork } = useSearchQueryNetworkParam()
 
-  // Using object here to force side effect trigger when setting to the same layer
-  const [selectedLayer, setSelectedLayer] = useState<{ current: SelectorLayer }>()
-  const [activeMobileGraphTooltip, setActiveMobileGraphTooltip] = useState<{ current: SelectorLayer | null }>(
-    {
-      current: null,
-    },
-  )
+  // Using object here to force side effect trigger when setting to the same area
+  const [selectedArea, setSelectedArea] = useState<{ current: SelectorArea }>()
+  const [activeMobileGraphTooltip, setActiveMobileGraphTooltip] = useState<{ current: SelectorArea | null }>({
+    current: null,
+  })
 
   const [scale, setScale] = useState<number>(1)
 
@@ -189,10 +192,10 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   })
 
   useEffect(() => {
-    if (selectedLayer) {
-      quickPinchZoomRef.current?.scaleTo(GraphUtils.getScaleTo(selectedLayer.current, { width, height }))
+    if (selectedArea) {
+      quickPinchZoomRef.current?.scaleTo(GraphUtils.getScaleTo(selectedArea.current, { width, height }))
     }
-  }, [selectedLayer, width, height])
+  }, [selectedArea, width, height])
 
   useEffect(() => {
     // Switch from mobile -> desktop view while on help screen
@@ -212,7 +215,7 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   }
 
   const onZoomOutClick = () => {
-    setSelectedLayer({ current: UniverseLayer })
+    setSelectedArea({ current: UniverseArea })
   }
 
   const onPinchZoom = ({ x, y, scale }: UpdateAction) => {
@@ -225,9 +228,9 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
     quickPinchZoomInnerRef.current?.style.setProperty('transform', transformValue)
   }
 
-  const clearSelectedLayer = () => {
-    if (selectedLayer?.current) {
-      setSelectedLayer(undefined)
+  const clearSelectedArea = () => {
+    if (selectedArea?.current) {
+      setSelectedArea(undefined)
     }
   }
 
@@ -248,7 +251,7 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
               onUpdate={onPinchZoom}
               maxZoom={2.5}
               minZoom={0.5}
-              onDragEnd={clearSelectedLayer}
+              onDragEnd={clearSelectedArea}
             >
               <QuickPinchZoomInner ref={quickPinchZoomInnerRef}>
                 <Graph
@@ -256,8 +259,8 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
                   network={network}
                   disabled={disabled}
                   transparent={ParaTimeSelectorUtils.getIsGraphTransparent(step)}
-                  selectedLayer={selectedLayer?.current}
-                  setSelectedLayer={(layer: Layer) => setSelectedLayer({ current: layer })}
+                  selectedArea={selectedArea?.current}
+                  setSelectedArea={(area: SelectorArea) => setSelectedArea({ current: area })}
                   scale={scale}
                   setActiveMobileGraphTooltip={setActiveMobileGraphTooltip}
                   isZoomedIn={graphZoomedIn}
@@ -300,7 +303,7 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
       {activeMobileGraphTooltip.current && (
         <GraphTooltipMobile
           network={network}
-          layer={activeMobileGraphTooltip.current}
+          area={activeMobileGraphTooltip.current}
           onClose={() => {
             setActiveMobileGraphTooltip({ current: null })
           }}

--- a/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
+++ b/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
@@ -152,6 +152,12 @@ interface ParaTimeSelectorProps extends ParaTimeSelectorBaseProps {
 
 const localStore = storage()
 
+// This is a special layer used to indicate that we should zoom out,
+// and see the whole universe.
+export const UniverseLayer = 'Universe'
+
+export type SelectorLayer = Layer | typeof UniverseLayer
+
 const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   disabled,
   step,
@@ -169,10 +175,12 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   const { network, setNetwork } = useSearchQueryNetworkParam()
 
   // Using object here to force side effect trigger when setting to the same layer
-  const [selectedLayer, setSelectedLayer] = useState<{ current: Layer }>()
-  const [activeMobileGraphTooltip, setActiveMobileGraphTooltip] = useState<{ current: Layer | null }>({
-    current: null,
-  })
+  const [selectedLayer, setSelectedLayer] = useState<{ current: SelectorLayer }>()
+  const [activeMobileGraphTooltip, setActiveMobileGraphTooltip] = useState<{ current: SelectorLayer | null }>(
+    {
+      current: null,
+    },
+  )
 
   const [scale, setScale] = useState<number>(1)
 
@@ -204,7 +212,7 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
   }
 
   const onZoomOutClick = () => {
-    setSelectedLayer({ current: Layer.consensus })
+    setSelectedLayer({ current: UniverseLayer })
   }
 
   const onPinchZoom = ({ x, y, scale }: UpdateAction) => {


### PR DESCRIPTION
Earlier, the "zoom out" functionality (of the metaverse graph, in desktop mode)  worked by selecting the consensus layer, which had the whole graph as designated area, so zooming to it actually zoomed out.

But then we wanted to make the consensus circle selectable and zoomable, so in #1404 the designated zoom are has been changed. This made is possible to zoom in on selection (on mobile), but has broken the zoom out button (on desktop). (see https://github.com/oasisprotocol/explorer/pull/1404#discussion_r1600031198 )

So now we are fixing this be introducing a special "fake" layer, just for the components in/around the layer selector, for zooming out: the "universe layer". This layer will have the whole graph as designated zoom area, so selecting this layer will zoom out, while the consensus layer can have it's small area.

Also, since it's no longer always a layer, we are now calling the selection on the graph "area". All related props and functions have been renamed accordingly.