### PR TITLE
Provide data to validator staking trend chart

### DIFF
--- a/.changelog/1502.trivial.md
+++ b/.changelog/1502.trivial.md
@@ -1,0 +1,1 @@
+Provide data to validator staking trend chart

--- a/src/app/components/charts/LineChart.tsx
+++ b/src/app/components/charts/LineChart.tsx
@@ -21,6 +21,8 @@ interface LineChartProps<T extends object> extends Formatters {
   tickMargin?: number
   tooltipActiveDotRadius?: number
   withLabels?: boolean
+  maximumFractionDigits?: number
+  alignDomainToDataPoints?: boolean
 }
 
 const LineChartCmp = <T extends object>({
@@ -33,6 +35,8 @@ const LineChartCmp = <T extends object>({
   tickMargin = 0,
   tooltipActiveDotRadius = 5,
   withLabels,
+  maximumFractionDigits = 0,
+  alignDomainToDataPoints,
 }: LineChartProps<T>): ReactElement => {
   const { t } = useTranslation()
 
@@ -54,7 +58,7 @@ const LineChartCmp = <T extends object>({
           }}
         />
         <YAxis
-          domain={withLabels ? [0, 'auto'] : ['dataMin', 'dataMax']}
+          domain={!alignDomainToDataPoints && withLabels ? [0, 'auto'] : ['dataMin', 'dataMax']}
           axisLine={false}
           interval={0}
           tickLine={false}
@@ -68,6 +72,7 @@ const LineChartCmp = <T extends object>({
               formatParams: {
                 value: {
                   notation: 'compact',
+                  maximumFractionDigits,
                 } satisfies Intl.NumberFormatOptions,
               },
             })

--- a/src/app/pages/ValidatorDetailsPage/StakingTrend.tsx
+++ b/src/app/pages/ValidatorDetailsPage/StakingTrend.tsx
@@ -3,36 +3,53 @@ import { useTranslation } from 'react-i18next'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
+import { useGetConsensusValidatorsAddressHistory } from '../../../oasis-nexus/api'
+import { SearchScope } from '../../../types/searchScope'
 import { LineChart } from '../../components/charts/LineChart'
-import { SearchScope } from 'types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
 
-export const StakingTrend: FC<{ scope: SearchScope }> = ({ scope }) => {
+const epochsInMonth = 720
+
+type StakingTrendProps = {
+  address: string
+  scope: SearchScope
+}
+
+export const StakingTrend: FC<StakingTrendProps> = ({ address, scope }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
-  // TODO: provide data from the API is ready and sync dataKey value
-  const windows = undefined
+  const historyQuery = useGetConsensusValidatorsAddressHistory(scope.network, address, {
+    limit: epochsInMonth,
+  })
+  const history = historyQuery.data?.data?.history
+  const filteredHistory = history
+    ?.map(item => ({
+      active_balance: item.active_balance,
+      epoch: item.epoch,
+    }))
+    .reverse()
 
   return (
     <Card sx={{ flex: 1 }}>
       <CardHeader disableTypography component="h3" title={t('validator.stakingTrend')} />
       <CardContent sx={{ height: 250 }}>
-        {windows && (
+        {history && filteredHistory && (
           <LineChart
             tooltipActiveDotRadius={9}
             cartesianGrid
             strokeWidth={3}
-            dataKey={'volume'}
-            data={windows}
+            dataKey="active_balance"
+            data={filteredHistory}
             margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
             tickMargin={16}
             withLabels
             formatters={{
-              data: (value: number) => value.toLocaleString(),
-              label: (value: string) =>
-                t('common.formattedDateTime', {
-                  timestamp: new Date(value),
+              data: value =>
+                t('common.valueInToken', {
+                  value,
+                  ticker: history[0].ticker,
                 }),
+              label: (value: string) => `${t('common.epoch')}: ${value}`,
             }}
           />
         )}

--- a/src/app/pages/ValidatorDetailsPage/StakingTrend.tsx
+++ b/src/app/pages/ValidatorDetailsPage/StakingTrend.tsx
@@ -35,6 +35,7 @@ export const StakingTrend: FC<StakingTrendProps> = ({ address, scope }) => {
       <CardContent sx={{ height: 250 }}>
         {history && filteredHistory && (
           <LineChart
+            alignDomainToDataPoints
             tooltipActiveDotRadius={9}
             cartesianGrid
             strokeWidth={3}
@@ -43,6 +44,7 @@ export const StakingTrend: FC<StakingTrendProps> = ({ address, scope }) => {
             margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
             tickMargin={16}
             withLabels
+            maximumFractionDigits={2}
             formatters={{
               data: value =>
                 t('common.valueInToken', {

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -57,7 +57,7 @@ export const ValidatorDetailsPage: FC = () => {
       <ValidatorDetailsCard isLoading={isLoading} validator={validator} />
       <Grid container spacing={4}>
         <StyledGrid item xs={12} md={6}>
-          <StakingTrend scope={scope} />
+          <StakingTrend address={address} scope={scope} />
         </StyledGrid>
         <StyledGrid item xs={12} md={6}>
           <SignedBlocks />


### PR DESCRIPTION
- can be tested only on testnet for now
- staking trend chart looks flat with testnet data. we will have to validate how these charts look like with prod validators
- there is an issue with recharts y axis ticks (and compact notation) when we deal with many points with large values that are almost the same. added two props, but I expect that we will have to tweak this in the future
