### PR TITLE
Automatically throw on 5xx error responses

### DIFF
--- a/.changelog/1493.bugfix.md
+++ b/.changelog/1493.bugfix.md
@@ -1,0 +1,1 @@
+Automatically throw on 5xx error responses

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -15,7 +15,7 @@ import { UseQueryResult } from '@tanstack/react-query'
 export const useIsApiReachable = (
   network: Network,
 ): { reachable: true } | { reachable: false; reason: 'userOffline' | 'apiOffline' } => {
-  const query = useGetStatus(network)
+  const query = useGetStatus(network, { query: { useErrorBoundary: false } })
   if (query.isPaused) return { reachable: false, reason: 'userOffline' }
   if (query.isFetched && !query.isSuccess) return { reachable: false, reason: 'apiOffline' }
   return { reachable: true }
@@ -80,7 +80,7 @@ export const useConsensusFreshness = (
   queryParams: { polling?: boolean } = {},
 ): FreshnessInfo => {
   const query = useGetStatus(network, {
-    query: { refetchInterval: queryParams.polling ? 8000 : undefined },
+    query: { refetchInterval: queryParams.polling ? 8000 : undefined, useErrorBoundary: false },
   })
 
   return useFreshness(network, query)
@@ -95,7 +95,7 @@ export const useRuntimeFreshness = (
   }
 
   const query = useGetRuntimeStatus(scope.network, scope.layer, {
-    query: { refetchInterval: queryParams.polling ? 8000 : undefined },
+    query: { refetchInterval: queryParams.polling ? 8000 : undefined, useErrorBoundary: false },
   })
 
   return useFreshness(scope.network, query)

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import {
   Layer,
   useGetConsensusAccountsAddresses,
@@ -65,12 +65,11 @@ const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise
 export const useOasisAccountsMetadata = (
   network: Network,
   layer: Layer,
-  queryOptions: { enabled: boolean; useErrorBoundary?: boolean },
+  queryOptions: UseQueryOptions<AccountData, unknown, AccountData, string[]>,
 ) => {
   return useQuery(['oasisAccounts', network, layer], () => getOasisAccountsMetadata(network, layer), {
-    enabled: queryOptions.enabled,
     staleTime: Infinity,
-    useErrorBoundary: queryOptions.useErrorBoundary,
+    ...queryOptions,
   })
 }
 
@@ -78,7 +77,7 @@ export const useOasisAccountMetadata = (
   network: Network,
   layer: Layer,
   address: string,
-  queryOptions: { enabled: boolean; useErrorBoundary?: boolean },
+  queryOptions: UseQueryOptions<AccountData, unknown, AccountData, string[]>,
 ): AccountMetadataInfo => {
   const { isLoading, isError, error, data: allData } = useOasisAccountsMetadata(network, layer, queryOptions)
   if (isError) {
@@ -95,14 +94,14 @@ export const useSearchForOasisAccountsByName = (
   network: Network,
   layer: Layer,
   nameFragment: string,
-  queryOptions: { enabled: boolean },
+  queryOptions: { enabled: boolean } & UseQueryOptions<AccountData, unknown, AccountData, string[]>,
 ): AccountNameSearchResults => {
   const {
     isLoading: isMetadataLoading,
     isError: isMetadataError,
     error: metadataError,
     data: namedAccounts,
-  } = useOasisAccountsMetadata(network, layer, { ...queryOptions, useErrorBoundary: false })
+  } = useOasisAccountsMetadata(network, layer, { useErrorBoundary: false, ...queryOptions })
   if (isMetadataError) {
     console.log('Failed to load Oasis account metadata', metadataError)
   }

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -65,11 +65,12 @@ const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise
 export const useOasisAccountsMetadata = (
   network: Network,
   layer: Layer,
-  queryOptions: { enabled: boolean },
+  queryOptions: { enabled: boolean; useErrorBoundary?: boolean },
 ) => {
   return useQuery(['oasisAccounts', network, layer], () => getOasisAccountsMetadata(network, layer), {
     enabled: queryOptions.enabled,
     staleTime: Infinity,
+    useErrorBoundary: queryOptions.useErrorBoundary,
   })
 }
 
@@ -77,7 +78,7 @@ export const useOasisAccountMetadata = (
   network: Network,
   layer: Layer,
   address: string,
-  queryOptions: { enabled: boolean },
+  queryOptions: { enabled: boolean; useErrorBoundary?: boolean },
 ): AccountMetadataInfo => {
   const { isLoading, isError, error, data: allData } = useOasisAccountsMetadata(network, layer, queryOptions)
   if (isError) {
@@ -101,7 +102,7 @@ export const useSearchForOasisAccountsByName = (
     isError: isMetadataError,
     error: metadataError,
     data: namedAccounts,
-  } = useOasisAccountsMetadata(network, layer, queryOptions)
+  } = useOasisAccountsMetadata(network, layer, { ...queryOptions, useErrorBoundary: false })
   if (isMetadataError) {
     console.log('Failed to load Oasis account metadata', metadataError)
   }

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -34,16 +34,20 @@ const getPontusXAccountsMetadata = async () => {
   }
 }
 
-export const usePontusXAccountsMetadata = (queryOptions: { enabled: boolean }) => {
+export const usePontusXAccountsMetadata = (queryOptions: {
+  enabled: boolean
+  useErrorBoundary?: boolean
+}) => {
   return useQuery(['pontusXNames'], getPontusXAccountsMetadata, {
     enabled: queryOptions.enabled,
     staleTime: Infinity,
+    useErrorBoundary: queryOptions.useErrorBoundary,
   })
 }
 
 export const usePontusXAccountMetadata = (
   address: string,
-  queryOptions: { enabled: boolean },
+  queryOptions: { enabled: boolean; useErrorBoundary?: boolean },
 ): AccountMetadataInfo => {
   const { isLoading, isError, error, data: allData } = usePontusXAccountsMetadata(queryOptions)
   if (isError) {
@@ -66,7 +70,7 @@ export const useSearchForPontusXAccountsByName = (
     isError: isMetadataError,
     error: metadataError,
     data: namedAccounts,
-  } = usePontusXAccountsMetadata(queryOptions)
+  } = usePontusXAccountsMetadata({ ...queryOptions, useErrorBoundary: false })
   if (isMetadataError) {
     console.log('Failed to load Pontus-X account names', metadataError)
   }

--- a/src/coin-gecko/api.ts
+++ b/src/coin-gecko/api.ts
@@ -43,6 +43,7 @@ export function useGetTokenPricesFromGecko(tokenIds: string[], fiatCurrency: str
         }),
     {
       staleTime,
+      useErrorBoundary: false,
     },
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,11 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       retry: false,
+      useErrorBoundary: (error: any) => {
+        // Automatically throw on 5xx errors. Components that want to handle
+        // errors should set `useErrorBoundary: false` in their queries.
+        return error.response?.status >= 500
+      },
     },
   },
 })


### PR DESCRIPTION
These are currently throwing `{"msg":"storage error: can't scan into dest[5]: cannot scan NULL into *string"}`
https://explorer.dev.oasis.io/testnet/sapphire/address/oasis1qp66ryj9caek77kewkxxvjvkzypljhsdgvm5q34d
https://explorer.dev.oasis.io/search?q=8d5a30f1e586dce3ae7839c5f20c846d6d71b27d185adbacd32778d6c60f55eb
but frontend is ignoring the error

| Before | After |
| --- | --- |
| ![explorer dev oasis io_testnet_sapphire_address_oasis1qp66ryj9caek77kewkxxvjvkzypljhsdgvm5q34d](https://github.com/user-attachments/assets/6fce78d7-c742-4be1-b030-1a5cf54a98c3) | ![localhost_1234_testnet_sapphire_address_oasis1qp66ryj9caek77kewkxxvjvkzypljhsdgvm5q34d](https://github.com/user-attachments/assets/68ee259f-211a-4cbb-ba74-905d4786d2ba) |
| ![explorer dev oasis io_search_q=8d5a30f1e586dce3ae7839c5f20c846d6d71b27d185adbacd32778d6c60f55eb](https://github.com/user-attachments/assets/faf648f0-484e-45ea-8a34-bfab7fc5783e) | ![localhost_1234_search_q=8d5a30f1e586dce3ae7839c5f20c846d6d71b27d185adbacd32778d6c60f55eb](https://github.com/user-attachments/assets/89fbb979-1cd8-4cee-849e-ef5d69f6b0b6) |
