### PR TITLE
Add details column to Consensus transactions list

### DIFF
--- a/.changelog/1472.trivial.md
+++ b/.changelog/1472.trivial.md
@@ -1,0 +1,1 @@
+Sync Consensus transactions list with updated designs

--- a/src/app/components/Transactions/ConsensusTransactionDetails.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionDetails.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { TFunction } from 'i18next'
 import Box from '@mui/material/Box'
 import { ConsensusTxMethod, Transaction } from '../../../oasis-nexus/api'
-import { From, Shares, To } from './TransactionDetailsElements'
+import { From, LabelValue, Shares, To } from './TransactionDetailsElements'
 import { useTranslation } from 'react-i18next'
 
 type ConsensusTransactionDetailsProps = {
@@ -17,13 +17,20 @@ export const ConsensusTransactionDetails: FC<ConsensusTransactionDetailsProps> =
   const { t } = useTranslation()
   const details = getConsensusTransactionDetails(t, transaction, ownAddress)
 
-  return <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '20px' }}>{details}</Box>
+  return <Box sx={{ display: 'flex', flexWrap: 'no-wrap', gap: '20px' }}>{details}</Box>
 }
 
 const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, ownAddress?: string) => {
   const scope = { layer: transaction.layer, network: transaction.network }
 
   switch (transaction.method) {
+    case ConsensusTxMethod.roothashExecutorCommit:
+      return (
+        <>
+          <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
+          <LabelValue label={t('common.id')} value={transaction.body?.id} trimMobile />
+        </>
+      )
     case ConsensusTxMethod.stakingAddEscrow:
       return (
         <>

--- a/src/app/components/Transactions/ConsensusTransactionDetails.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionDetails.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react'
+import { TFunction } from 'i18next'
+import Box from '@mui/material/Box'
+import { ConsensusTxMethod, Transaction } from '../../../oasis-nexus/api'
+import { From, Shares, To } from './TransactionDetailsElements'
+import { useTranslation } from 'react-i18next'
+
+type ConsensusTransactionDetailsProps = {
+  ownAddress?: string
+  transaction: Transaction
+}
+
+export const ConsensusTransactionDetails: FC<ConsensusTransactionDetailsProps> = ({
+  ownAddress,
+  transaction,
+}) => {
+  const { t } = useTranslation()
+  const details = getConsensusTransactionDetails(t, transaction, ownAddress)
+
+  return <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '20px' }}>{details}</Box>
+}
+
+const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, ownAddress?: string) => {
+  const scope = { layer: transaction.layer, network: transaction.network }
+
+  switch (transaction.method) {
+    case ConsensusTxMethod.stakingAddEscrow:
+      return (
+        <>
+          <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
+          <To address={transaction.body.account} label={t('validator.title')} scope={scope} />
+        </>
+      )
+    case ConsensusTxMethod.stakingAllow:
+      return (
+        <>
+          <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
+          <To address={transaction.body.beneficiary} label={t('common.recipient')} scope={scope} />
+        </>
+      )
+    case ConsensusTxMethod.stakingReclaimEscrow:
+      return (
+        <>
+          <From address={transaction.body.account} ownAddress={ownAddress} scope={scope} />
+          <To address={transaction.sender} scope={scope} />
+          <Shares value={transaction.body.shares} />
+        </>
+      )
+    case ConsensusTxMethod.stakingTransfer:
+      return (
+        <>
+          <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
+          <To address={transaction.body.to} scope={scope} />
+        </>
+      )
+    default:
+      return (
+        <From
+          address={transaction.sender}
+          ownAddress={ownAddress}
+          scope={{ layer: transaction.layer, network: transaction.network }}
+        />
+      )
+  }
+}

--- a/src/app/components/Transactions/ConsensusTransactionDetails.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionDetails.tsx
@@ -35,7 +35,13 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} label={t('validator.title')} ownAddress={ownAddress} scope={scope} />
+          <To
+            address={transaction.to}
+            label={t('validator.title')}
+            ownAddress={ownAddress}
+            scope={scope}
+            type="validator"
+          />
         </>
       )
     case ConsensusTxMethod.stakingAllow:
