### PR TITLE
Get latest Nexus changes (not yet deployed)

### DIFF
--- a/.changelog/1425.internal.md
+++ b/.changelog/1425.internal.md
@@ -1,0 +1,1 @@
+Follow Nexus API changes up to Nexus v0.3.0

--- a/.changelog/1426.internal.md
+++ b/.changelog/1426.internal.md
@@ -1,0 +1,1 @@
+Follow latest Nexus API changes

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -7,7 +7,7 @@ import CardContent from '@mui/material/CardContent'
 import Divider from '@mui/material/Divider'
 import Grid from '@mui/material/Grid'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { Validator, useGetConsensusValidatorsEntityId } from '../../../oasis-nexus/api'
+import { Validator, useGetConsensusValidatorsAddress } from '../../../oasis-nexus/api'
 import { RouterTabs } from '../../components/RouterTabs'
 import { StyledDescriptionList } from '../../components/StyledDescriptionList'
 import { PageLayout } from '../../components/PageLayout'
@@ -36,9 +36,8 @@ export const ValidatorDetailsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
-  // TODO: currently API does not work with address query param. Wait for API update or switch to entity_id
   const { address } = useLoaderData() as AddressLoaderData
-  const validatorQuery = useGetConsensusValidatorsEntityId(scope.network, address)
+  const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
   const { isLoading, data } = validatorQuery
   const validator = data?.data
   const transactionsLink = useHref('')

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -654,9 +654,9 @@ export interface TxVolumeList {
 export interface AccountStats {
   /** The total number of transactions this account was involved with. */
   num_txns: number;
-  /** The total number of tokens received, in base units. */
+  /** The total amount of native tokens received, in base units. */
   total_received: TextBigInt;
-  /** The total number of tokens sent, in base units. */
+  /** The total amount of native tokens sent, in base units. */
   total_sent: TextBigInt;
 }
 

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -112,7 +112,7 @@ offset?: number;
 /**
  * Only return NFT instances from the token contract at the given staking address.
  */
-token_address?: StakingAddress;
+token_address?: EthOrOasisAddress;
 };
 
 export type GetRuntimeEvmTokensAddressNftsParams = {
@@ -201,7 +201,7 @@ this account. For example, for a `accounts.Transfer` event, this will be
 the sender or the recipient of tokens.
 
  */
-rel?: string;
+rel?: EthOrOasisAddress;
 /**
  * A filter on the evm log signatures.
 Note: The filter will only match on parsed (verified) EVM events.
@@ -210,10 +210,10 @@ Note: The filter will only match on parsed (verified) EVM events.
 evm_log_signature?: string;
 /**
  * A filter on a smart contract. Every returned event will have been
-emitted by the contract at this Oasis address.
+emitted by the contract at this address.
 
  */
-contract_address?: string;
+contract_address?: EthOrOasisAddress;
 /**
  * A filter on NFT events. Every returned event will be specifically
 about this NFT instance ID. You must specify the contract_address
@@ -260,11 +260,9 @@ this account in a way. For example, for an `accounts.Transfer` tx, this will be
 the sender or the recipient of tokens.
 Nexus detects related accounts inside EVM transactions and events on a
 best-effort basis. For example, it inspects ERC20 methods inside `evm.Call` txs.
-However, you must provide the Oasis-style derived address here, not the Eth address.
-See `AddressPreimage` for more info on Oasis-style vs Eth addresses.
 
  */
-rel?: StakingAddress;
+rel?: EthOrOasisAddress;
 };
 
 export type GetRuntimeBlocksParams = {
@@ -1804,6 +1802,8 @@ export type CallFormat = string;
  * A base64-encoded ed25519 public key.
  */
 export type Ed25519PubKey = string;
+
+export type EthOrOasisAddress = string;
 
 /**
  * An Oasis-style (bech32) address.
@@ -3766,7 +3766,7 @@ export const useGetRuntimeEvmTokens = <TData = Awaited<ReturnType<typeof GetRunt
 export const GetRuntimeEvmTokensAddress = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
  options?: SecondParameter<typeof GetRuntimeEvmTokensAddressMutator>,signal?: AbortSignal
 ) => {
       
@@ -3780,14 +3780,14 @@ export const GetRuntimeEvmTokensAddress = (
 
 export const getGetRuntimeEvmTokensAddressQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,) => {
+    address: EthOrOasisAddress,) => {
     return [`/${network}/${runtime}/evm_tokens/${address}`] as const;
     }
 
     
 export const getGetRuntimeEvmTokensAddressQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressMutator>}
+    address: EthOrOasisAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
@@ -3814,7 +3814,7 @@ export type GetRuntimeEvmTokensAddressQueryError = HumanReadableErrorResponse | 
 export const useGetRuntimeEvmTokensAddress = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressMutator>}
+    address: EthOrOasisAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
@@ -3838,7 +3838,7 @@ This endpoint does not verify that `address` is actually an EVM token; if it is 
 export const GetRuntimeEvmTokensAddressHolders = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressHoldersParams,
  options?: SecondParameter<typeof GetRuntimeEvmTokensAddressHoldersMutator>,signal?: AbortSignal
 ) => {
@@ -3854,7 +3854,7 @@ export const GetRuntimeEvmTokensAddressHolders = (
 
 export const getGetRuntimeEvmTokensAddressHoldersQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressHoldersParams,) => {
     return [`/${network}/${runtime}/evm_tokens/${address}/holders`, ...(params ? [params]: [])] as const;
     }
@@ -3862,7 +3862,7 @@ export const getGetRuntimeEvmTokensAddressHoldersQueryKey = (network: 'mainnet' 
     
 export const getGetRuntimeEvmTokensAddressHoldersQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressHolders>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressHoldersParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressHolders>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressHoldersMutator>}
 ) => {
 
@@ -3892,7 +3892,7 @@ This endpoint does not verify that `address` is actually an EVM token; if it is 
 export const useGetRuntimeEvmTokensAddressHolders = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressHolders>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressHoldersParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressHolders>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressHoldersMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -3917,7 +3917,7 @@ This endpoint does not verify that `address` is actually an EVM token; if it is 
 export const GetRuntimeEvmTokensAddressNfts = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressNftsParams,
  options?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsMutator>,signal?: AbortSignal
 ) => {
@@ -3933,7 +3933,7 @@ export const GetRuntimeEvmTokensAddressNfts = (
 
 export const getGetRuntimeEvmTokensAddressNftsQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressNftsParams,) => {
     return [`/${network}/${runtime}/evm_tokens/${address}/nfts`, ...(params ? [params]: [])] as const;
     }
@@ -3941,7 +3941,7 @@ export const getGetRuntimeEvmTokensAddressNftsQueryKey = (network: 'mainnet' | '
     
 export const getGetRuntimeEvmTokensAddressNftsQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNfts>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressNftsParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNfts>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsMutator>}
 ) => {
 
@@ -3971,7 +3971,7 @@ This endpoint does not verify that `address` is actually an EVM token; if it is 
 export const useGetRuntimeEvmTokensAddressNfts = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNfts>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeEvmTokensAddressNftsParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNfts>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -3995,7 +3995,7 @@ export const useGetRuntimeEvmTokensAddressNfts = <TData = Awaited<ReturnType<typ
 export const GetRuntimeEvmTokensAddressNftsId = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     id: TextBigInt,
  options?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsIdMutator>,signal?: AbortSignal
 ) => {
@@ -4010,7 +4010,7 @@ export const GetRuntimeEvmTokensAddressNftsId = (
 
 export const getGetRuntimeEvmTokensAddressNftsIdQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     id: TextBigInt,) => {
     return [`/${network}/${runtime}/evm_tokens/${address}/nfts/${id}`] as const;
     }
@@ -4018,7 +4018,7 @@ export const getGetRuntimeEvmTokensAddressNftsIdQueryKey = (network: 'mainnet' |
     
 export const getGetRuntimeEvmTokensAddressNftsIdQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNftsId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     id: TextBigInt, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNftsId>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsIdMutator>}
 ) => {
 
@@ -4047,7 +4047,7 @@ export type GetRuntimeEvmTokensAddressNftsIdQueryError = HumanReadableErrorRespo
 export const useGetRuntimeEvmTokensAddressNftsId = <TData = Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNftsId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     id: TextBigInt, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeEvmTokensAddressNftsId>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeEvmTokensAddressNftsIdMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -4070,7 +4070,7 @@ export const useGetRuntimeEvmTokensAddressNftsId = <TData = Awaited<ReturnType<t
 export const GetRuntimeAccountsAddress = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
  options?: SecondParameter<typeof GetRuntimeAccountsAddressMutator>,signal?: AbortSignal
 ) => {
       
@@ -4084,14 +4084,14 @@ export const GetRuntimeAccountsAddress = (
 
 export const getGetRuntimeAccountsAddressQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,) => {
+    address: EthOrOasisAddress,) => {
     return [`/${network}/${runtime}/accounts/${address}`] as const;
     }
 
     
 export const getGetRuntimeAccountsAddressQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressMutator>}
+    address: EthOrOasisAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
@@ -4118,7 +4118,7 @@ export type GetRuntimeAccountsAddressQueryError = HumanReadableErrorResponse | N
 export const useGetRuntimeAccountsAddress = <TData = Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressMutator>}
+    address: EthOrOasisAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddress>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
@@ -4141,7 +4141,7 @@ export const useGetRuntimeAccountsAddress = <TData = Awaited<ReturnType<typeof G
 export const GetRuntimeAccountsAddressNfts = (
     network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeAccountsAddressNftsParams,
  options?: SecondParameter<typeof GetRuntimeAccountsAddressNftsMutator>,signal?: AbortSignal
 ) => {
@@ -4157,7 +4157,7 @@ export const GetRuntimeAccountsAddressNfts = (
 
 export const getGetRuntimeAccountsAddressNftsQueryKey = (network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeAccountsAddressNftsParams,) => {
     return [`/${network}/${runtime}/accounts/${address}/nfts`, ...(params ? [params]: [])] as const;
     }
@@ -4165,7 +4165,7 @@ export const getGetRuntimeAccountsAddressNftsQueryKey = (network: 'mainnet' | 't
     
 export const getGetRuntimeAccountsAddressNftsQueryOptions = <TData = Awaited<ReturnType<typeof GetRuntimeAccountsAddressNfts>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeAccountsAddressNftsParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddressNfts>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressNftsMutator>}
 ) => {
 
@@ -4194,7 +4194,7 @@ export type GetRuntimeAccountsAddressNftsQueryError = HumanReadableErrorResponse
 export const useGetRuntimeAccountsAddressNfts = <TData = Awaited<ReturnType<typeof GetRuntimeAccountsAddressNfts>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
     runtime: Runtime,
-    address: StakingAddress,
+    address: EthOrOasisAddress,
     params?: GetRuntimeAccountsAddressNftsParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetRuntimeAccountsAddressNfts>>, TError, TData>, request?: SecondParameter<typeof GetRuntimeAccountsAddressNftsMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -813,6 +813,113 @@ export interface RuntimeTransactionEncryptionEnvelope {
 export type RuntimeTransactionBody = { [key: string]: any };
 
 /**
+ * A list of runtime transactions.
+
+ */
+export type RuntimeTransactionListAllOf = {
+  transactions: RuntimeTransaction[];
+};
+
+export type RuntimeTransactionList = List & RuntimeTransactionListAllOf;
+
+export type RuntimeEvmContractVerificationSourceFilesItem = { [key: string]: any };
+
+/**
+ * The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
+Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
+
+ */
+export type RuntimeEvmContractVerificationCompilationMetadata = { [key: string]: any };
+
+/**
+ * The level of verification of a smart contract, as defined by Sourcify.
+An absence of this field means that the contract has not been verified.
+See also https://docs.sourcify.dev/docs/full-vs-partial-match/
+
+ */
+export type VerificationLevel = typeof VerificationLevel[keyof typeof VerificationLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const VerificationLevel = {
+  partial: 'partial',
+  full: 'full',
+} as const;
+
+export interface RuntimeEvmContractVerification {
+  /** The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
+Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
+ */
+  compilation_metadata?: RuntimeEvmContractVerificationCompilationMetadata;
+  /** Array of all contract source files, in JSON format as returned by [Sourcify](https://sourcify.dev/server/api-docs/#/Repository/get_files_any__chain___address_).
+ */
+  source_files?: RuntimeEvmContractVerificationSourceFilesItem[];
+  verification_level?: VerificationLevel;
+}
+
+export interface RuntimeEvmContract {
+  /** The creation bytecode of the smart contract. This includes the constructor logic
+and the constructor parameters. When run, this code generates the runtime bytecode.
+Can be omitted for contracts that were created by another contract, as opposed
+to a direct `Create` call.
+ */
+  creation_bytecode?: string;
+  /** The Oasis cryptographic hash of the transaction that created the smart contract.
+Can be omitted for contracts that were created by another contract, as opposed
+to a direct `Create` call.
+ */
+  creation_tx?: string;
+  /** The Ethereum transaction hash of the transaction in `creation_tx`.
+Encoded as a lowercase hex string.
+ */
+  eth_creation_tx?: string;
+  /** The total amount of gas used to create or call this contract. */
+  gas_used: number;
+  /** The runtime bytecode of the smart contract. This is the code stored on-chain that
+describes a smart contract. Every contract has this info, but Nexus fetches
+it separately, so the field may be missing for very fresh contracts (or if the fetching
+process is stalled).
+ */
+  runtime_bytecode?: string;
+  /** Additional information obtained from contract verification. Only available for smart
+contracts that have been verified successfully by Sourcify.
+ */
+  verification?: RuntimeEvmContractVerification;
+}
+
+/**
+ * Details about the EVM token involved in the event, if any.
+
+ */
+export interface EvmEventToken {
+  /** The number of least significant digits in base units that should be displayed as
+decimals when displaying tokens. `tokens = base_units / (10**decimals)`.
+Affects display only. Often equals 18, to match ETH.
+ */
+  decimals?: number;
+  /** Symbol of the token, as provided by token contract's `symbol()` method. */
+  symbol?: string;
+  type?: EvmTokenType;
+}
+
+/**
+ * A decoded parameter of an event or error emitted from an EVM runtime.
+Values of EVM type `int128`, `uint128`, `int256`, `uint256`, `fixed`, and `ufixed` are represented as strings.
+Values of EVM type `address` and `address payable` are represented as lowercase hex strings with a "0x" prefix.
+Values of EVM type `bytes` and `bytes<N>` are represented as base64 strings.
+Values of other EVM types (integer types, strings, arrays, etc.) are represented as their JSON counterpart.
+
+ */
+export interface EvmAbiParam {
+  /** The solidity type of the parameter. */
+  evm_type: string;
+  /** The parameter name. */
+  name: string;
+  /** The parameter value. */
+  value: unknown;
+}
+
+/**
  * A runtime transaction.
 
  */
@@ -919,113 +1026,6 @@ if applicable. The meaning varies based on the transaction method. Some notable 
   /** A reasonable "to" Ethereum address associated with this transaction,
  */
   to_eth?: string;
-}
-
-/**
- * A list of runtime transactions.
-
- */
-export type RuntimeTransactionListAllOf = {
-  transactions: RuntimeTransaction[];
-};
-
-export type RuntimeTransactionList = List & RuntimeTransactionListAllOf;
-
-export type RuntimeEvmContractVerificationSourceFilesItem = { [key: string]: any };
-
-/**
- * The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
-Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
-
- */
-export type RuntimeEvmContractVerificationCompilationMetadata = { [key: string]: any };
-
-/**
- * The level of verification of a smart contract, as defined by Sourcify.
-An absence of this field means that the contract has not been verified.
-See also https://docs.sourcify.dev/docs/full-vs-partial-match/
-
- */
-export type VerificationLevel = typeof VerificationLevel[keyof typeof VerificationLevel];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const VerificationLevel = {
-  partial: 'partial',
-  full: 'full',
-} as const;
-
-export interface RuntimeEvmContractVerification {
-  /** The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
-Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
- */
-  compilation_metadata?: RuntimeEvmContractVerificationCompilationMetadata;
-  /** Array of all contract source files, in JSON format as returned by [Sourcify](https://sourcify.dev/server/api-docs/#/Repository/get_files_any__chain___address_).
- */
-  source_files?: RuntimeEvmContractVerificationSourceFilesItem[];
-  verification_level?: VerificationLevel;
-}
-
-export interface RuntimeEvmContract {
-  /** The creation bytecode of the smart contract. This includes the constructor logic
-and the constructor parameters. When run, this code generates the runtime bytecode.
-Can be omitted for contracts that were created by another contract, as opposed
-to a direct `Create` call.
- */
-  creation_bytecode?: string;
-  /** The Oasis cryptographic hash of the transaction that created the smart contract.
-Can be omitted for contracts that were created by another contract, as opposed
-to a direct `Create` call.
- */
-  creation_tx?: string;
-  /** The Ethereum transaction hash of the transaction in `creation_tx`.
-Encoded as a lowercase hex string.
- */
-  eth_creation_tx?: string;
-  /** The total amount of gas used to create or call this contract. */
-  gas_used: number;
-  /** The runtime bytecode of the smart contract. This is the code stored on-chain that
-describes a smart contract. Every contract has this info, but Nexus fetches
-it separately, so the field may be missing for very fresh contracts (or if the fetching
-process is stalled).
- */
-  runtime_bytecode?: string;
-  /** Additional information obtained from contract verification. Only available for smart
-contracts that have been verified successfully by Sourcify.
- */
-  verification?: RuntimeEvmContractVerification;
-}
-
-/**
- * Details about the EVM token involved in the event, if any.
-
- */
-export interface EvmEventToken {
-  /** The number of least significant digits in base units that should be displayed as
-decimals when displaying tokens. `tokens = base_units / (10**decimals)`.
-Affects display only. Often equals 18, to match ETH.
- */
-  decimals?: number;
-  /** Symbol of the token, as provided by token contract's `symbol()` method. */
-  symbol?: string;
-  type?: EvmTokenType;
-}
-
-/**
- * A decoded parameter of an event or error emitted from an EVM runtime.
-Values of EVM type `int128`, `uint128`, `int256`, `uint256`, `fixed`, and `ufixed` are represented as strings.
-Values of EVM type `address` and `address payable` are represented as lowercase hex strings with a "0x" prefix.
-Values of EVM type `bytes` and `bytes<N>` are represented as base64 strings.
-Values of other EVM types (integer types, strings, arrays, etc.) are represented as their JSON counterpart.
-
- */
-export interface EvmAbiParam {
-  /** The solidity type of the parameter. */
-  evm_type: string;
-  /** The parameter name. */
-  name: string;
-  /** The parameter value. */
-  value: unknown;
 }
 
 export type RuntimeEventType = typeof RuntimeEventType[keyof typeof RuntimeEventType];

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1567,6 +1567,20 @@ This object will conform to one of the `*Event` types two levels down
 the hierarchy, e.g. `TransferEvent` from `Event > staking.Event > TransferEvent`
  */
   body: ConsensusEventBody;
+  /** The runtime to which the event relates.
+Present only for events of type `roothash.*`.
+ */
+  roothash_runtime?: Runtime;
+  /** The ID of the runtime to which the event relates, encoded in hex.
+Present only for events of type `roothash.*`.
+ */
+  roothash_runtime_id?: string;
+  /** When applicable, the round in the runtime to which this event
+relates.
+Present only for events of type `roothash.*` except for
+`roothash.execution_discrepancy` before Eden.
+ */
+  roothash_runtime_round?: number;
   /** Hash of this event's originating transaction.
 Absent if the event did not originate from a transaction.
  */

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1046,11 +1046,13 @@ export const RuntimeEventType = {
 } as const;
 
 /**
- * The decoded event contents. This spec does not encode the many possible types;
-instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
+ * The decoded event contents, possibly augmented with additional address info.
+This spec does not encode the many possible types; instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
 This object will conform to one of the `*Event` types two levels down
 the hierarchy (e.g. `MintEvent` from `accounts > Event > MintEvent`),
-OR `evm > Event`.
+OR `evm > Event`. For object fields that specify an oasis-style address, Nexus
+will add a field specifying the corresponding Ethereum address, if known. Currently, 
+the only such possible fields are `from_eth`, `to_eth`, and `owner_eth`.
 
  */
 export type RuntimeEventBody = { [key: string]: any };
@@ -1059,11 +1061,13 @@ export type RuntimeEventBody = { [key: string]: any };
  * An event emitted by the runtime layer
  */
 export interface RuntimeEvent {
-  /** The decoded event contents. This spec does not encode the many possible types;
-instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
+  /** The decoded event contents, possibly augmented with additional address info.
+This spec does not encode the many possible types; instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
 This object will conform to one of the `*Event` types two levels down
 the hierarchy (e.g. `MintEvent` from `accounts > Event > MintEvent`),
-OR `evm > Event`.
+OR `evm > Event`. For object fields that specify an oasis-style address, Nexus
+will add a field specifying the corresponding Ethereum address, if known. Currently, 
+the only such possible fields are `from_eth`, `to_eth`, and `owner_eth`.
  */
   body: RuntimeEventBody;
   /** Ethereum trasnsaction hash of this event's originating transaction.

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1777,8 +1777,8 @@ export type Runtime = typeof Runtime[keyof typeof Runtime];
 export const Runtime = {
   emerald: 'emerald',
   sapphire: 'sapphire',
-  cipher: 'cipher',
   pontusx: 'pontusx',
+  cipher: 'cipher',
 } as const;
 
 export type Layer = typeof Layer[keyof typeof Layer];
@@ -1788,8 +1788,8 @@ export type Layer = typeof Layer[keyof typeof Layer];
 export const Layer = {
   emerald: 'emerald',
   sapphire: 'sapphire',
-  cipher: 'cipher',
   pontusx: 'pontusx',
+  cipher: 'cipher',
   consensus: 'consensus',
 } as const;
 

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1280,7 +1280,7 @@ For efficiency, this field is omitted when listing multiple-accounts.
   delegations_balance?: TextBigInt;
   /** The active escrow balance, in base units. */
   escrow: TextBigInt;
-  /** A nonce used to prevent replay. */
+  /** The expected nonce for the next transaction (= last used nonce + 1) */
   nonce: number;
 }
 

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1143,6 +1143,10 @@ export type RuntimeBlockList = List & RuntimeBlockListAllOf;
 export interface ProposalVote {
   /** The staking address casting this vote. */
   address: string;
+  /** The block height at which this vote was recorded. */
+  height?: number;
+  /** The second-granular consensus time of the block in which this vote was cast. */
+  timestamp?: string;
   /** The vote cast. */
   vote: string;
 }

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -713,6 +713,7 @@ Affects display only. Often equals 18, to match ETH.
   /** Whether the contract has been successfully verified by Sourcify.
 Additional information on verified contracts is available via
 the `/{runtime}/accounts/{address}` endpoint.
+DEPRECATED: This field will be removed in the future in favor of verification_level
  */
   is_verified: boolean;
   /** Name of the token, as provided by token contract's `name()` method. */
@@ -733,6 +734,7 @@ ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
 detected or is not supported, this field will be null/absent.
  */
   type: EvmTokenType;
+  verification_level?: VerificationLevel;
 }
 
 /**
@@ -938,6 +940,21 @@ Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi
  */
 export type RuntimeEvmContractVerificationCompilationMetadata = { [key: string]: any };
 
