### PR TITLE
Don't show TX error messages for empty error blocks

### DIFF
--- a/.changelog/1444.trivial.md
+++ b/.changelog/1444.trivial.md
@@ -1,0 +1,1 @@
+Don't show TX error messages for empty error blocks

--- a/src/app/components/StatusIcon/index.tsx
+++ b/src/app/components/StatusIcon/index.tsx
@@ -92,7 +92,7 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText }) =>
           &nbsp;
           {statusIcon[status]}
         </StyledBox>
-        {error && <ErrorBox>{errorMessage}</ErrorBox>}
+        {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
       </>
     )
   } else {

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -3,7 +3,11 @@ import { TxError } from '../../oasis-nexus/api'
 
 export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
   const { t } = useTranslation()
-  if (!error || (!error.module && !error.code)) return undefined
+  if (
+    !error ||
+    (!error.module && !error.code) // TODO: This second check shouldn't be necessary. Remove when https://github.com/oasisprotocol/nexus/issues/704 is fixed.
+  )
+    return undefined
   if (error.module === 'evm' && error.code === 8 && !error.message) {
     // EVM reverted, with missing error message
     return `${t('errors.revertedWithoutMessage')} (${t('errors.code')} ${error.code})`

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -3,7 +3,7 @@ import { TxError } from '../../oasis-nexus/api'
 
 export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
   const { t } = useTranslation()
-  if (!error) return undefined
+  if (!error || (!error.module && !error.code)) return undefined
   if (error.module === 'evm' && error.code === 8 && !error.message) {
     // EVM reverted, with missing error message
     return `${t('errors.revertedWithoutMessage')} (${t('errors.code')} ${error.code})`


### PR DESCRIPTION
Some transactions have an `error` block like this:

```
"error": {
  "code": 0,
  "module": ""
}
```

An example found by @matevz is available [here](https://explorer.oasis.io/mainnet/sapphire/tx/7224d59e6b74d9b2caf55ab40dfe0757cef4f71c66d3a7aba3de1d267d2ea409).

In these cases, no error message should be shown.