### PR TITLE
Automatically throw on CORS error responses (e.g. Cloudflare timeouts)

### DIFF
--- a/.changelog/1513.bugfix.md
+++ b/.changelog/1513.bugfix.md
@@ -1,0 +1,1 @@
+Automatically throw on 5xx error responses

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,14 @@ const queryClient = new QueryClient({
       useErrorBoundary: (error: any) => {
         // Automatically throw on 5xx errors. Components that want to handle
         // errors should set `useErrorBoundary: false` in their queries.
-        return error.response?.status >= 500
+        if (error.response?.status >= 500) return true
+
+        // https://nexus.oasis.io/v1/sapphire/events?offset=0&limit=10&type=evm.log&evm_log_signature=ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef&rel=oasis1qpdgv5nv2dhxp4q897cgag6kgnm9qs0dccwnckuu
+        // threw 524 error after 100 seconds but didn't return status code to javascript. It's because Nexus didn't
+        // respond quickly enough, so Cloudflare canceled with timeout, but Cloudflare doesn't add Nexus' CORS headers.
+        if (!error.response && error.code === 'ERR_NETWORK') return true
+
+        return false
       },
     },
   },


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/explorer/pull/1493

https://explorer.dev.oasis.io/mainnet/sapphire/address/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3/token-transfers#transfers
| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-21 06-22-34](https://github.com/user-attachments/assets/f66d22ba-efc5-41da-9707-66659bf643f0) |  ![Screenshot from 2024-08-21 06-16-44](https://github.com/user-attachments/assets/d62841a3-bb67-4c6e-bd67-2ef896af8897) |