+/**
+ * The level of verification of a smart contract, as defined by Sourcify.
+An absence of this field means that the contract has not been verified.
+See also https://docs.sourcify.dev/docs/full-vs-partial-match/
+
+ */
+export type VerificationLevel = typeof VerificationLevel[keyof typeof VerificationLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const VerificationLevel = {
+  partial: 'partial',
+  full: 'full',
+} as const;
+
 export interface RuntimeEvmContractVerification {
   /** The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
 Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
@@ -946,6 +963,7 @@ Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi
   /** Array of all contract source files, in JSON format as returned by [Sourcify](https://sourcify.dev/server/api-docs/#/Repository/get_files_any__chain___address_).
  */
   source_files?: RuntimeEvmContractVerificationSourceFilesItem[];
+  verification_level?: VerificationLevel;
 }
 
 export interface RuntimeEvmContract {

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -811,113 +811,6 @@ export interface RuntimeTransactionEncryptionEnvelope {
 export type RuntimeTransactionBody = { [key: string]: any };
 
 /**
- * A list of runtime transactions.
-
- */
-export type RuntimeTransactionListAllOf = {
-  transactions: RuntimeTransaction[];
-};
-
-export type RuntimeTransactionList = List & RuntimeTransactionListAllOf;
-
-export type RuntimeEvmContractVerificationSourceFilesItem = { [key: string]: any };
-
-/**
- * The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
-Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
-
- */
-export type RuntimeEvmContractVerificationCompilationMetadata = { [key: string]: any };
-
-/**
- * The level of verification of a smart contract, as defined by Sourcify.
-An absence of this field means that the contract has not been verified.
-See also https://docs.sourcify.dev/docs/full-vs-partial-match/
-
- */
-export type VerificationLevel = typeof VerificationLevel[keyof typeof VerificationLevel];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const VerificationLevel = {
-  partial: 'partial',
-  full: 'full',
-} as const;
-
-export interface RuntimeEvmContractVerification {
-  /** The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
-Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
- */
-  compilation_metadata?: RuntimeEvmContractVerificationCompilationMetadata;
-  /** Array of all contract source files, in JSON format as returned by [Sourcify](https://sourcify.dev/server/api-docs/#/Repository/get_files_any__chain___address_).
- */
-  source_files?: RuntimeEvmContractVerificationSourceFilesItem[];
-  verification_level?: VerificationLevel;
-}
-
-export interface RuntimeEvmContract {
-  /** The creation bytecode of the smart contract. This includes the constructor logic
-and the constructor parameters. When run, this code generates the runtime bytecode.
-Can be omitted for contracts that were created by another contract, as opposed
-to a direct `Create` call.
- */
-  creation_bytecode?: string;
-  /** The Oasis cryptographic hash of the transaction that created the smart contract.
-Can be omitted for contracts that were created by another contract, as opposed
-to a direct `Create` call.
- */
-  creation_tx?: string;
-  /** The Ethereum transaction hash of the transaction in `creation_tx`.
-Encoded as a lowercase hex string.
- */
-  eth_creation_tx?: string;
-  /** The total amount of gas used to create or call this contract. */
-  gas_used: number;
-  /** The runtime bytecode of the smart contract. This is the code stored on-chain that
-describes a smart contract. Every contract has this info, but Nexus fetches
-it separately, so the field may be missing for very fresh contracts (or if the fetching
-process is stalled).
- */
-  runtime_bytecode?: string;
-  /** Additional information obtained from contract verification. Only available for smart
-contracts that have been verified successfully by Sourcify.
- */
-  verification?: RuntimeEvmContractVerification;
-}
-
-/**
- * Details about the EVM token involved in the event, if any.
-
- */
-export interface EvmEventToken {
-  /** The number of least significant digits in base units that should be displayed as
-decimals when displaying tokens. `tokens = base_units / (10**decimals)`.
-Affects display only. Often equals 18, to match ETH.
- */
-  decimals?: number;
-  /** Symbol of the token, as provided by token contract's `symbol()` method. */
-  symbol?: string;
-  type?: EvmTokenType;
-}
-
-/**
- * A decoded parameter of an event or error emitted from an EVM runtime.
-Values of EVM type `int128`, `uint128`, `int256`, `uint256`, `fixed`, and `ufixed` are represented as strings.
-Values of EVM type `address` and `address payable` are represented as lowercase hex strings with a "0x" prefix.
-Values of EVM type `bytes` and `bytes<N>` are represented as base64 strings.
-Values of other EVM types (integer types, strings, arrays, etc.) are represented as their JSON counterpart.
-
- */
-export interface EvmAbiParam {
-  /** The solidity type of the parameter. */
-  evm_type: string;
-  /** The parameter name. */
-  name: string;
-  /** The parameter value. */
-  value: unknown;
-}
-
-/**
  * A runtime transaction.
 
  */
@@ -1024,6 +917,113 @@ if applicable. The meaning varies based on the transaction method. Some notable 
   /** A reasonable "to" Ethereum address associated with this transaction,
  */
   to_eth?: string;
+}
+
+/**
+ * A list of runtime transactions.
+
+ */
+export type RuntimeTransactionListAllOf = {
+  transactions: RuntimeTransaction[];
+};
+
+export type RuntimeTransactionList = List & RuntimeTransactionListAllOf;
+
+export type RuntimeEvmContractVerificationSourceFilesItem = { [key: string]: any };
+
+/**
+ * The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
+Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
+
+ */
+export type RuntimeEvmContractVerificationCompilationMetadata = { [key: string]: any };
+
+/**
+ * The level of verification of a smart contract, as defined by Sourcify.
+An absence of this field means that the contract has not been verified.
+See also https://docs.sourcify.dev/docs/full-vs-partial-match/
+
+ */
+export type VerificationLevel = typeof VerificationLevel[keyof typeof VerificationLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const VerificationLevel = {
+  partial: 'partial',
+  full: 'full',
+} as const;
+
+export interface RuntimeEvmContractVerification {
+  /** The smart contract's [metadata.json](https://docs.soliditylang.org/en/latest/metadata.html) file in JSON format as defined by Solidity.
+Includes the smart contract's [ABI](https://docs.soliditylang.org/en/develop/abi-spec.html).
+ */
+  compilation_metadata?: RuntimeEvmContractVerificationCompilationMetadata;
+  /** Array of all contract source files, in JSON format as returned by [Sourcify](https://sourcify.dev/server/api-docs/#/Repository/get_files_any__chain___address_).
+ */
+  source_files?: RuntimeEvmContractVerificationSourceFilesItem[];
+  verification_level?: VerificationLevel;
+}
+
+export interface RuntimeEvmContract {
+  /** The creation bytecode of the smart contract. This includes the constructor logic
+and the constructor parameters. When run, this code generates the runtime bytecode.
+Can be omitted for contracts that were created by another contract, as opposed
+to a direct `Create` call.
+ */
+  creation_bytecode?: string;
+  /** The Oasis cryptographic hash of the transaction that created the smart contract.
+Can be omitted for contracts that were created by another contract, as opposed
+to a direct `Create` call.
+ */
+  creation_tx?: string;
+  /** The Ethereum transaction hash of the transaction in `creation_tx`.
+Encoded as a lowercase hex string.
+ */
+  eth_creation_tx?: string;
+  /** The total amount of gas used to create or call this contract. */
+  gas_used: number;
+  /** The runtime bytecode of the smart contract. This is the code stored on-chain that
+describes a smart contract. Every contract has this info, but Nexus fetches
+it separately, so the field may be missing for very fresh contracts (or if the fetching
+process is stalled).
+ */
+  runtime_bytecode?: string;
+  /** Additional information obtained from contract verification. Only available for smart
+contracts that have been verified successfully by Sourcify.
+ */
+  verification?: RuntimeEvmContractVerification;
+}
+
+/**
+ * Details about the EVM token involved in the event, if any.
+
+ */
+export interface EvmEventToken {
+  /** The number of least significant digits in base units that should be displayed as
+decimals when displaying tokens. `tokens = base_units / (10**decimals)`.
+Affects display only. Often equals 18, to match ETH.
+ */
+  decimals?: number;
+  /** Symbol of the token, as provided by token contract's `symbol()` method. */
+  symbol?: string;
+  type?: EvmTokenType;
+}
+
+/**
+ * A decoded parameter of an event or error emitted from an EVM runtime.
+Values of EVM type `int128`, `uint128`, `int256`, `uint256`, `fixed`, and `ufixed` are represented as strings.
+Values of EVM type `address` and `address payable` are represented as lowercase hex strings with a "0x" prefix.
+Values of EVM type `bytes` and `bytes<N>` are represented as base64 strings.
+Values of other EVM types (integer types, strings, arrays, etc.) are represented as their JSON counterpart.
+
+ */
+export interface EvmAbiParam {
+  /** The solidity type of the parameter. */
+  evm_type: string;
+  /** The parameter name. */
+  name: string;
+  /** The parameter value. */
+  value: unknown;
 }
 
 export type RuntimeEventType = typeof RuntimeEventType[keyof typeof RuntimeEventType];
@@ -1632,37 +1632,6 @@ data origin is not tracked and error information can be faked.
 export type TransactionBody = { [key: string]: any };
 
 /**
- * A list of consensus transactions.
-
- */
-export type TransactionListAllOf = {
-  transactions: Transaction[];
-};
-
-export type ConsensusTxMethod = typeof ConsensusTxMethod[keyof typeof ConsensusTxMethod];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ConsensusTxMethod = {
-  stakingTransfer: 'staking.Transfer',
-  stakingAddEscrow: 'staking.AddEscrow',
-  stakingReclaimEscrow: 'staking.ReclaimEscrow',
-  stakingAmendCommissionSchedule: 'staking.AmendCommissionSchedule',
-  stakingAllow: 'staking.Allow',
-  stakingWithdraw: 'staking.Withdraw',
-  roothashExecutorCommit: 'roothash.ExecutorCommit',
-  roothashExecutorProposerTimeout: 'roothash.ExecutorProposerTimeout',
-  registryRegisterEntity: 'registry.RegisterEntity',
-  registryRegisterNode: 'registry.RegisterNode',
-  registryRegisterRuntime: 'registry.RegisterRuntime',
-  governanceCastVote: 'governance.CastVote',
-  governanceSubmitProposal: 'governance.SubmitProposal',
-  beaconPVSSCommit: 'beacon.PVSSCommit',
-  beaconPVSSReveal: 'beacon.PVSSReveal',
-  beaconVRFProve: 'beacon.VRFProve',
-} as const;
-
-/**
  * A consensus transaction.
 
  */
@@ -1696,6 +1665,39 @@ to pay to execute it.
 }
 
 /**
+ * A list of consensus transactions.
+
+ */
+export type TransactionListAllOf = {
+  transactions: Transaction[];
+};
+
+export type TransactionList = List & TransactionListAllOf;
+
+export type ConsensusTxMethod = typeof ConsensusTxMethod[keyof typeof ConsensusTxMethod];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ConsensusTxMethod = {
+  stakingTransfer: 'staking.Transfer',
+  stakingAddEscrow: 'staking.AddEscrow',
+  stakingReclaimEscrow: 'staking.ReclaimEscrow',
+  stakingAmendCommissionSchedule: 'staking.AmendCommissionSchedule',
+  stakingAllow: 'staking.Allow',
+  stakingWithdraw: 'staking.Withdraw',
+  roothashExecutorCommit: 'roothash.ExecutorCommit',
+  roothashExecutorProposerTimeout: 'roothash.ExecutorProposerTimeout',
+  registryRegisterEntity: 'registry.RegisterEntity',
+  registryRegisterNode: 'registry.RegisterNode',
+  registryRegisterRuntime: 'registry.RegisterRuntime',
+  governanceCastVote: 'governance.CastVote',
+  governanceSubmitProposal: 'governance.SubmitProposal',
+  beaconPVSSCommit: 'beacon.PVSSCommit',
+  beaconPVSSReveal: 'beacon.PVSSReveal',
+  beaconVRFProve: 'beacon.VRFProve',
+} as const;
+
+/**
  * A debonding delegation.
 
  */
@@ -1719,6 +1721,8 @@ export interface DebondingDelegation {
 export type DebondingDelegationListAllOf = {
   debonding_delegations: DebondingDelegation[];
 };
+
+export type DebondingDelegationList = List & DebondingDelegationListAllOf;
 
 /**
  * A delegation.
@@ -1785,10 +1789,6 @@ the query would return with limit=infinity.
  */
   total_count: number;
 }
-
-export type TransactionList = List & TransactionListAllOf;
-
-export type DebondingDelegationList = List & DebondingDelegationListAllOf;
 
 /**
  * A list of consensus blocks.

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1543,6 +1543,8 @@ export const ConsensusEventType = {
   roothashexecution_discrepancy: 'roothash.execution_discrepancy',
   roothashexecutor_committed: 'roothash.executor_committed',
   roothashfinalized: 'roothash.finalized',
+  roothashmessage: 'roothash.message',
+  roothashin_msg_processed: 'roothash.in_msg_processed',
   stakingallowance_change: 'staking.allowance_change',
   stakingburn: 'staking.burn',
   stakingescrowadd: 'staking.escrow.add',

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -22,11 +22,11 @@ import GetConsensusTransactionsTxHashMutator from '../replaceNetworkWithBaseURL'
 import GetConsensusEventsMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusRoothashMessagesMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusEntitiesMutator from '../replaceNetworkWithBaseURL';
-import GetConsensusEntitiesEntityIdMutator from '../replaceNetworkWithBaseURL';
-import GetConsensusEntitiesEntityIdNodesMutator from '../replaceNetworkWithBaseURL';
-import GetConsensusEntitiesEntityIdNodesNodeIdMutator from '../replaceNetworkWithBaseURL';
+import GetConsensusEntitiesAddressMutator from '../replaceNetworkWithBaseURL';
+import GetConsensusEntitiesAddressNodesMutator from '../replaceNetworkWithBaseURL';
+import GetConsensusEntitiesAddressNodesNodeIdMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusValidatorsMutator from '../replaceNetworkWithBaseURL';
-import GetConsensusValidatorsEntityIdMutator from '../replaceNetworkWithBaseURL';
+import GetConsensusValidatorsAddressMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusAccountsMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusAccountsAddressMutator from '../replaceNetworkWithBaseURL';
 import GetConsensusAccountsAddressDelegationsMutator from '../replaceNetworkWithBaseURL';
@@ -456,7 +456,7 @@ limit?: number;
 offset?: number;
 };
 
-export type GetConsensusEntitiesEntityIdNodesParams = {
+export type GetConsensusEntitiesAddressNodesParams = {
 /**
  * The maximum numbers of items to return.
 
@@ -2477,58 +2477,58 @@ export const useGetConsensusEntities = <TData = Awaited<ReturnType<typeof GetCon
 /**
  * @summary Returns an entity registered at the consensus layer.
  */
-export const GetConsensusEntitiesEntityId = (
+export const GetConsensusEntitiesAddress = (
     network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
- options?: SecondParameter<typeof GetConsensusEntitiesEntityIdMutator>,signal?: AbortSignal
+    address: StakingAddress,
+ options?: SecondParameter<typeof GetConsensusEntitiesAddressMutator>,signal?: AbortSignal
 ) => {
       
       
-      return GetConsensusEntitiesEntityIdMutator<Entity>(
-      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(entityId))}`, method: 'GET', signal
+      return GetConsensusEntitiesAddressMutator<Entity>(
+      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(address))}`, method: 'GET', signal
     },
       options);
     }
   
 
