### PR TITLE
Stop renovate from updating "engines"

### DIFF
--- a/.changelog/1452.trivial.md
+++ b/.changelog/1452.trivial.md
@@ -1,1 +1,1 @@
-Stop renovate from updating "engines"
+Stop renovate from bumping "engines"

--- a/.changelog/1452.trivial.md
+++ b/.changelog/1452.trivial.md
@@ -1,0 +1,1 @@
+Stop renovate from updating "engines"

--- a/renovate.json
+++ b/renovate.json
@@ -31,9 +31,11 @@
       "matchManagers": ["github-actions"]
     },
     {
-      "groupName": "Ignore package.json > engines",
+      "groupName": "Don't bump package.json > engines except for security",
+      "description": "https://github.com/renovatebot/renovate/discussions/13521",
       "packageNames": ["node"],
-      "enabled": false
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "auto"
     }
   ],
   "rangeStrategy": "bump"

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
     {
       "groupName": "CI github-actions",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "Ignore package.json > engines",
+      "packageNames": ["node"],
+      "enabled": false
     }
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
Prevent PRs like https://github.com/oasisprotocol/explorer/pull/1420 and https://github.com/oasisprotocol/explorer/pull/1447