### PR TITLE
Set up Pontus-X devnet and testnet

### DIFF
--- a/.changelog/1435.feature.md
+++ b/.changelog/1435.feature.md
@@ -1,0 +1,1 @@
+Add/fix support for Pontus-X devnet and testnet

--- a/src/app/components/LayerPicker/LayerDetails.tsx
+++ b/src/app/components/LayerPicker/LayerDetails.tsx
@@ -68,11 +68,18 @@ const getDetails = (t: TFunction): Details => ({
       chainDecimalId: '23295',
       docs: docs.sapphire,
     },
-    [Layer.pontusx]: {
-      description: t('layerPicker.testnet.pontusx'),
+    [Layer.pontusxdev]: {
+      description: t('layerPicker.testnet.pontusxdev'),
       rpcHttp: 'https://pontusx.not.si:443',
       chainHexId: '0x7ec8',
       chainDecimalId: '32456',
+      docs: docs.pontusx1,
+    },
+    [Layer.pontusx]: {
+      description: t('layerPicker.testnet.pontusxtest'),
+      rpcHttp: 'https://pontusx.not.si:443',
+      chainHexId: '0x7ec9',
+      chainDecimalId: '32457',
       docs: docs.pontusx1,
     },
   },

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -33,6 +33,7 @@ export const searchSuggestionTerms = {
       suggestedTokenFragment: 'mock',
     },
     cipher: undefined,
+    pontusxdev: undefined,
     pontusx: undefined,
     consensus: undefined,
   },
@@ -50,11 +51,17 @@ export const searchSuggestionTerms = {
       suggestedTokenFragment: 'USD',
     },
     cipher: undefined,