@@ -49,7 +55,13 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} scope={scope} ownAddress={ownAddress} />
+          <To
+            address={transaction.to}
+            label={t('validator.title')}
+            scope={scope}
+            ownAddress={ownAddress}
+            type="validator"
+          />
           <Shares value={transaction.body.shares} />
         </>
       )

--- a/src/app/components/Transactions/ConsensusTransactionDetails.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionDetails.tsx
@@ -35,21 +35,21 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.body.account} label={t('validator.title')} scope={scope} />
+          <To address={transaction.to} label={t('validator.title')} scope={scope} />
         </>
       )
     case ConsensusTxMethod.stakingAllow:
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.body.beneficiary} label={t('common.recipient')} scope={scope} />
+          <To address={transaction.to} label={t('common.recipient')} scope={scope} />
         </>
       )
     case ConsensusTxMethod.stakingReclaimEscrow:
       return (
         <>
-          <From address={transaction.body.account} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.sender} scope={scope} />
+          <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
+          <To address={transaction.to} scope={scope} />
           <Shares value={transaction.body.shares} />
         </>
       )
@@ -57,7 +57,7 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.body.to} scope={scope} />
+          <To address={transaction.to} scope={scope} />
         </>
       )
     default:

--- a/src/app/components/Transactions/ConsensusTransactionDetails.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionDetails.tsx
@@ -35,21 +35,21 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} label={t('validator.title')} scope={scope} />
+          <To address={transaction.to} label={t('validator.title')} ownAddress={ownAddress} scope={scope} />
         </>
       )
     case ConsensusTxMethod.stakingAllow:
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} label={t('common.recipient')} scope={scope} />
+          <To address={transaction.to} label={t('common.recipient')} ownAddress={ownAddress} scope={scope} />
         </>
       )
     case ConsensusTxMethod.stakingReclaimEscrow:
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} scope={scope} />
+          <To address={transaction.to} scope={scope} ownAddress={ownAddress} />
           <Shares value={transaction.body.shares} />
         </>
       )
@@ -57,7 +57,7 @@ const getConsensusTransactionDetails = (t: TFunction, transaction: Transaction, 
       return (
         <>
           <From address={transaction.sender} ownAddress={ownAddress} scope={scope} />
-          <To address={transaction.to} scope={scope} />
+          <To address={transaction.to} ownAddress={ownAddress} scope={scope} />
         </>
       )
     default:

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -26,7 +26,6 @@ type ConsensusTransactionsProps = {
   isLoading: boolean
   limit: number
   pagination: false | TablePaginationProps
-  verbose?: boolean
 }
 
 export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
@@ -35,7 +34,6 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
   pagination,
   transactions,
   ownAddress,
-  verbose = true,
 }) => {
   const { t } = useTranslation()
 
@@ -44,7 +42,7 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
     { key: 'hash', content: t('common.hash') },
     { key: 'age', content: t('common.age') },
     { key: 'type', content: t('common.type') },
-    ...(verbose ? [{ key: 'details', content: t('common.details') }] : []),
+    { key: 'details', content: t('common.details') },
     { align: TableCellAlign.Right, key: 'value', content: t('common.amount') },
   ]
 
@@ -68,14 +66,11 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
           content: <ConsensusTransactionMethod method={transaction.method} truncate />,
           key: 'method',
         },