-export const getGetConsensusEntitiesEntityIdQueryKey = (network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,) => {
-    return [`/${network}/consensus/entities/${entityId}`] as const;
+export const getGetConsensusEntitiesAddressQueryKey = (network: 'mainnet' | 'testnet',
+    address: StakingAddress,) => {
+    return [`/${network}/consensus/entities/${address}`] as const;
     }
 
     
-export const getGetConsensusEntitiesEntityIdQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdMutator>}
+export const getGetConsensusEntitiesAddressQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
+    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesEntityIdQueryKey(network,entityId);
+  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesAddressQueryKey(network,address);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>> = ({ signal }) => GetConsensusEntitiesEntityId(network,entityId, requestOptions, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>> = ({ signal }) => GetConsensusEntitiesAddress(network,address, requestOptions, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(network && entityId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(network && address), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetConsensusEntitiesEntityIdQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>>
-export type GetConsensusEntitiesEntityIdQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
+export type GetConsensusEntitiesAddressQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>>
+export type GetConsensusEntitiesAddressQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
 
 /**
  * @summary Returns an entity registered at the consensus layer.
  */
-export const useGetConsensusEntitiesEntityId = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
+export const useGetConsensusEntitiesAddress = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdMutator>}
+    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddress>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetConsensusEntitiesEntityIdQueryOptions(network,entityId,options)
+  const queryOptions = getGetConsensusEntitiesAddressQueryOptions(network,address,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -2543,63 +2543,63 @@ export const useGetConsensusEntitiesEntityId = <TData = Awaited<ReturnType<typeo
 /**
  * @summary Returns a list of nodes registered at the consensus layer.
  */
-export const GetConsensusEntitiesEntityIdNodes = (
+export const GetConsensusEntitiesAddressNodes = (
     network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    params?: GetConsensusEntitiesEntityIdNodesParams,
- options?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesMutator>,signal?: AbortSignal
+    address: StakingAddress,
+    params?: GetConsensusEntitiesAddressNodesParams,
+ options?: SecondParameter<typeof GetConsensusEntitiesAddressNodesMutator>,signal?: AbortSignal
 ) => {
       
       
-      return GetConsensusEntitiesEntityIdNodesMutator<NodeList>(
-      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(entityId))}/nodes`, method: 'GET',
+      return GetConsensusEntitiesAddressNodesMutator<NodeList>(
+      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(address))}/nodes`, method: 'GET',
         params, signal
     },
       options);
     }
   
 
-export const getGetConsensusEntitiesEntityIdNodesQueryKey = (network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    params?: GetConsensusEntitiesEntityIdNodesParams,) => {
-    return [`/${network}/consensus/entities/${entityId}/nodes`, ...(params ? [params]: [])] as const;
+export const getGetConsensusEntitiesAddressNodesQueryKey = (network: 'mainnet' | 'testnet',
+    address: StakingAddress,
+    params?: GetConsensusEntitiesAddressNodesParams,) => {
+    return [`/${network}/consensus/entities/${address}/nodes`, ...(params ? [params]: [])] as const;
     }
 
     
-export const getGetConsensusEntitiesEntityIdNodesQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    params?: GetConsensusEntitiesEntityIdNodesParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesMutator>}
+export const getGetConsensusEntitiesAddressNodesQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
+    address: StakingAddress,
+    params?: GetConsensusEntitiesAddressNodesParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressNodesMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesEntityIdNodesQueryKey(network,entityId,params);
+  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesAddressNodesQueryKey(network,address,params);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>> = ({ signal }) => GetConsensusEntitiesEntityIdNodes(network,entityId,params, requestOptions, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>> = ({ signal }) => GetConsensusEntitiesAddressNodes(network,address,params, requestOptions, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(network && entityId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(network && address), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetConsensusEntitiesEntityIdNodesQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>>
-export type GetConsensusEntitiesEntityIdNodesQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
+export type GetConsensusEntitiesAddressNodesQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>>
+export type GetConsensusEntitiesAddressNodesQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
 
 /**
  * @summary Returns a list of nodes registered at the consensus layer.
  */
-export const useGetConsensusEntitiesEntityIdNodes = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
+export const useGetConsensusEntitiesAddressNodes = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    params?: GetConsensusEntitiesEntityIdNodesParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodes>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesMutator>}
+    address: StakingAddress,
+    params?: GetConsensusEntitiesAddressNodesParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodes>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressNodesMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetConsensusEntitiesEntityIdNodesQueryOptions(network,entityId,params,options)
+  const queryOptions = getGetConsensusEntitiesAddressNodesQueryOptions(network,address,params,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -2614,62 +2614,62 @@ export const useGetConsensusEntitiesEntityIdNodes = <TData = Awaited<ReturnType<
 /**
  * @summary Returns a node registered at the consensus layer.
  */
-export const GetConsensusEntitiesEntityIdNodesNodeId = (
+export const GetConsensusEntitiesAddressNodesNodeId = (
     network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
+    address: StakingAddress,
     nodeId: Ed25519PubKey,
- options?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesNodeIdMutator>,signal?: AbortSignal
+ options?: SecondParameter<typeof GetConsensusEntitiesAddressNodesNodeIdMutator>,signal?: AbortSignal
 ) => {
       
       
-      return GetConsensusEntitiesEntityIdNodesNodeIdMutator<Node>(
-      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(entityId))}/nodes/${encodeURIComponent(String(nodeId))}`, method: 'GET', signal
+      return GetConsensusEntitiesAddressNodesNodeIdMutator<Node>(
+      {url: `/${encodeURIComponent(String(network))}/consensus/entities/${encodeURIComponent(String(address))}/nodes/${encodeURIComponent(String(nodeId))}`, method: 'GET', signal
     },
       options);
     }
   
 
-export const getGetConsensusEntitiesEntityIdNodesNodeIdQueryKey = (network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
+export const getGetConsensusEntitiesAddressNodesNodeIdQueryKey = (network: 'mainnet' | 'testnet',
+    address: StakingAddress,
     nodeId: Ed25519PubKey,) => {
-    return [`/${network}/consensus/entities/${entityId}/nodes/${nodeId}`] as const;
+    return [`/${network}/consensus/entities/${address}/nodes/${nodeId}`] as const;
     }
 
     
-export const getGetConsensusEntitiesEntityIdNodesNodeIdQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    nodeId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesNodeIdMutator>}
+export const getGetConsensusEntitiesAddressNodesNodeIdQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
+    address: StakingAddress,
+    nodeId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressNodesNodeIdMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesEntityIdNodesNodeIdQueryKey(network,entityId,nodeId);
+  const queryKey =  queryOptions?.queryKey ?? getGetConsensusEntitiesAddressNodesNodeIdQueryKey(network,address,nodeId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>> = ({ signal }) => GetConsensusEntitiesEntityIdNodesNodeId(network,entityId,nodeId, requestOptions, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>> = ({ signal }) => GetConsensusEntitiesAddressNodesNodeId(network,address,nodeId, requestOptions, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(network && entityId && nodeId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(network && address && nodeId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetConsensusEntitiesEntityIdNodesNodeIdQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>>
-export type GetConsensusEntitiesEntityIdNodesNodeIdQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
+export type GetConsensusEntitiesAddressNodesNodeIdQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>>
+export type GetConsensusEntitiesAddressNodesNodeIdQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
 
 /**
  * @summary Returns a node registered at the consensus layer.
  */
-export const useGetConsensusEntitiesEntityIdNodesNodeId = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
+export const useGetConsensusEntitiesAddressNodesNodeId = <TData = Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
-    nodeId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesEntityIdNodesNodeId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesEntityIdNodesNodeIdMutator>}
+    address: StakingAddress,
+    nodeId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusEntitiesAddressNodesNodeId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusEntitiesAddressNodesNodeIdMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetConsensusEntitiesEntityIdNodesNodeIdQueryOptions(network,entityId,nodeId,options)
+  const queryOptions = getGetConsensusEntitiesAddressNodesNodeIdQueryOptions(network,address,nodeId,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -2751,58 +2751,58 @@ export const useGetConsensusValidators = <TData = Awaited<ReturnType<typeof GetC
 /**
  * @summary Returns a validator registered at the consensus layer.
  */
-export const GetConsensusValidatorsEntityId = (
+export const GetConsensusValidatorsAddress = (
     network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,
- options?: SecondParameter<typeof GetConsensusValidatorsEntityIdMutator>,signal?: AbortSignal
+    address: StakingAddress,
+ options?: SecondParameter<typeof GetConsensusValidatorsAddressMutator>,signal?: AbortSignal
 ) => {
       
       
-      return GetConsensusValidatorsEntityIdMutator<Validator>(
-      {url: `/${encodeURIComponent(String(network))}/consensus/validators/${encodeURIComponent(String(entityId))}`, method: 'GET', signal
+      return GetConsensusValidatorsAddressMutator<Validator>(
+      {url: `/${encodeURIComponent(String(network))}/consensus/validators/${encodeURIComponent(String(address))}`, method: 'GET', signal
     },
       options);
     }
   
 
-export const getGetConsensusValidatorsEntityIdQueryKey = (network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey,) => {
-    return [`/${network}/consensus/validators/${entityId}`] as const;
+export const getGetConsensusValidatorsAddressQueryKey = (network: 'mainnet' | 'testnet',
+    address: StakingAddress,) => {
+    return [`/${network}/consensus/validators/${address}`] as const;
     }
 
     
-export const getGetConsensusValidatorsEntityIdQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusValidatorsEntityIdMutator>}
+export const getGetConsensusValidatorsAddressQueryOptions = <TData = Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(network: 'mainnet' | 'testnet',
+    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>, TError, TData>, request?: SecondParameter<typeof GetConsensusValidatorsAddressMutator>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetConsensusValidatorsEntityIdQueryKey(network,entityId);
+  const queryKey =  queryOptions?.queryKey ?? getGetConsensusValidatorsAddressQueryKey(network,address);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>> = ({ signal }) => GetConsensusValidatorsEntityId(network,entityId, requestOptions, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>> = ({ signal }) => GetConsensusValidatorsAddress(network,address, requestOptions, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(network && entityId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(network && address), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetConsensusValidatorsEntityIdQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>>
-export type GetConsensusValidatorsEntityIdQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
+export type GetConsensusValidatorsAddressQueryResult = NonNullable<Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>>
+export type GetConsensusValidatorsAddressQueryError = HumanReadableErrorResponse | NotFoundErrorResponse
 
 /**
  * @summary Returns a validator registered at the consensus layer.
  */
-export const useGetConsensusValidatorsEntityId = <TData = Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
+export const useGetConsensusValidatorsAddress = <TData = Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>, TError = HumanReadableErrorResponse | NotFoundErrorResponse>(
  network: 'mainnet' | 'testnet',
-    entityId: Ed25519PubKey, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsEntityId>>, TError, TData>, request?: SecondParameter<typeof GetConsensusValidatorsEntityIdMutator>}
+    address: StakingAddress, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetConsensusValidatorsAddress>>, TError, TData>, request?: SecondParameter<typeof GetConsensusValidatorsAddressMutator>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetConsensusValidatorsEntityIdQueryOptions(network,entityId,options)
+  const queryOptions = getGetConsensusValidatorsAddressQueryOptions(network,address,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1629,6 +1629,11 @@ data origin is not tracked and error information can be faked.
 }
 
 /**
+ * The method call body. This spec does not encode the many possible types; instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go) of oasis-core. This object will conform to one of the types passed to variable instantiations using `NewMethodName` two levels down the hierarchy, e.g. `MethodTransfer` from `oasis-core/go/staking/api` seen [here](https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go@v0.2300.10/staking/api#pkg-variables).
+ */
+export type TransactionBody = { [key: string]: any };
+
+/**
  * A list of consensus transactions.
 
  */
@@ -1666,8 +1671,8 @@ export const ConsensusTxMethod = {
 export interface Transaction {
   /** The block height at which this transaction was executed. */
   block: number;
-  /** The method call body. */
-  body: string;
+  /** The method call body. This spec does not encode the many possible types; instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go) of oasis-core. This object will conform to one of the types passed to variable instantiations using `NewMethodName` two levels down the hierarchy, e.g. `MethodTransfer` from `oasis-core/go/staking/api` seen [here](https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go@v0.2300.10/staking/api#pkg-variables). */
+  body: TransactionBody;
   /** Error details of a failed transaction. */
   error?: TxError;
   /** The fee that this transaction's sender committed

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1056,7 +1056,7 @@ Absent if the event did not originate from an EVM transaction.
 evm event, e.g. `Transfer`. 
 Absent if the event type is not `evm.log`.
  */
-  evm_log_name?: string | null;
+  evm_log_name?: string;
   /** The decoded `evm.log` event data.
 Absent if the event type is not `evm.log`.
  */
@@ -1070,7 +1070,7 @@ Absent if the event type is not `evm.log`.
   /** Hash of this event's originating transaction.
 Absent if the event did not originate from a transaction.
  */
-  tx_hash?: string | null;
+  tx_hash?: string;
   /** 0-based index of this event's originating transaction within its block.
 Absent if the event did not originate from a transaction.
  */
@@ -1361,7 +1361,7 @@ is the Ethereum address (in base64, not hex!).
  */
   context: AddressDerivationContext;
   /** Version of the `context`. */
-  context_version?: number | null;
+  context_version?: number;
 }
 
 /**
@@ -1550,11 +1550,11 @@ the hierarchy, e.g. `TransferEvent` from `Event > staking.Event > TransferEvent`
   /** Hash of this event's originating transaction.
 Absent if the event did not originate from a transaction.
  */
-  tx_hash?: string | null;
+  tx_hash?: string;
   /** 0-based index of this event's originating transaction within its block.
 Absent if the event did not originate from a transaction.
  */
-  tx_index?: number | null;
+  tx_index?: number;
   /** The type of the event. */
   type: ConsensusEventType;
 }


### PR DESCRIPTION
Please see #1425 for all the Nexus API changes up to v0.3.0 (currently deployed).

This PR depends on that, and added the remaining API changes, which are not yet deployed.
There is a breaking change, and out code is adapted accordingly.