-    pontusx: {
+    pontusxdev: {
       suggestedBlock: '390632',
       suggestedTransaction: '0x244f71bcc67a0359c0d1e417b302ec3b358193769399e71f0112c58135f0fc82',
       suggestedAccount: '0xC09c6A1d5538E7ed135d6146241c8da11e92130B',
       suggestedTokenFragment: 'Ocean',
+    },
+    pontusx: {
+      suggestedBlock: '390632', // TODO
+      suggestedTransaction: '0x244f71bcc67a0359c0d1e417b302ec3b358193769399e71f0112c58135f0fc82', // TODO
+      suggestedAccount: '0xC09c6A1d5538E7ed135d6146241c8da11e92130B', // TODO
+      suggestedTokenFragment: 'Ocean', // TODO
     },
     consensus: undefined,
   },

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -12,7 +12,7 @@ import { getOasisAddress } from '../utils/helpers'
  * since this function also includes caching.
  */
 export const useAccountMetadata = (scope: SearchScope, address: string): AccountMetadataInfo => {
-  const isPontusX = scope.layer === Layer.pontusx
+  const isPontusX = scope.layer === Layer.pontusx || scope.layer === Layer.pontusxdev
   const pontusXData = usePontusXAccountMetadata(address, { enabled: isPontusX })
   const oasisData = useOasisAccountMetadata(scope.network, scope.layer, getOasisAddress(address), {
     enabled: !isPontusX,
@@ -24,11 +24,12 @@ export const useSearchForAccountsByName = (
   scope: SearchScope,
   nameFragment = '',
 ): AccountNameSearchResults => {
-  const isValidPontusXSearch = scope.layer === Layer.pontusx && !!nameFragment
+  const isPontusX = scope.layer === Layer.pontusx || scope.layer === Layer.pontusxdev
+  const isValidPontusXSearch = isPontusX && !!nameFragment
   const pontusXResults = useSearchForPontusXAccountsByName(scope.network, nameFragment, {
     enabled: isValidPontusXSearch,
   })
-  const isValidOasisSearch = scope.layer !== Layer.pontusx && !!nameFragment
+  const isValidOasisSearch = !isPontusX && !!nameFragment
   const oasisResults = useSearchForOasisAccountsByName(scope.network, scope.layer, nameFragment, {
     enabled: isValidOasisSearch,
   })

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -62,6 +62,7 @@ const getContent = (t: TFunction) => {
         },
       },
       [Layer.cipher]: undefined,
+      [Layer.pontusxdev]: undefined,
       [Layer.pontusx]: undefined,
     },
     [Network.testnet]: {
@@ -100,20 +101,37 @@ const getContent = (t: TFunction) => {
         },
       },
       [Layer.cipher]: undefined,
-      [Layer.pontusx]: {
+      [Layer.pontusxdev]: {
         primary: {
-          description: t('learningMaterials.pontusx.1.description'),
-          header: t('learningMaterials.pontusx.1.header'),
+          description: t('learningMaterials.pontusxdevnet.1.description'),
+          header: t('learningMaterials.pontusxdevnet.1.header'),
           url: docs.pontusx1,
         },
         secondary: {
-          description: t('learningMaterials.pontusx.2.description'),
-          header: t('learningMaterials.pontusx.2.header'),
+          description: t('learningMaterials.pontusxdevnet.2.description'),
+          header: t('learningMaterials.pontusxdevnet.2.header'),
           url: docs.pontusx2,
         },
         tertiary: {
-          description: t('learningMaterials.pontusx.2.description'),
-          header: t('learningMaterials.pontusx.3.header'),
+          description: t('learningMaterials.pontusxdevnet.3.description'),
+          header: t('learningMaterials.pontusxdevnet.3.header'),
+          url: docs.pontusx3,
+        },
+      },
+      [Layer.pontusx]: {
+        primary: {
+          description: t('learningMaterials.pontusxtestnet.1.description'),
+          header: t('learningMaterials.pontusxtestnet.1.header'),
+          url: docs.pontusx1,
+        },
+        secondary: {
+          description: t('learningMaterials.pontusxtestnet.2.description'),
+          header: t('learningMaterials.pontusxtestnet.2.header'),
+          url: docs.pontusx2,
+        },
+        tertiary: {
+          description: t('learningMaterials.pontusxtestnet.3.description'),
+          header: t('learningMaterials.pontusxtestnet.3.header'),
           url: docs.pontusx3,
         },
       },

--- a/src/app/utils/content.tsx
+++ b/src/app/utils/content.tsx
@@ -9,7 +9,8 @@ export const getLayerLabels = (t: TFunction): Record<Layer, string> => ({
   [Layer.emerald]: t('common.emerald'),
   [Layer.sapphire]: t('common.sapphire'),
   [Layer.cipher]: t('common.cipher'),
-  [Layer.pontusx]: t('common.pontusx'),
+  [Layer.pontusxdev]: t('pontusx.devnet'),
+  [Layer.pontusx]: t('pontusx.testnet'),
   [Layer.consensus]: t('common.consensus'),
 })
 

--- a/src/app/utils/faucet-links.ts
+++ b/src/app/utils/faucet-links.ts
@@ -9,8 +9,11 @@ const faucetLinks: Partial<Record<Network, Partial<Record<Layer, Partial<Record<
     [Layer.emerald]: { [Ticker.TEST]: `${faucets.oasisTestnet}?paratime=emerald` },
     [Layer.sapphire]: { [Ticker.TEST]: `${faucets.oasisTestnet}?paratime=sapphire` },
     [Layer.cipher]: { [Ticker.TEST]: `${faucets.oasisTestnet}?paratime=cipher` },
+    [Layer.pontusxdev]: {
+      [Ticker.EUROe]: `mailto:contact@delta-dao.com?subject=${encodeURIComponent('Request test tokens for Pontus-X Devnet')}`,
+    },
     [Layer.pontusx]: {
-      [Ticker.EUROe]: `mailto:contact@delta-dao.com?subject=${encodeURIComponent('Request test tokens')}`,
+      [Ticker.EUROe]: `mailto:contact@delta-dao.com?subject=${encodeURIComponent('Request test tokens for Pontus-X Testnet')}`,
     },
   },
 }

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -43,6 +43,7 @@ export abstract class RouteUtils {
       [Layer.emerald]: true,
       [Layer.sapphire]: true,
       [Layer.cipher]: false,
+      [Layer.pontusxdev]: false,
       [Layer.pontusx]: false,
       // Disable WIP Consensus on production and staging
       [Layer.consensus]: !isStableDeploy,
@@ -51,6 +52,7 @@ export abstract class RouteUtils {
       [Layer.emerald]: true,
       [Layer.sapphire]: true,
       [Layer.cipher]: false,
+      [Layer.pontusxdev]: true,
       [Layer.pontusx]: true,
       // Disable WIP Consensus on production and staging
       [Layer.consensus]: !isStableDeploy,

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,7 +114,27 @@ const sapphireConfig: LayerConfig = {
   type: RuntimeTypes.Evm,
 }
 
-const pontusxConfig: LayerConfig = {
+const pontusxDevConfig: LayerConfig = {
+  mainnet: {
+    activeNodes: undefined,
+    address: undefined,
+    blockGasLimit: undefined,
+    runtimeId: undefined,
+    tokens: [NativeToken.EUROe],
+  },
+  testnet: {
+    activeNodes: 3,
+    address: 'oasis1qr02702pr8ecjuff2z3es254pw9xl6z2yg9qcc6c',
+    blockGasLimit: 15_000_000,
+    runtimeId: '0000000000000000000000000000000000000000000000004febe52eb412b421',
+    tokens: [NativeToken.EUROe, NativeToken.TEST],
+    fiatCurrency: 'eur',
+  },
+  decimals: 18,
+  type: RuntimeTypes.Evm,
+}
+
+const pontusxTestConfig: LayerConfig = {
   mainnet: {
     activeNodes: undefined,
     address: undefined,
@@ -124,9 +144,9 @@ const pontusxConfig: LayerConfig = {
   },
   testnet: {
     activeNodes: 1,
-    address: 'oasis1qr02702pr8ecjuff2z3es254pw9xl6z2yg9qcc6c',
+    address: 'oasis1qrg6c89655pmdxeel08qkngs02jnrfll5v9c508v',
     blockGasLimit: 15_000_000,
-    runtimeId: '0000000000000000000000000000000000000000000000004febe52eb412b421',
+    runtimeId: '00000000000000000000000000000000000000000000000004a6f9071c007069',
     tokens: [NativeToken.EUROe, NativeToken.TEST],
     fiatCurrency: 'eur',
   },
@@ -142,7 +162,8 @@ export const paraTimesConfig = {
   [Layer.cipher]: cipherConfig,
   [Layer.emerald]: emeraldConfig,
   [Layer.sapphire]: sapphireConfig,
-  [Layer.pontusx]: pontusxConfig,
+  [Layer.pontusxdev]: pontusxDevConfig,
+  [Layer.pontusx]: pontusxTestConfig,
   [Layer.consensus]: null,
 } satisfies LayersConfig
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -106,7 +106,6 @@
     "paratime": "Paratime",
     "parentheses": "({{subject}})",
     "percentage": "Percentage",
-    "pontusx": "Pontus-X",
     "proposal": "Proposal",
     "proposer": "Proposer",
     "rank": "Rank",
@@ -295,7 +294,21 @@
       "header": "Add the {{ layer }} Testnet to Hardhat",
       "description": "Open up your hardhat.config.ts and drop in these lines."
     },
-    "pontusx": {
+    "pontusxdevnet": {
+      "1": {
+        "header": "What is the Pontus-X Network?",
+        "description": "The Pontus-X Network is our official confidential EVM Compatible ParaTime offering a smart contract development environment that is compatible with the Ethereum Virtual Machine (EVM) focused on building a Federated Data Economy."
+      },
+      "2": {
+        "header": "Devnet Parameters",
+        "description": "The Devnet for Pontus-X may undergo frequent version upgrades."
+      },
+      "3": {
+        "header": "Adding the Pontus-X Devnet to Hardhat",
+        "description": "To integrate with Pontus-X devnet, open your hardhat.config.ts file and insert the following configurations."
+      }
+    },
+    "pontusxtestnet": {
       "1": {
         "header": "What is the Pontus-X Network?",
         "description": "The Pontus-X Network is our official confidential EVM Compatible ParaTime offering a smart contract development environment that is compatible with the Ethereum Virtual Machine (EVM) focused on building a Federated Data Economy."
@@ -306,7 +319,7 @@
       },
       "3": {
         "header": "Adding the Pontus-X Testnet to Hardhat",
-        "description": "To integrate with Pontus-X, open your hardhat.config.ts file and insert the following configurations."
+        "description": "To integrate with Pontus-X testnet, open your hardhat.config.ts file and insert the following configurations."
       }
     },
     "token": {
@@ -516,7 +529,8 @@
     "testnet": {
       "emerald": "The Testnet of the EVM Compatible ParaTime providing a smart contract development environment.",
       "sapphire": "The Testnet of the official confidential EVM Compatible ParaTime providing a smart contract development environment with EVM compatibility.",
-      "pontusx": "The Testnet of the official confidential EVM Compatible ParaTime offering a smart contract development environment that is compatible with the Ethereum Virtual Machine (EVM) focused on building a Federated Data Economy."
+      "pontusxdev": "The Devnet of Pontus-X, a confidential EVM Compatible ParaTime offering a smart contract development environment that is compatible with the Ethereum Virtual Machine (EVM) focused on building a Federated Data Economy.",
+      "pontusxtest": "The Testnet of Pontus-X, a confidential EVM Compatible ParaTime offering a smart contract development environment that is compatible with the Ethereum Virtual Machine (EVM) focused on building a Federated Data Economy."
     }
   },
   "home": {
@@ -563,6 +577,10 @@
     "nodes": "Nodes:",
     "online": "Online",
     "outdated": "Out-of-date"
+  },
+  "pontusx": {
+    "devnet": "Pontus-X devnet",
+    "testnet": "Pontus-X testnet"
   },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1927,6 +1927,7 @@ export const Runtime = {
   emerald: 'emerald',
   sapphire: 'sapphire',
   pontusx: 'pontusx',
+  pontusxdev: 'pontusxdev',
   cipher: 'cipher',
 } as const;
 
@@ -1938,6 +1939,7 @@ export const Layer = {
   emerald: 'emerald',
   sapphire: 'sapphire',
   pontusx: 'pontusx',
+  pontusxdev: 'pontusxdev',
   cipher: 'cipher',
   consensus: 'consensus',
 } as const;

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -16,10 +16,11 @@ const layerOrder: Record<Layer, number> = {
   [Layer.sapphire]: 2,
   [Layer.emerald]: 3,
   [Layer.cipher]: 4,
-  [Layer.pontusx]: 5,
+  [Layer.pontusxdev]: 5,
+  [Layer.pontusx]: 6,
 }
 
-const hiddenLayers: Layer[] = [Layer.pontusx]
+const hiddenLayers: Layer[] = [Layer.pontusxdev, Layer.pontusx]
 
 export const orderByLayer = (itemA: HasLayer, itemB: HasLayer): number =>
   layerOrder[itemA.layer] - layerOrder[itemB.layer]


### PR DESCRIPTION
This PR adds / fixes support for Pontus-X devnet and testnet.

They are both hidden layers, so not available in the layer selector, only available via URL.

Things left to do:
 - Configure search suggestions for Pontus-X testnet