-        ...(verbose
-          ? [
-              {
-                content: <ConsensusTransactionDetails ownAddress={ownAddress} transaction={transaction} />,
-                key: 'details',
-              },
-            ]
-          : []),
+
+        {
+          content: <ConsensusTransactionDetails ownAddress={ownAddress} transaction={transaction} />,
+          key: 'details',
+        },
         {
           align: TableCellAlign.Right,
           content: (

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -8,6 +8,7 @@ import { StatusIcon } from '../StatusIcon'
 import { Age } from '../Age'
 import { TransactionLink } from './TransactionLink'
 import { ConsensusTransactionMethod } from '../ConsensusTransactionMethod'
+import { ConsensusTransactionDetails } from './ConsensusTransactionDetails'
 
 type TableConsensusTransaction = Transaction & {
   markAsNew?: boolean
@@ -70,14 +71,19 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
         ...(verbose
           ? [
               {
-                content: <></>,
+                content: <ConsensusTransactionDetails ownAddress={ownAddress} transaction={transaction} />,
                 key: 'details',
               },
             ]
           : []),
         {
           align: TableCellAlign.Right,
-          content: <RoundedBalance value={transaction.body.amount} ticker={transaction.ticker} />,
+          content: (
+            <RoundedBalance
+              value={transaction.body?.amount || transaction.body?.amount_change}
+              ticker={transaction.ticker}
+            />
+          ),
           key: 'amount',
         },
       ],

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -1,12 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
 import { Transaction } from '../../../oasis-nexus/api'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { RoundedBalance } from '../../components/RoundedBalance'
 import { TablePaginationProps } from '../Table/TablePagination'
-import { BlockLink } from '../Blocks/BlockLink'
-import { AccountLink } from '../Account/AccountLink'
 import { StatusIcon } from '../StatusIcon'
 import { Age } from '../Age'
 import { TransactionLink } from './TransactionLink'
@@ -44,21 +41,13 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
   const tableColumns: TableColProps[] = [
     { key: 'status', content: t('common.status') },
     { key: 'hash', content: t('common.hash') },
-    { key: 'block', content: t('common.block') },
     { key: 'age', content: t('common.age') },
-    ...(verbose
-      ? [
-          { key: 'method', content: t('common.method') },
-          { key: 'from', content: t('common.from'), width: '150px' },
-          { key: 'to', content: t('common.to'), width: '150px' },
-          { key: 'txnFee', content: t('common.transactionFee'), align: TableCellAlign.Right, width: '250px' },
-          { key: 'value', align: TableCellAlign.Right, content: t('common.value'), width: '250px' },
-        ]
-      : []),
+    { key: 'type', content: t('common.type') },
+    ...(verbose ? [{ key: 'details', content: t('common.details') }] : []),
+    { align: TableCellAlign.Right, key: 'value', content: t('common.amount') },
   ]
 
   const tableRows = transactions?.map(transaction => {
-    const targetAddress = transaction.body.to || transaction.body.account
     return {
       key: `${transaction.hash}${transaction.index}`,
       data: [
@@ -71,63 +60,26 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
           key: 'hash',
         },
         {
-          content: <BlockLink scope={transaction} height={transaction.block} />,
-          key: 'round',
-        },
-        {
           content: <Age sinceTimestamp={transaction.timestamp} />,
           key: 'timestamp',
+        },
+        {
+          content: <ConsensusTransactionMethod method={transaction.method} truncate />,
+          key: 'method',
         },
         ...(verbose
           ? [
               {
-                content: <ConsensusTransactionMethod method={transaction.method} truncate />,
-                key: 'method',
-              },
-              {
-                align: TableCellAlign.Right,
-                content: (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      position: 'relative',
-                      pr: 3,
-                    }}
-                  >
-                    <AccountLink
-                      labelOnly={transaction.sender === ownAddress}
-                      scope={transaction}
-                      address={transaction.sender}
-                      alwaysTrim
-                    />
-                  </Box>
-                ),
-                key: 'from',
-              },
-              {
-                content: targetAddress ? (
-                  <AccountLink
-                    labelOnly={targetAddress === ownAddress}
-                    scope={transaction}
-                    address={targetAddress}
-                    alwaysTrim
-                  />
-                ) : null,
-                key: 'to',
-              },
-              {
-                align: TableCellAlign.Right,
-                content: <RoundedBalance value={transaction.fee} ticker={transaction.ticker} />,
-                key: 'fee_amount',
-              },
-              {
-                align: TableCellAlign.Right,
-                content: <RoundedBalance value={transaction.body.amount} ticker={transaction.ticker} />,
-                key: 'value',
+                content: <></>,
+                key: 'details',
               },
             ]
           : []),
+        {
+          align: TableCellAlign.Right,
+          content: <RoundedBalance value={transaction.body.amount} ticker={transaction.ticker} />,
+          key: 'amount',
+        },
       ],
       highlight: transaction.markAsNew,
     }

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -43,10 +43,11 @@ export const From: FC<FromProps> = ({ address, ownAddress, scope }) => {
 type ToProps = {
   address: string | undefined
   label?: string
+  ownAddress?: string
   scope: SearchScope
 }
 
-export const To: FC<ToProps> = ({ address, label, scope }) => {
+export const To: FC<ToProps> = ({ address, label, ownAddress, scope }) => {
   const { t } = useTranslation()
 
   if (!address) {
@@ -56,7 +57,7 @@ export const To: FC<ToProps> = ({ address, label, scope }) => {
   return (
     <Box sx={{ display: 'inline-flex' }}>
       <Label>{label || t('common.to')}</Label>
-      <AccountLink scope={scope} address={address} alwaysTrim />
+      <AccountLink labelOnly={address === ownAddress} scope={scope} address={address} alwaysTrim />
     </Box>
   )
 }

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -24,6 +24,10 @@ type FromProps = {
 export const From: FC<FromProps> = ({ address, ownAddress, scope }) => {
   const { t } = useTranslation()
 
+  if (!address) {
+    return null
+  }
+
   return (
     <Box sx={{ display: 'inline-flex' }}>
       <Label>{t('common.from')}</Label>
@@ -41,6 +45,10 @@ type ToProps = {
 export const To: FC<ToProps> = ({ address, label, scope }) => {
   const { t } = useTranslation()
 
+  if (!address) {
+    return null
+  }
+
   return (
     <Box sx={{ display: 'inline-flex' }}>
       <Label>{label || t('common.to')}</Label>
@@ -55,6 +63,10 @@ type SharesProps = {
 
 export const Shares: FC<SharesProps> = ({ value }) => {
   const { t } = useTranslation()
+
+  if (!value) {
+    return null
+  }
 
   return (
     <Box sx={{ display: 'inline-flex' }}>

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -5,6 +5,8 @@ import Typography from '@mui/material/Typography'
 import { SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
 import { RoundedBalance } from '../../components/RoundedBalance'
+import { trimLongString } from '../../utils/trimLongString'
+import { useScreenSize } from '../../hooks/useScreensize'
 import { AccountLink } from '../Account/AccountLink'
 
 const Label: FC<PropsWithChildren> = ({ children }) => {
@@ -74,6 +76,25 @@ export const Shares: FC<SharesProps> = ({ value }) => {
       <Typography fontWeight={700}>
         <RoundedBalance compactLargeNumbers value={value} />
       </Typography>
+    </Box>
+  )
+}
+
+type LabelValueProps = {
+  label?: string
+  trimMobile?: boolean
+  value: string
+}
+
+export const LabelValue: FC<LabelValueProps> = ({ label, trimMobile, value }) => {
+  const { t } = useTranslation()
+  const { isTablet } = useScreenSize()
+  const trimEnabled = trimMobile && isTablet
+
+  return (
+    <Box sx={{ display: 'inline-flex' }}>
+      <Label>{label || t('common.value')}</Label>
+      <Typography variant="mono">{trimEnabled ? trimLongString(value, 2, 18) : value}</Typography>
     </Box>
   )
 }

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -39,7 +39,7 @@ export const From: FC<FromProps> = ({ address, ownAddress, scope }) => {
 }
 
 type ToProps = {
-  address: string
+  address: string | undefined
   label?: string
   scope: SearchScope
 }

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -10,6 +10,7 @@ import { RoundedBalance } from '../../components/RoundedBalance'
 import { trimLongString } from '../../utils/trimLongString'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { AccountLink } from '../Account/AccountLink'
+import { ValidatorLink } from '../Validators/ValidatorLink'
 
 const Label: FC<PropsWithChildren> = ({ children }) => {
   return (
@@ -45,9 +46,10 @@ type ToProps = {
   label?: string
   ownAddress?: string
   scope: SearchScope
+  type?: 'account' | 'validator'
 }
 
-export const To: FC<ToProps> = ({ address, label, ownAddress, scope }) => {
+export const To: FC<ToProps> = ({ address, label, ownAddress, scope, type = 'account' }) => {
   const { t } = useTranslation()
 
   if (!address) {
@@ -57,7 +59,10 @@ export const To: FC<ToProps> = ({ address, label, ownAddress, scope }) => {
   return (
     <Box sx={{ display: 'inline-flex' }}>
       <Label>{label || t('common.to')}</Label>
-      <AccountLink labelOnly={address === ownAddress} scope={scope} address={address} alwaysTrim />
+      {type === 'account' && (
+        <AccountLink labelOnly={address === ownAddress} scope={scope} address={address} alwaysTrim />
+      )}
+      {type === 'validator' && <ValidatorLink network={scope.network} address={address} alwaysTrim />}
     </Box>
   )
 }

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -1,0 +1,67 @@
+import { FC, PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { SearchScope } from '../../../types/searchScope'
+import { COLORS } from '../../../styles/theme/colors'
+import { RoundedBalance } from '../../components/RoundedBalance'
+import { AccountLink } from '../Account/AccountLink'
+
+const Label: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <Typography color={COLORS.grayDark} sx={{ paddingRight: 4 }}>
+      {children}
+    </Typography>
+  )
+}
+
+type FromProps = {
+  address: string
+  ownAddress?: string
+  scope: SearchScope
+}
+
+export const From: FC<FromProps> = ({ address, ownAddress, scope }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ display: 'inline-flex' }}>
+      <Label>{t('common.from')}</Label>
+      <AccountLink labelOnly={address === ownAddress} scope={scope} address={address} alwaysTrim />
+    </Box>
+  )
+}
+
+type ToProps = {
+  address: string
+  label?: string
+  scope: SearchScope
+}
+
+export const To: FC<ToProps> = ({ address, label, scope }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ display: 'inline-flex' }}>
+      <Label>{label || t('common.to')}</Label>
+      <AccountLink scope={scope} address={address} alwaysTrim />
+    </Box>
+  )
+}
+
+type SharesProps = {
+  value: string
+}
+
+export const Shares: FC<SharesProps> = ({ value }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ display: 'inline-flex' }}>
+      <Label>{t('common.shares')}</Label>
+      <Typography fontWeight={700}>
+        <RoundedBalance compactLargeNumbers value={value} />
+      </Typography>
+    </Box>
+  )
+}

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -1,9 +1,11 @@
 import { FC, PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
+import { tooltipDelay } from '../../../styles/theme'
 import { RoundedBalance } from '../../components/RoundedBalance'
 import { trimLongString } from '../../utils/trimLongString'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -94,7 +96,13 @@ export const LabelValue: FC<LabelValueProps> = ({ label, trimMobile, value }) =>
   return (
     <Box sx={{ display: 'inline-flex' }}>
       <Label>{label || t('common.value')}</Label>
-      <Typography variant="mono">{trimEnabled ? trimLongString(value, 2, 18) : value}</Typography>
+      {trimEnabled ? (
+        <Tooltip arrow placement="top" title={value} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
+          <Typography variant="mono">{trimLongString(value, 2, 18)}</Typography>
+        </Tooltip>
+      ) : (
+        <Typography variant="mono">{value}</Typography>
+      )}
     </Box>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -10,10 +10,8 @@ import { SearchScope } from '../../../types/searchScope'
 import { ConsensusTransactions } from '../../components/Transactions'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD as limit } from '../../config'
 import { RouteUtils } from '../../utils/route-utils'
-import { useScreenSize } from '../../hooks/useScreensize'
 
 export const LatestConsensusTransactions: FC<{ scope: SearchScope }> = ({ scope }) => {
-  const { isTablet } = useScreenSize()
   const { t } = useTranslation()
   const { network } = scope
 
@@ -45,7 +43,6 @@ export const LatestConsensusTransactions: FC<{ scope: SearchScope }> = ({ scope 
           isLoading={transactionsQuery.isLoading}
           limit={limit}
           pagination={false}
-          verbose={!isTablet}
         />
       </CardContent>
     </Card>

--- a/src/app/utils/transaction.ts
+++ b/src/app/utils/transaction.ts
@@ -3,7 +3,7 @@ import { ConsensusTxMethod, Transaction } from '../../oasis-nexus/api'
 export const getConsensusTransactionToAddress = (transaction: Transaction) => {
   switch (transaction.method) {
     case ConsensusTxMethod.stakingAddEscrow:
-      return transaction.body?.address
+      return transaction.body?.account
     case ConsensusTxMethod.stakingAllow:
       return transaction.body?.beneficiary
     case ConsensusTxMethod.stakingReclaimEscrow:

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -95,6 +95,7 @@
     "hash": "Hash",
     "height": "Height",
     "hide": "Hide",
+    "id": "ID",
     "invalidVotes": "Invalid votes",
     "layer": "Layer",
     "loadMore": "Load more",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -154,6 +154,7 @@
     "votes": "Votes",
     "paraTimeOnline": "ParaTime Online",
     "paraTimeOutOfDate": "ParaTime Out of date",
+    "recipient": "Recipient",
     "mainnet": "Mainnet",
     "testnet": "Testnet",
     "valuePair": "{{value, number}}"
@@ -414,7 +415,7 @@
       "stakingAddEscrow": "Start delegate",
       "stakingReclaimEscrow": "Start undelegate",
       "stakingAmendCommissionSchedule": "Amend commission schedule",
-      "stakingAllow": "Set delegate allowance",
+      "stakingAllow": "Allowance Change",
       "stakingWithdraw": "Continued delegate",
       "roothashExecutorCommit": "Executor commit",
       "roothashExecutorProposerTimeout": "Executor proposer timeout",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -63,6 +63,7 @@
   "common": {
     "address": "Address",
     "age": "Age",
+    "amount": "Amount",
     "balance": "Balance",
     "block": "Block",
     "blockSizeLimit": "Block size limit",
@@ -74,6 +75,7 @@
     "copy": "Copy",
     "data": "Data",
     "debonding": "Debonding",
+    "details": "Details",
     "emerald": "Emerald",
     "epoch": "Epoch",
     "cipher": "Cipher",
@@ -97,7 +99,6 @@
     "layer": "Layer",
     "loadMore": "Load more",
     "lessThanAmount": "&lt; {{value, number}} <TickerLink />",
-    "method": "Method",
     "missing": "n/a",
     "name": "Name",
     "network": "Network",

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -174,8 +174,12 @@ export const useGetConsensusTransactions: typeof generated.useGetConsensusTransa
           return {
             ...data,
             transactions: data.transactions.map(tx => {
+              const amount = getConsensusTransactionAmount(tx)
+              const to = getConsensusTransactionToAddress(tx)
               return {
                 ...tx,
+                amount: amount ? fromBaseUnits(amount, consensusDecimals) : undefined,
+                to,
                 network,
                 layer: Layer.consensus,
                 ticker,

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -182,6 +182,9 @@ export const useGetConsensusTransactions: typeof generated.useGetConsensusTransa
                 body: {
                   ...tx.body,
                   amount: tx.body?.amount ? fromBaseUnits(tx.body.amount, consensusDecimals) : undefined,
+                  amount_change: tx.body?.amount_change
+                    ? fromBaseUnits(tx.body.amount_change, consensusDecimals)
+                    : undefined,
                 },
               }
             }),

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -106,6 +106,43 @@ const mockedTransactions = [
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
+
+    block: 19969802,
+    body: {
+      commits: [
+        {
+          header: {
+            header: {
+              in_msgs_hash: 'c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a',
+              io_root: '6a134a3102e3ea9f4871ece1c5824ce06f4dc06571e0e5dd04e7e282a6348991',
+              messages_hash: 'c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a',
+              previous_hash: 'ebb7743594d53594f95585de30b563042724f3d48ac9c7c37b292c299d7b8ddd',
+              round: 4419548,
+              state_root: '77824195a9191c802cd83af14a2bdbb974eb16919e5a333cf03f81dc1dc1d688',
+            },
+            rak_sig:
+              'OyaCvwnekOqKv+3ymvXJzoQulhb7KVun6g8F2kWabeUXShPxGnFt9JR8J7JEV7Fgs7vlAdjkduSDN2n2GZdJDw==',
+            scheduler_id: 'drsZxbpqG5h+4tq/JKWqmoVGXmQUirVCjD8GLBuNj9M=',
+          },
+          node_id: 'UCKrtVNlmCaCdKpMMDT8AQxqVs/JP1/zQUH4yxUY4mM=',
+          sig: 'DGs5KVnCg2EqArJ4yqFufta0ujGiSFzVQlpi0E8LgOIGztiSpnhhk6ktwB7s/Xe5dYSugPeKpCAxwgtgKpoLBw==',
+        },
+      ],
+      id: '000000000000000000000000000000000000000000000000f80306c9858e7279',
+    },
+    fee: '0',
+    hash: '11c58dc52abba9cf838b87bf9aa691dac5aef96c84428aa608a67a2b3a206f46',
+    index: 0,
+    method: ConsensusTxMethod.roothashExecutorCommit,
+    nonce: 942923,
+    sender: 'oasis1qrxvr94pgj6kt36fkwn4al3uttj2veh5ey8jvapv',
+    success: true,
+    timestamp: '2024-07-03T10:12:47Z',
+  },
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
     sender: 'oasis1qzyw98s2qrvf3t78nf0guu98laykw6lzkga5zlzy',
     success: true,
     timestamp: '2024-07-03T09:23:32Z',

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -31,6 +31,8 @@ export const ConsensusList: StoryObj = {
 
 const mockedTransactions = [
   {
+    amount: '100',
+    to: 'oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev',
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
@@ -40,6 +42,7 @@ const mockedTransactions = [
       amount: '100',
     },
     fee: '0',
+    gas_limit: '0',
     hash: 'd46e9223c45bd52d885673dd574f008b5e377ad879adb08f52af53c292151984',
     index: 26,
     method: ConsensusTxMethod.stakingAddEscrow,
@@ -49,6 +52,8 @@ const mockedTransactions = [
     timestamp: '2024-06-25T06:52:19Z',
   },
   {
+    amount: '10',
+    to: 'oasis1qrd3mnzhhgst26hsp96uf45yhq6zlax0cuzdgcfc',
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
@@ -58,6 +63,7 @@ const mockedTransactions = [
       beneficiary: 'oasis1qrd3mnzhhgst26hsp96uf45yhq6zlax0cuzdgcfc',
     },
     fee: '0',
+    gas_limit: '0',
     hash: '2c849b3b9aaf63d73c35502af5b3bbf5881439288ebe3153966c6b78891d1978',
     index: 26,
     method: ConsensusTxMethod.stakingAllow,
@@ -67,6 +73,8 @@ const mockedTransactions = [
     timestamp: '2024-04-15T07:09:52Z',
   },
   {
+    amount: undefined,
+    to: 'oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt',
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
@@ -76,6 +84,7 @@ const mockedTransactions = [
       shares: '30027579719',
     },
     fee: '0',
+    gas_limit: '0',
     hash: 'e8ca2ea8f664d668603178687bc335c6ebb79dce716ce4e54f33d14a57f9fa5e',
     index: 25,
     method: ConsensusTxMethod.stakingReclaimEscrow,
@@ -85,6 +94,8 @@ const mockedTransactions = [
     timestamp: '2024-06-25T06:53:53Z',
   },
   {
+    amount: '100',
+    to: 'oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn',
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
@@ -94,6 +105,7 @@ const mockedTransactions = [
       to: 'oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn',
     },
     fee: '0',
+    gas_limit: '0',
     hash: 'a06aa6c1535727a1f578638b3754e8feff34293f26449b76cf80d94f216d22ff',
     index: 25,
     method: ConsensusTxMethod.stakingTransfer,
@@ -103,10 +115,11 @@ const mockedTransactions = [
     timestamp: '2024-07-03T09:23:32Z',
   },
   {
+    amount: undefined,
+    to: undefined,
     network: Network.mainnet,
     layer: Layer.consensus,
     ticker: Ticker.ROSE,
-
     block: 19969802,
     body: {
       commits: [
@@ -131,6 +144,7 @@ const mockedTransactions = [
       id: '000000000000000000000000000000000000000000000000f80306c9858e7279',
     },
     fee: '0',
+    gas_limit: '0',
     hash: '11c58dc52abba9cf838b87bf9aa691dac5aef96c84428aa608a67a2b3a206f46',
     index: 0,
     method: ConsensusTxMethod.roothashExecutorCommit,
@@ -140,8 +154,11 @@ const mockedTransactions = [
     timestamp: '2024-07-03T10:12:47Z',
   },
   {
+    amount: undefined,
+    to: undefined,
     network: Network.mainnet,
     layer: Layer.consensus,
+    hash: '11c58dc52abba9cf838b87bf9aa691dac5aef96c84428aa608a67a2b3a206f46',
     ticker: Ticker.ROSE,
     sender: 'oasis1qzyw98s2qrvf3t78nf0guu98laykw6lzkga5zlzy',
     success: true,

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -1,0 +1,113 @@
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { withRouter } from 'storybook-addon-react-router-v6'
+import Box from '@mui/material/Box'
+import { ConsensusTransactions } from '../app/components/Transactions'
+import { ConsensusTxMethod, Layer, Transaction } from '../oasis-nexus/api'
+import { Network } from '../types/network'
+import { Ticker } from '../types/ticker'
+
+export default {
+  title: 'Example/Transactions',
+  decorators: [withRouter],
+} satisfies Meta<any>
+
+const ConsensusListStory: StoryFn = () => {
+  return (
+    <Box>
+      <ConsensusTransactions
+        isLoading={false}
+        limit={100}
+        pagination={false}
+        transactions={mockedTransactions}
+      />
+    </Box>
+  )
+}
+
+export const ConsensusList: StoryObj = {
+  render: ConsensusListStory,
+  args: {},
+}
+
+const mockedTransactions = [
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
+    block: 19851448,
+    body: {
+      account: 'oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev',
+      amount: '100',
+    },
+    fee: '0',
+    hash: 'd46e9223c45bd52d885673dd574f008b5e377ad879adb08f52af53c292151984',
+    index: 26,
+    method: ConsensusTxMethod.stakingAddEscrow,
+    nonce: 275,
+    sender: 'oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk',
+    success: true,
+    timestamp: '2024-06-25T06:52:19Z',
+  },
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
+    block: 18818862,
+    body: {
+      amount_change: '10',
+      beneficiary: 'oasis1qrd3mnzhhgst26hsp96uf45yhq6zlax0cuzdgcfc',
+    },
+    fee: '0',
+    hash: '2c849b3b9aaf63d73c35502af5b3bbf5881439288ebe3153966c6b78891d1978',
+    index: 26,
+    method: ConsensusTxMethod.stakingAllow,
+    nonce: 266,
+    sender: 'oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk',
+    success: true,
+    timestamp: '2024-04-15T07:09:52Z',
+  },
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
+    block: 19851464,
+    body: {
+      account: 'oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt',
+      shares: '30027579719',
+    },
+    fee: '0',
+    hash: 'e8ca2ea8f664d668603178687bc335c6ebb79dce716ce4e54f33d14a57f9fa5e',
+    index: 25,
+    method: ConsensusTxMethod.stakingReclaimEscrow,
+    nonce: 277,
+    sender: 'oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk',
+    success: true,
+    timestamp: '2024-06-25T06:53:53Z',
+  },
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
+    block: 19969302,
+    body: {
+      amount: '100',
+      to: 'oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn',
+    },
+    fee: '0',
+    hash: 'a06aa6c1535727a1f578638b3754e8feff34293f26449b76cf80d94f216d22ff',
+    index: 25,
+    method: ConsensusTxMethod.stakingTransfer,
+    nonce: 322926,
+    sender: 'oasis1qzyw98s2qrvf3t78nf0guu98laykw6lzkga5zlzy',
+    success: true,
+    timestamp: '2024-07-03T09:23:32Z',
+  },
+  {
+    network: Network.mainnet,
+    layer: Layer.consensus,
+    ticker: Ticker.ROSE,
+    sender: 'oasis1qzyw98s2qrvf3t78nf0guu98laykw6lzkga5zlzy',
+    success: true,
+    timestamp: '2024-07-03T09:23:32Z',
+  } as Transaction,
+]


### PR DESCRIPTION
- adds details row. The way how each method details will look like is not defined yet and we will narrow this down during a meeting (handle more types via `getConsensusTransactionDetails`)
- currently older transactions are not correctly indexed by Nexus. Older txs will show empty details in most cases, but recent one are Ok for testing

TODO:
- [x] keep hash column
