### PR TITLE
Remove redundancy, simplify tx encryption status

### DIFF
--- a/.changelog/1453.internal.md
+++ b/.changelog/1453.internal.md
@@ -1,0 +1,1 @@
+Remove redundancy, simplify tx encryption status

--- a/src/app/components/TransactionEncryptionStatus/index.tsx
+++ b/src/app/components/TransactionEncryptionStatus/index.tsx
@@ -9,6 +9,7 @@ import { tooltipDelay } from '../../../styles/theme'
 
 type TransactionEncryptionStatusProps = {
   envelope?: RuntimeTransactionEncryptionEnvelope
+  withText?: boolean
 }
 
 export const TransactionEncrypted = () => {
@@ -41,5 +42,17 @@ export const TransactionNotEncrypted = () => {
   )
 }
 
-export const TransactionEncryptionStatus: FC<TransactionEncryptionStatusProps> = ({ envelope }) =>
-  envelope ? <TransactionEncrypted /> : <TransactionNotEncrypted />
+export const TransactionEncryptionStatus: FC<TransactionEncryptionStatusProps> = ({ envelope, withText }) => {
+  const { t } = useTranslation()
+  return envelope ? (
+    <>
+      {withText && <>{envelope.format} &nbsp;</>}
+      <TransactionEncrypted />
+    </>
+  ) : (
+    <>
+      {withText && <>{t('transactions.encryption.plain')} &nbsp;</>}
+      <TransactionNotEncrypted />
+    </>
+  )
+}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -29,7 +29,7 @@ import { getNameForTicker, Ticker } from '../../../types/ticker'
 import { AllTokenPrices, useAllTokenPrices } from '../../../coin-gecko/api'
 import { CurrentFiatValue } from './CurrentFiatValue'
 import { AddressSwitch, AddressSwitchOption } from '../../components/AddressSwitch'
-import { TransactionEncrypted, TransactionNotEncrypted } from '../../components/TransactionEncryptionStatus'
+import { TransactionEncryptionStatus } from '../../components/TransactionEncryptionStatus'
 import Typography from '@mui/material/Typography'
 import { LongDataDisplay } from '../../components/LongDataDisplay'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
@@ -230,15 +230,7 @@ export const RuntimeTransactionDetailView: FC<{
 
           <dt>{t('transactions.encryption.format')}</dt>
           <dd>
-            {transaction.encryption_envelope ? (
-              <>
-                {transaction.encryption_envelope.format} &nbsp; <TransactionEncrypted />
-              </>
-            ) : (
-              <>
-                {t('transactions.encryption.plain')} &nbsp; <TransactionNotEncrypted />
-              </>
-            )}
+            <TransactionEncryptionStatus envelope={transaction.encryption_envelope} withText={true} />
           </dd>
 
           <dt>{t('common.timestamp')}</dt>


### PR DESCRIPTION
We have a dedicated component for displaying encryption status for transactions.
Let's use it everywhere.
(For this, we need to extend the component a bit.)