### PR TITLE
Avoid showing "NaN%" in the charts when there is no prev data

### DIFF
--- a/.changelog/1443.trivial.md
+++ b/.changelog/1443.trivial.md
@@ -1,0 +1,1 @@
+Avoid showing "NaN%" in the charts when there is no prev data

--- a/src/app/components/PercentageGain/index.tsx
+++ b/src/app/components/PercentageGain/index.tsx
@@ -13,6 +13,9 @@ interface PercentageGainProps {
  * Negative percentage shows red box with down arrow.
  */
 export const PercentageGain: FC<PercentageGainProps> = ({ earliestValue, latestValue }) => {
+  // If the previous data was zero, we can't divide with it, it would just get us infinity or Nan...
+  if (earliestValue === 0) return
+
   const ratio = (latestValue - earliestValue) / earliestValue
 
   return (


### PR DESCRIPTION
We have some statistics up on the paratime dashboards. However, when comparing to the current data to the previous one (whatever that means for the current setting), if the previous one was 0, when calculating the change, we get a division by zero error, and hence, NaN.

As discussed with @donouwens , in these situations, we should simply hide the percentage value. Like this:

| Before:   | After: |
| ------------- | ------------- |
| ![image](https://github.com/oasisprotocol/explorer/assets/2093792/af631b2f-bf5c-419b-ad61-bdd0c7eb2faa)  | ![image](https://github.com/oasisprotocol/explorer/assets/2093792/9839b8d5-3b55-48ed-a4a7-56019edae0dd) |

