### PR TITLE
Add Total Escrow to Balance Distribution card

### DIFF
--- a/.changelog/1517.trivial.md
+++ b/.changelog/1517.trivial.md
@@ -1,0 +1,1 @@
+Add Total Escrow to Balance Distribution card

--- a/src/app/components/charts/PieChart.tsx
+++ b/src/app/components/charts/PieChart.tsx
@@ -16,6 +16,7 @@ interface PieChartProps<T extends object> extends Formatters {
   compact: boolean
   data: T[]
   dataKey: Extract<keyof T, string>
+  prependLegendList?: ReactNode
 }
 
 const colorPalette = [COLORS.brandDark, COLORS.brandMedium, TESTNET_COLORS.testnet, COLORS.grayMedium2]
@@ -23,7 +24,7 @@ const colorPalette = [COLORS.brandDark, COLORS.brandMedium, TESTNET_COLORS.testn
 type LegendListItemProps = {
   children: ReactNode
   compact: boolean
-  isActive: boolean
+  isActive?: boolean
   color?: string
 }
 
@@ -39,15 +40,15 @@ const LegendListItem: FC<LegendListItemProps> = ({ children, compact, isActive, 
           alignItems: 'center',
           justifyContent: 'center',
           borderRadius: '50%',
-          backgroundColor: isActive ? `${color}40` : 'transparent',
+          backgroundColor: isActive && color ? `${color}40` : 'transparent',
         }}
       >
-        <CircleIcon sx={{ color: color, fontSize: compact ? 12 : 18 }} />
+        <CircleIcon sx={{ color: color || COLORS.grayMedium, fontSize: compact ? 12 : 18 }} />
       </Box>
       <Typography
         component="span"
         sx={{
-          color: isActive ? color : COLORS.grayMedium,
+          color: isActive && color ? color : COLORS.grayMedium,
           fontSize: compact ? 12 : 18,
           ml: 2,
           fontWeight: isActive ? 700 : 400,
@@ -62,14 +63,16 @@ const LegendListItem: FC<LegendListItemProps> = ({ children, compact, isActive, 
 type CustomLegendProps = Props & {
   activeLabel?: string
   compact: boolean
+  prependLegendList?: ReactNode
 }
 
 const CustomLegend = (props: CustomLegendProps) => {
-  const { activeLabel, compact, payload } = props
+  const { activeLabel, compact, payload, prependLegendList } = props
   const { t } = useTranslation()
 
   return (
     <List sx={{ listStyleType: 'none' }}>
+      {prependLegendList && <LegendListItem compact={compact}>{prependLegendList}</LegendListItem>}
       {payload?.map(item => {
         if (!item.payload) {
           return null
@@ -98,7 +101,13 @@ const CustomLegend = (props: CustomLegendProps) => {
   )
 }
 
-const PieChartCmp = <T extends object>({ compact, data, dataKey, formatters }: PieChartProps<T>) => {
+const PieChartCmp = <T extends object>({
+  compact,
+  data,
+  dataKey,
+  formatters,
+  prependLegendList,
+}: PieChartProps<T>) => {
   const [activeLabel, setActiveLabel] = useState<string>()
   if (!data.length) {
     return null
@@ -122,7 +131,12 @@ const PieChartCmp = <T extends object>({ compact, data, dataKey, formatters }: P
           align="left"
           verticalAlign="middle"
           content={props => (
-            <CustomLegend activeLabel={activeLabel} compact={compact} payload={props.payload} />
+            <CustomLegend
+              activeLabel={activeLabel}
+              compact={compact}
+              prependLegendList={prependLegendList}
+              payload={props.payload}
+            />
           )}
         />
         <Pie

--- a/src/app/components/charts/PieChart.tsx
+++ b/src/app/components/charts/PieChart.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react'
+import { FC, memo, ReactNode, useState } from 'react'
 import { Legend, ResponsiveContainer, Tooltip, PieChart as RechartsPieChart, Pie, Cell } from 'recharts'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
@@ -20,6 +20,45 @@ interface PieChartProps<T extends object> extends Formatters {
 
 const colorPalette = [COLORS.brandDark, COLORS.brandMedium, TESTNET_COLORS.testnet, COLORS.grayMedium2]
 
+type LegendListItemProps = {
+  children: ReactNode
+  compact: boolean
+  isActive: boolean
+  color?: string
+}
+
+const LegendListItem: FC<LegendListItemProps> = ({ children, compact, isActive, color }) => {
+  return (
+    <ListItem sx={{ padding: 0 }}>
+      <Box
+        sx={{
+          width: compact ? 32 : 48,
+          height: compact ? 32 : 48,
+          display: 'flex',
+          position: 'relative',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '50%',
+          backgroundColor: isActive ? `${color}40` : 'transparent',
+        }}
+      >
+        <CircleIcon sx={{ color: color, fontSize: compact ? 12 : 18 }} />
+      </Box>
+      <Typography
+        component="span"
+        sx={{
+          color: isActive ? color : COLORS.grayMedium,
+          fontSize: compact ? 12 : 18,
+          ml: 2,
+          fontWeight: isActive ? 700 : 400,
+        }}
+      >
+        {children}
+      </Typography>
+    </ListItem>
+  )
+}
+
 type CustomLegendProps = Props & {
   activeLabel?: string
   compact: boolean
@@ -40,43 +79,19 @@ const CustomLegend = (props: CustomLegendProps) => {
         const label = payload.name
         const isActive = activeLabel === label
         return (
-          <ListItem key={label} sx={{ padding: 0 }}>
-            <Box
-              sx={{
-                width: compact ? 32 : 48,
-                height: compact ? 32 : 48,
-                display: 'flex',
-                position: 'relative',
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderRadius: '50%',
-                backgroundColor: isActive ? `${item.color}40` : 'transparent',
-              }}
-            >
-              <CircleIcon sx={{ color: item.color, fontSize: compact ? 12 : 18 }} />
-            </Box>
-            <Typography
-              component="span"
-              sx={{
-                color: isActive ? item.color : COLORS.grayMedium,
-                fontSize: compact ? 12 : 18,
-                ml: 2,
-                fontWeight: isActive ? 700 : 400,
-              }}
-            >
-              {label} (
-              {t('common.valuePair', {
-                value: payload.percent,
-                formatParams: {
-                  value: {
-                    style: 'percent',
-                    maximumFractionDigits: 2,
-                  } satisfies Intl.NumberFormatOptions,
-                },
-              })}
-              )
-            </Typography>
-          </ListItem>
+          <LegendListItem key={label} color={item.color} compact={compact} isActive={isActive}>
+            {label} (
+            {t('common.valuePair', {
+              value: payload.percent,
+              formatParams: {
+                value: {
+                  style: 'percent',
+                  maximumFractionDigits: 2,
+                } satisfies Intl.NumberFormatOptions,
+              },
+            })}
+            )
+          </LegendListItem>
         )
       })}
     </List>

--- a/src/app/pages/ValidatorDetailsPage/BalanceDistributionCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/BalanceDistributionCard.tsx
@@ -1,10 +1,12 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TFunction } from 'i18next'
+import Typography from '@mui/material/Typography'
 import { Validator } from '../../../oasis-nexus/api'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { PieChart } from '../../components/charts/PieChart'
+import { RoundedBalance } from '../../components/RoundedBalance'
 
 type BalanceDistributionCardProps = {
   validator?: Validator
@@ -39,18 +41,36 @@ export const BalanceDistributionCard: FC<BalanceDistributionCardProps> = ({ vali
 
   return (
     <SnapshotCard title={t('validator.balanceDistribution')}>
-      <PieChart
-        compact
-        data={chartData(t, validator)}
-        dataKey="value"
-        formatters={{
-          data: (value: number) =>
-            t('common.valueLong', {
-              ...getPreciseNumberFormat(value.toString()),
-            }),
-          label: (label: string) => label,
-        }}
-      />
+      {validator?.escrow.active_balance && (
+        <PieChart
+          compact
+          prependLegendList={
+            <>
+              {t('validator.totalEscrow')}
+              <Typography sx={{ fontSize: 10 }}>
+                {t('common.valueInToken', {
+                  ...getPreciseNumberFormat(validator.escrow.active_balance),
+                  ticker: validator.ticker,
+                })}
+              </Typography>
+              <RoundedBalance
+                compactLargeNumbers
+                value={validator?.escrow.active_shares}
+                ticker={t('common.shares')}
+              />
+            </>
+          }
+          data={chartData(t, validator)}
+          dataKey="value"
+          formatters={{
+            data: (value: number) =>
+              t('common.valueLong', {
+                ...getPreciseNumberFormat(value.toString()),
+              }),
+            label: (label: string) => label,
+          }}
+        />
+      )}
     </SnapshotCard>
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -685,6 +685,7 @@
     "stakingTrend": "Staking Trend",
     "startDate": "Start Date",
     "title": "Validator",
+    "totalEscrow": " Total Escrow (100%)",
     "totalShare": "Total Share",
     "undelegations": "Undelegations",
     "uptime": "Uptime",


### PR DESCRIPTION
Figma designs were updated after discussion with backend (chart is handling 2 values, but legend shows 3).

https://26520edb.oasis-explorer.pages.dev/testnet/consensus/validators/oasis1qpz97gfrvj5xzx8jx7x9zweeq0rcf2q6jg4a09qz