### PR TITLE
Follow Nexus: support for pontusxdev

### DIFF
--- a/.changelog/1434.internal.md
+++ b/.changelog/1434.internal.md
@@ -1,0 +1,1 @@
+Follow Nexus: support for pontusxdev

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -33,6 +33,7 @@ export const searchSuggestionTerms = {
       suggestedTokenFragment: 'mock',
     },
     cipher: undefined,
+    pontusxdev: undefined,
     pontusx: undefined,
     consensus: undefined,
   },
@@ -50,11 +51,17 @@ export const searchSuggestionTerms = {
       suggestedTokenFragment: 'USD',
     },
     cipher: undefined,
-    pontusx: {
+    pontusxdev: {
       suggestedBlock: '390632',
       suggestedTransaction: '0x244f71bcc67a0359c0d1e417b302ec3b358193769399e71f0112c58135f0fc82',
       suggestedAccount: '0xC09c6A1d5538E7ed135d6146241c8da11e92130B',
       suggestedTokenFragment: 'Ocean',
+    },
+    pontusx: {
+      suggestedBlock: '390632', // TODO
+      suggestedTransaction: '0x244f71bcc67a0359c0d1e417b302ec3b358193769399e71f0112c58135f0fc82', // TODO
+      suggestedAccount: '0xC09c6A1d5538E7ed135d6146241c8da11e92130B', // TODO
+      suggestedTokenFragment: 'Ocean', // TODO
     },
     consensus: undefined,
   },

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -62,6 +62,7 @@ const getContent = (t: TFunction) => {
         },
       },
       [Layer.cipher]: undefined,
+      [Layer.pontusxdev]: undefined,
       [Layer.pontusx]: undefined,
     },
     [Network.testnet]: {
@@ -100,6 +101,23 @@ const getContent = (t: TFunction) => {
         },
       },
       [Layer.cipher]: undefined,
+      [Layer.pontusxdev]: {
+        primary: {
+          description: t('learningMaterials.pontusx.1.description'),
+          header: t('learningMaterials.pontusx.1.header'),
+          url: docs.pontusx1,
+        },
+        secondary: {
+          description: t('learningMaterials.pontusx.2.description'),
+          header: t('learningMaterials.pontusx.2.header'),
+          url: docs.pontusx2,
+        },
+        tertiary: {
+          description: t('learningMaterials.pontusx.2.description'),
+          header: t('learningMaterials.pontusx.3.header'),
+          url: docs.pontusx3,
+        },
+      },
       [Layer.pontusx]: {
         primary: {
           description: t('learningMaterials.pontusx.1.description'),

--- a/src/app/utils/content.tsx
+++ b/src/app/utils/content.tsx
@@ -9,7 +9,8 @@ export const getLayerLabels = (t: TFunction): Record<Layer, string> => ({
   [Layer.emerald]: t('common.emerald'),
   [Layer.sapphire]: t('common.sapphire'),
   [Layer.cipher]: t('common.cipher'),
-  [Layer.pontusx]: t('common.pontusx'),
+  [Layer.pontusxdev]: t('common.pontusx'), // TODO
+  [Layer.pontusx]: t('common.pontusx'), // TODO
   [Layer.consensus]: t('common.consensus'),
 })
 

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -43,6 +43,7 @@ export abstract class RouteUtils {
       [Layer.emerald]: true,
       [Layer.sapphire]: true,
       [Layer.cipher]: false,
+      [Layer.pontusxdev]: false,
       [Layer.pontusx]: false,
       // Disable WIP Consensus on production and staging
       [Layer.consensus]: !isStableDeploy,
@@ -51,6 +52,7 @@ export abstract class RouteUtils {
       [Layer.emerald]: true,
       [Layer.sapphire]: true,
       [Layer.cipher]: false,
+      [Layer.pontusxdev]: true,
       [Layer.pontusx]: true,
       // Disable WIP Consensus on production and staging
       [Layer.consensus]: !isStableDeploy,

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,7 +114,27 @@ const sapphireConfig: LayerConfig = {
   type: RuntimeTypes.Evm,
 }
 
-const pontusxConfig: LayerConfig = {
+const pontusxDevConfig: LayerConfig = {
+  mainnet: {
+    activeNodes: undefined,
+    address: undefined,
+    blockGasLimit: undefined,
+    runtimeId: undefined,
+    tokens: [NativeToken.EUROe],
+  },
+  testnet: {
+    activeNodes: 1,
+    address: 'oasis1qr02702pr8ecjuff2z3es254pw9xl6z2yg9qcc6c',
+    blockGasLimit: 15_000_000,
+    runtimeId: '0000000000000000000000000000000000000000000000004febe52eb412b421',
+    tokens: [NativeToken.EUROe, NativeToken.TEST],
+    fiatCurrency: 'eur',
+  },
+  decimals: 18,
+  type: RuntimeTypes.Evm,
+}
+
+const pontusxTestConfig: LayerConfig = {
   mainnet: {
     activeNodes: undefined,
     address: undefined,
@@ -142,7 +162,8 @@ export const paraTimesConfig = {
   [Layer.cipher]: cipherConfig,
   [Layer.emerald]: emeraldConfig,
   [Layer.sapphire]: sapphireConfig,
-  [Layer.pontusx]: pontusxConfig,
+  [Layer.pontusxdev]: pontusxDevConfig,
+  [Layer.pontusx]: pontusxTestConfig,
   [Layer.consensus]: null,
 } satisfies LayersConfig
 

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1927,6 +1927,7 @@ export const Runtime = {
   emerald: 'emerald',
   sapphire: 'sapphire',
   pontusx: 'pontusx',
+  pontusxdev: 'pontusxdev',
   cipher: 'cipher',
 } as const;
 
@@ -1938,6 +1939,7 @@ export const Layer = {
   emerald: 'emerald',
   sapphire: 'sapphire',
   pontusx: 'pontusx',
+  pontusxdev: 'pontusxdev',
   cipher: 'cipher',
   consensus: 'consensus',
 } as const;

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -16,7 +16,8 @@ const layerOrder: Record<Layer, number> = {
   [Layer.sapphire]: 2,
   [Layer.emerald]: 3,
   [Layer.cipher]: 4,
-  [Layer.pontusx]: 5,
+  [Layer.pontusxdev]: 5,
+  [Layer.pontusx]: 6,
 }
 
 const hiddenLayers: Layer[] = [Layer.pontusx]


### PR DESCRIPTION
This adapts our code for the new pontusxdev support on the Nexus API.

No actual work is done to properly support the new pontusx paratime yet,
just patch up our code enough so that there are no more TypeScript syntax errors.

See #1435 for proper support for the new paratime.