### PR TITLE
Handle various proposal types titles

### DIFF
--- a/.changelog/1460.trivial.md
+++ b/.changelog/1460.trivial.md
@@ -1,0 +1,1 @@
+Handle various proposal type titles

--- a/src/app/components/NetworkProposalsList/index.tsx
+++ b/src/app/components/NetworkProposalsList/index.tsx
@@ -7,6 +7,7 @@ import { Proposal } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { RoundedBalance } from '../RoundedBalance'
 import { ProposalStatusIcon } from '../../components/Proposals/ProposalStatusIcon'
+import { getProposalTitle } from '../../utils/proposals'
 import { ProposalLink } from '../Proposals/ProposalLink'
 
 type NetworkProposalsListProps = {
@@ -45,7 +46,11 @@ export const NetworkProposalsList: FC<NetworkProposalsListProps> = ({
       {
         align: TableCellAlign.Left,
         content: (
-          <ProposalLink network={proposal.network} proposalId={proposal.id} label={proposal.handler} />
+          <ProposalLink
+            network={proposal.network}
+            proposalId={proposal.id}
+            label={getProposalTitle(proposal)}
+          />
         ),
         key: 'handler',
       },

--- a/src/app/components/NetworkProposalsList/index.tsx
+++ b/src/app/components/NetworkProposalsList/index.tsx
@@ -7,7 +7,6 @@ import { Proposal } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { RoundedBalance } from '../RoundedBalance'
 import { ProposalStatusIcon } from '../../components/Proposals/ProposalStatusIcon'
-import { getProposalTitle } from '../../utils/proposals'
 import { ProposalLink } from '../Proposals/ProposalLink'
 
 type NetworkProposalsListProps = {
@@ -45,13 +44,7 @@ export const NetworkProposalsList: FC<NetworkProposalsListProps> = ({
       },
       {
         align: TableCellAlign.Left,
-        content: (
-          <ProposalLink
-            network={proposal.network}
-            proposalId={proposal.id}
-            label={getProposalTitle(proposal)}
-          />
-        ),
+        content: <ProposalLink network={proposal.network} proposalId={proposal.id} label={proposal.title} />,
         key: 'handler',
       },
       ...(verbose

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -24,6 +24,7 @@ import { ProposalVotesCard } from './ProposalVotesCard'
 import { useVoteStats } from './hooks'
 import Skeleton from '@mui/material/Skeleton'
 import { getTypeNameForProposal } from '../../../types/proposalType'
+import { getProposalTitle } from '../../utils/proposals'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -110,7 +111,7 @@ export const ProposalDetailView: FC<{
 
       <dt>{t('common.title')}</dt>
       <dd>
-        <HighlightedText text={proposal.handler} pattern={highlightedPart} />
+        <HighlightedText text={getProposalTitle(proposal)} pattern={highlightedPart} />
       </dd>
 
       <dt>{t('common.type')}</dt>

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -24,7 +24,6 @@ import { ProposalVotesCard } from './ProposalVotesCard'
 import { useVoteStats } from './hooks'
 import Skeleton from '@mui/material/Skeleton'
 import { getTypeNameForProposal } from '../../../types/proposalType'
-import { getProposalTitle } from '../../utils/proposals'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -111,7 +110,7 @@ export const ProposalDetailView: FC<{
 
       <dt>{t('common.title')}</dt>
       <dd>
-        <HighlightedText text={getProposalTitle(proposal)} pattern={highlightedPart} />
+        <HighlightedText text={proposal.title} pattern={highlightedPart} />
       </dd>
 
       <dt>{t('common.type')}</dt>

--- a/src/app/utils/proposals.ts
+++ b/src/app/utils/proposals.ts
@@ -4,7 +4,7 @@ import { exhaustedTypeWarning } from 'types/errors'
 
 export const getCancelTitle = (cancelId: Proposal['cancels']) => `cancel-upgrade-${cancelId}`
 
-const parameterChangePrefix = 'parameter-change'
+const parameterChangePrefix = 'change-parameter'
 export const getParameterChangeTitle = (
   module: Proposal['parameters_change_module'],
   parameter: Proposal['parameters_change'],

--- a/src/app/utils/proposals.ts
+++ b/src/app/utils/proposals.ts
@@ -1,0 +1,34 @@
+import { Proposal } from 'oasis-nexus/api'
+import { detectProposalType, ProposalType } from '../../types/proposalType'
+import { exhaustedTypeWarning } from 'types/errors'
+
+export const getCancelTitle = (cancelId: Proposal['cancels']) => `cancel-upgrade-${cancelId}`
+
+const parameterChangePrefix = 'parameter-change'
+export const getParameterChangeTitle = (
+  module: Proposal['parameters_change_module'],
+  parameter: Proposal['parameters_change'],
+) => {
+  if (parameter && typeof parameter === 'object') {
+    const updatedParameters = Object.keys(parameter)
+      .filter(key => (parameter as Record<string, any>)[key] !== null)
+      .join(', ')
+    return `${parameterChangePrefix}-${module}-${updatedParameters}`
+  }
+  return parameterChangePrefix
+}
+
+export const getProposalTitle = (proposal: Proposal): string | undefined => {
+  const type = detectProposalType(proposal)
+
+  switch (type) {
+    case ProposalType.upgrade:
+      return proposal.handler!
+    case ProposalType.parameterUpgrade:
+      return getParameterChangeTitle(proposal.parameters_change_module, proposal.parameters_change)
+    case ProposalType.cancellation:
+      return getCancelTitle(proposal.cancels)
+    default:
+      exhaustedTypeWarning('Unexpected result type', type)
+  }
+}

--- a/src/app/utils/proposals.ts
+++ b/src/app/utils/proposals.ts
@@ -19,6 +19,11 @@ export const getParameterChangeTitle = (
 }
 
 export const getProposalTitle = (proposal: Proposal): string | undefined => {
+  // Oasis Core v24.0 introduced new, optional metadata like "title" for each proposal
+  if (proposal.title) {
+    return proposal.title
+  }
+
   const type = detectProposalType(proposal)
 
   switch (type) {

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -17,7 +17,7 @@ import {
   RuntimeEventType,
 } from './generated/api'
 import { getAccountSize, getEthAddressForAccount, getOasisAddressOrNull } from '../app/utils/helpers'
-import { getCancelTitle, getParameterChangeTitle } from '../app/utils/proposals'
+import { getCancelTitle, getParameterChangeTitle, getProposalTitle } from '../app/utils/proposals'
 import { Network } from '../types/network'
 import { SearchScope } from '../types/searchScope'
 import { Ticker } from '../types/ticker'
@@ -920,6 +920,7 @@ export const useGetConsensusProposals: typeof generated.useGetConsensusProposals
                 network,
                 layer: Layer.consensus,
                 deposit: fromBaseUnits(proposal.deposit, consensusDecimals),
+                title: getProposalTitle(proposal),
               }
             }),
           }
@@ -948,6 +949,7 @@ export const useGetConsensusProposalsProposalId: typeof generated.useGetConsensu
             network,
             layer: Layer.consensus,
             deposit: fromBaseUnits(data.deposit, consensusDecimals),
+            title: getProposalTitle(data),
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -961,6 +961,10 @@ export const useGetConsensusProposalsByName = (network: Network, nameFragment: s
   const { isError, isLoading, isInitialLoading, data, status, error } = query
   const textMatcher = nameFragment
     ? (proposal: generated.Proposal): boolean => {
+        if (proposal.title?.includes(nameFragment)) {
+          return true
+        }
+
         if (proposal.handler?.includes(nameFragment)) {
           return true
         }

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -17,6 +17,7 @@ import {
   RuntimeEventType,
 } from './generated/api'
 import { getAccountSize, getEthAddressForAccount, getOasisAddressOrNull } from '../app/utils/helpers'
+import { getCancelTitle, getParameterChangeTitle } from '../app/utils/proposals'
 import { Network } from '../types/network'
 import { SearchScope } from '../types/searchScope'
 import { Ticker } from '../types/ticker'
@@ -959,8 +960,22 @@ export const useGetConsensusProposalsByName = (network: Network, nameFragment: s
   const query = useGetConsensusProposals(network, {}, { query: { enabled: !!nameFragment } })
   const { isError, isLoading, isInitialLoading, data, status, error } = query
   const textMatcher = nameFragment
-    ? (proposal: generated.Proposal): boolean =>
-        !!proposal.handler && proposal.handler?.includes(nameFragment)
+    ? (proposal: generated.Proposal): boolean => {
+        if (proposal.handler?.includes(nameFragment)) {
+          return true
+        }
+
+        if (getCancelTitle(proposal.cancels).includes(nameFragment)) {
+          return true
+        }
+
+        return (
+          !!proposal.parameters_change &&
+          getParameterChangeTitle(proposal.parameters_change_module, proposal.parameters_change).includes(
+            nameFragment,
+          )
+        )
+      }
     : () => false
   const results = data ? query.data.data.proposals.filter(textMatcher) : undefined
   return {


### PR DESCRIPTION
~Waits for Nexus deploy https://github.com/oasisprotocol/nexus/pull/710.~

Avoid showing ID in title column, by handling each of proposal type (similar to oasis scan)

master
![Screenshot from 2024-08-14 08-53-28](https://github.com/user-attachments/assets/02547d4f-e24c-440d-9337-90b85dbee38c)
new https://2b966ccd.oasis-explorer.pages.dev/testnet/consensus/proposal 
![Screenshot from 2024-08-14 08-53-54](https://github.com/user-attachments/assets/8d488997-2a16-4105-b2a7-1bdc0b1ff348)

