### PR TITLE
Sync with validators API changes and provide data to snapshot cards

### DIFF
--- a/.changelog/1518.trivial.md
+++ b/.changelog/1518.trivial.md
@@ -1,0 +1,1 @@
+Provide missing data to validator snapshot cards

--- a/src/app/components/Validators/index.tsx
+++ b/src/app/components/Validators/index.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
-import { Validator } from '../../../oasis-nexus/api'
+import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { StatusIcon } from '../StatusIcon'
 import { RoundedBalance } from '../RoundedBalance'
@@ -18,9 +18,10 @@ type ValidatorsProps = {
   isLoading: boolean
   limit: number
   pagination: false | TablePaginationProps
+  stats: ValidatorAggStats | undefined
 }
 
-export const Validators: FC<ValidatorsProps> = ({ isLoading, limit, pagination, validators }) => {
+export const Validators: FC<ValidatorsProps> = ({ isLoading, limit, pagination, validators, stats }) => {
   const { t } = useTranslation()
   const { network } = useRequiredScopeParam()
 
@@ -71,9 +72,9 @@ export const Validators: FC<ValidatorsProps> = ({ isLoading, limit, pagination, 
         align: TableCellAlign.Right,
         content: (
           <>
-            {typeof validator?.voting_power === 'number' && validator?.voting_power_total > 0
+            {typeof validator?.voting_power === 'number' && stats?.total_voting_power
               ? t('common.valuePair', {
-                  value: validator.voting_power / validator.voting_power_total,
+                  value: validator.voting_power / stats.total_voting_power,
                   formatParams: {
                     value: {
                       style: 'percent',

--- a/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
+++ b/src/app/pages/ConsensusDashboardPage/ConsensusSnapshot.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SearchScope } from '../../../types/searchScope'
+import { useGetConsensusValidators } from '../../../oasis-nexus/api'
 import { Snapshot, StyledGrid } from '../../components/Snapshots/Snapshot'
+import { API_MAX_TOTAL_COUNT } from '../../config'
 import { SnapshotEpoch } from './SnapshotEpoch'
 import { SnapshotDelegators } from './SnapshotDelegators'
 import { SnapshotValidators } from './SnapshotValidators'
@@ -9,6 +11,9 @@ import { SnapshotStaked } from './SnapshotStaked'
 
 export const ConsensusSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
+  const validatorsQuery = useGetConsensusValidators(scope.network, { limit: API_MAX_TOTAL_COUNT })
+  const validators = validatorsQuery.data?.data.validators
+  const stats = validatorsQuery.data?.data.stats
 
   return (
     <Snapshot title={t('consensusSnapshot.title')} scope={scope}>
@@ -16,13 +21,13 @@ export const ConsensusSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
         <SnapshotEpoch scope={scope} />
       </StyledGrid>
       <StyledGrid item xs={22} md={6}>
-        <SnapshotValidators scope={scope} />
+        <SnapshotValidators validators={validators} />
       </StyledGrid>
       <StyledGrid item xs={22} md={5}>
-        <SnapshotDelegators />
+        <SnapshotDelegators totalDelegators={stats?.total_delegators} />
       </StyledGrid>
       <StyledGrid item xs={22} md={6}>
-        <SnapshotStaked />
+        <SnapshotStaked totalStaked={stats?.total_staked_balance} ticker={stats?.ticker} />
       </StyledGrid>
     </Snapshot>
   )

--- a/src/app/pages/ConsensusDashboardPage/SnapshotDelegators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotDelegators.tsx
@@ -4,15 +4,17 @@ import Box from '@mui/material/Box'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 import { useScreenSize } from '../../hooks/useScreensize'
 
-export const SnapshotDelegators: FC = () => {
+type SnapshotDelegatorsProps = {
+  totalDelegators: number | undefined
+}
+
+export const SnapshotDelegators: FC<SnapshotDelegatorsProps> = ({ totalDelegators }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
-  // TODO: provide delegators number when API is ready
-  const delegators = undefined
 
   return (
     <SnapshotTextCard title={t('validator.delegators')}>
-      <Box sx={{ pb: isMobile ? 3 : 5 }}>{delegators}</Box>
+      {totalDelegators && <Box sx={{ pb: isMobile ? 3 : 5 }}>{totalDelegators.toLocaleString()}</Box>}
     </SnapshotTextCard>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/SnapshotStaked.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotStaked.tsx
@@ -3,13 +3,18 @@ import { Trans, useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
+import { Ticker } from '../../../types/ticker'
 import { RoundedBalance } from '../../components/RoundedBalance'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 
-export const SnapshotStaked: FC = () => {
+type SnapshotStakedProps = {
+  ticker: Ticker | undefined
+  totalStaked: string | undefined
+}
+
+export const SnapshotStaked: FC<SnapshotStakedProps> = ({ totalStaked, ticker }) => {
   const { t } = useTranslation()
-  //  TODO: provide label and staked values when API is ready, validate percentageValue formatting
-  const staked = undefined
+  //  TODO: provide totalCirculation
   const percentageValue = undefined
 
   return (
@@ -43,9 +48,9 @@ export const SnapshotStaked: FC = () => {
         )
       }
     >
-      {staked && (
+      {totalStaked && (
         <Box sx={{ wordBreak: 'break-all', lineHeight: 1 }}>
-          <RoundedBalance value={staked} />
+          <RoundedBalance value={totalStaked} ticker={ticker} compactLargeNumbers />
         </Box>
       )}
     </SnapshotTextCard>

--- a/src/app/pages/ConsensusDashboardPage/SnapshotValidators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotValidators.tsx
@@ -1,11 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TFunction } from 'i18next'
-import { useGetConsensusValidators, Validator } from '../../../oasis-nexus/api'
-import { SearchScope } from '../../../types/searchScope'
+import { Validator } from '../../../oasis-nexus/api'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { PieChart } from '../../components/charts/PieChart'
-import { API_MAX_TOTAL_COUNT } from '../../config'
 
 type ValidatorsStats = {
   label: string
@@ -22,12 +20,12 @@ function countValidatorsState(t: TFunction, validators: Validator[] | undefined)
   ]
 }
 
-export const SnapshotValidators: FC<{ scope: SearchScope }> = ({ scope }) => {
-  const { t } = useTranslation()
-  const { network } = scope
+type SnapshotValidatorsProps = {
+  validators: Validator[] | undefined
+}
 
-  const validatorsQuery = useGetConsensusValidators(network, { limit: API_MAX_TOTAL_COUNT })
-  const validators = validatorsQuery.data?.data.validators
+export const SnapshotValidators: FC<SnapshotValidatorsProps> = ({ validators }) => {
+  const { t } = useTranslation()
 
   return (
     <SnapshotCard title={t('validator.listTitle')}>

--- a/src/app/pages/ConsensusDashboardPage/Validators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/Validators.tsx
@@ -47,6 +47,7 @@ export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
       <CardContent>
         <Validators
           validators={validatorsQuery.data?.data.validators}
+          stats={validatorsQuery.data?.data.stats}
           isLoading={validatorsQuery.isLoading}
           limit={limit}
           pagination={false}

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -70,7 +70,7 @@ const VoteLoadingProblemIndicator: FC = () => {
 }
 
 export const ProposalDetailView: FC<{
-  proposal: Proposal
+  proposal: Proposal | undefined
   highlightedPart?: string
   isLoading?: boolean
   totalVotesLoading?: boolean
@@ -91,6 +91,7 @@ export const ProposalDetailView: FC<{
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   if (isLoading) return <TextSkeleton numberOfRows={7} />
+  if (!proposal) return null
 
   const proposalType = getTypeNameForProposal(t, proposal)
 

--- a/src/app/pages/ProposalsPage/index.tsx
+++ b/src/app/pages/ProposalsPage/index.tsx
@@ -13,7 +13,6 @@ import { LoadMoreButton } from '../../components/LoadMoreButton'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { NetworkProposalsList } from '../../components/NetworkProposalsList'
 import { CardHeaderWithCounter } from '../../components/CardHeaderWithCounter'
-import { ValidatorDetailsView } from '../ValidatorDetailsPage'
 import { VerticalList } from '../../components/VerticalList'
 import { ProposalDetailView } from '../ProposalDetailsPage'
 
@@ -81,7 +80,7 @@ export const ProposalsPage: FC = () => {
           <VerticalList>
             {isLoading &&
               [...Array(PAGE_SIZE).keys()].map(key => (
-                <ValidatorDetailsView key={key} isLoading={true} validator={undefined} standalone />
+                <ProposalDetailView key={key} isLoading={true} proposal={undefined} standalone />
               ))}
             {!isLoading &&
               proposalsData?.proposals.map(proposal => (

--- a/src/app/pages/ValidatorDetailsPage/ValidatorSnapshot.tsx
+++ b/src/app/pages/ValidatorDetailsPage/ValidatorSnapshot.tsx
@@ -11,15 +11,16 @@ import { SearchScope } from '../../../types/searchScope'
 import { UptimeCard } from './UptimeCard'
 import { VotingPowerCard } from './VotingPowerCard'
 import { BalanceDistributionCard } from './BalanceDistributionCard'
-import { Validator } from '../../../oasis-nexus/api'
+import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { StyledGrid } from '../../components/Snapshots/Snapshot'
 
 type ValidatorSnapshotProps = {
   scope: SearchScope
-  validator?: Validator
+  validator: Validator | undefined
+  stats: ValidatorAggStats | undefined
 }
 
-export const ValidatorSnapshot: FC<ValidatorSnapshotProps> = ({ scope, validator }) => {
+export const ValidatorSnapshot: FC<ValidatorSnapshotProps> = ({ scope, validator, stats }) => {
   const { t } = useTranslation()
 
   const theme = useTheme()
@@ -44,7 +45,7 @@ export const ValidatorSnapshot: FC<ValidatorSnapshotProps> = ({ scope, validator
           <BalanceDistributionCard validator={validator} />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
-          <VotingPowerCard validator={validator} />
+          <VotingPowerCard validator={validator} stats={stats} />
         </StyledGrid>
         <StyledGrid item xs={22} md={5}>
           <UptimeCard />

--- a/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
@@ -2,16 +2,17 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import { Validator } from '../../../oasis-nexus/api'
+import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from 'styles/theme/colors'
 import { VerticalProgressBar } from 'app/components/ProgressBar'
 
 type VotingPowerCardProps = {
-  validator?: Validator
+  validator: Validator | undefined
+  stats: ValidatorAggStats | undefined
 }
 
-export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator }) => {
+export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator, stats }) => {
   const { t } = useTranslation()
 
   return (
@@ -26,14 +27,14 @@ export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator }) => {
       }
       withContentPadding={false}
     >
-      {typeof validator?.voting_power === 'number' && validator?.voting_power_total > 0 && (
+      {typeof validator?.voting_power === 'number' && stats?.total_voting_power && (
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             <Typography sx={{ fontSize: 12, color: COLORS.grayMedium, textAlign: 'left', paddingBottom: 3 }}>
               {t('validator.votingPowerOverall')}
             </Typography>
             {t('common.valuePair', {
-              value: validator.voting_power / validator.voting_power_total,
+              value: validator.voting_power / stats.total_voting_power,
               formatParams: {
                 value: {
                   style: 'percent',
@@ -46,7 +47,7 @@ export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator }) => {
             <VerticalProgressBar
               height={80}
               width={50}
-              value={(100 * validator.voting_power) / validator.voting_power_total}
+              value={(100 * validator.voting_power) / stats.total_voting_power}
               barWithBorder={false}
               barBackgroundColor={COLORS.grayMediumLight}
             />

--- a/src/app/pages/ValidatorsPage/index.tsx
+++ b/src/app/pages/ValidatorsPage/index.tsx
@@ -63,6 +63,7 @@ export const ValidatorsPage: FC = () => {
       >
         {tableView === TableLayout.Horizontal && (
           <Validators
+            stats={validatorsQuery.data?.data.stats}
             validators={validatorsQuery.data?.data.validators}
             isLoading={validatorsQuery.isLoading}
             limit={PAGE_SIZE}
@@ -79,11 +80,22 @@ export const ValidatorsPage: FC = () => {
           <VerticalList>
             {isLoading &&
               [...Array(PAGE_SIZE).keys()].map(key => (
-                <ValidatorDetailsView key={key} isLoading={true} validator={undefined} standalone />
+                <ValidatorDetailsView
+                  key={key}
+                  isLoading={true}
+                  validator={undefined}
+                  stats={undefined}
+                  standalone
+                />
               ))}
             {!isLoading &&
               validatorsData?.validators.map(validator => (
-                <ValidatorDetailsView key={validator.entity_address} validator={validator} standalone />
+                <ValidatorDetailsView
+                  key={validator.entity_address}
+                  validator={validator}
+                  stats={validatorsQuery.data?.data.stats}
+                  standalone
+                />
               ))}
           </VerticalList>
         )}

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -1088,7 +1088,6 @@ export const useGetConsensusValidatorsAddressHistory: typeof generated.useGetCon
       },
     })
   }
-
 export const useGetConsensusValidatorsAddress: typeof generated.useGetConsensusValidatorsAddress = (
   network,
   address,
@@ -1101,26 +1100,32 @@ export const useGetConsensusValidatorsAddress: typeof generated.useGetConsensusV
       ...options?.request,
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
-        (validator: generated.Validator, headers, status) => {
-          if (status !== 200) return validator
+        (data: generated.ValidatorList, headers, status): ExtendedValidatorList => {
+          if (status !== 200) return data
+          const validators = data.validators.map((validator): generated.Validator => {
+            return {
+              ...validator,
+              escrow: {
+                ...validator.escrow,
+                active_balance: validator.escrow?.active_balance
+                  ? fromBaseUnits(validator.escrow.active_balance, consensusDecimals)
+                  : undefined,
+                active_balance_24: validator.escrow?.active_balance_24
+                  ? fromBaseUnits(validator.escrow.active_balance_24, consensusDecimals)
+                  : undefined,
+                debonding_balance: validator.escrow?.debonding_balance
+                  ? fromBaseUnits(validator.escrow.debonding_balance, consensusDecimals)
+                  : undefined,
+                self_delegation_balance: validator.escrow?.self_delegation_balance
+                  ? fromBaseUnits(validator.escrow.self_delegation_balance, consensusDecimals)
+                  : undefined,
+              },
+              ticker,
+            }
+          })
           return {
-            ...validator,
-            escrow: {
-              ...validator.escrow,
-              active_balance: validator.escrow.active_balance
-                ? fromBaseUnits(validator.escrow.active_balance, consensusDecimals)
-                : undefined,
-              active_balance_24: validator.escrow?.active_balance_24
-                ? fromBaseUnits(validator.escrow.active_balance_24, consensusDecimals)
-                : undefined,
-              debonding_balance: validator.escrow?.debonding_balance
-                ? fromBaseUnits(validator.escrow.debonding_balance, consensusDecimals)
-                : undefined,
-              self_delegation_balance: validator.escrow?.self_delegation_balance
-                ? fromBaseUnits(validator.escrow.self_delegation_balance, consensusDecimals)
-                : undefined,
-            },
-            ticker,
+            ...data,
+            validators,
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -117,6 +117,10 @@ declare module './generated/api' {
   export interface Validator {
     ticker: Ticker
   }
+
+  export interface ValidatorAggStats {
+    ticker: Ticker
+  }
 }
 
 export const isAccountEmpty = (account: RuntimeAccount | Account) => {
@@ -1047,6 +1051,11 @@ export const useGetConsensusValidators: typeof generated.useGetConsensusValidato
           validators.forEach(validator => map.set(validator.entity_address, validator))
           return {
             ...data,
+            stats: {
+              ...data.stats,
+              total_staked_balance: fromBaseUnits(data.stats.total_staked_balance, consensusDecimals),
+              ticker,
+            },
             validators,
             map,
           }
@@ -1126,6 +1135,11 @@ export const useGetConsensusValidatorsAddress: typeof generated.useGetConsensusV
           return {
             ...data,
             validators,
+            stats: {
+              ...data.stats,
+              total_staked_balance: fromBaseUnits(data.stats.total_staked_balance, consensusDecimals),
+              ticker,
+            },
           }
         },
         ...arrayify(options?.request?.transformResponse),

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1193,6 +1193,8 @@ export type ProposalVotesAllOf = {
   votes: ProposalVote[];
 };
 
+export type ProposalVotes = List & ProposalVotesAllOf;
+
 /**
  * The state of the proposal.
  */
@@ -1537,19 +1539,35 @@ export interface Validator {
   start_date: string;
   /** The voting power of this validator. */
   voting_power: number;
+}
+
+export interface ValidatorAggStats {
+  /** The total number of delegators in the network. */
+  total_delegators: number;
+  /** The total amount of token staked to validators. */
+  total_staked_balance: TextBigInt;
   /** The total voting power across all validators. */
-  voting_power_total: number;
+  total_voting_power: number;
 }
 
 /**
- * A list of validators registered at the consensus layer.
+ * A list of validators registered at the consensus layer, plus summary
+statistics across all consensus validators.
 
  */
 export type ValidatorListAllOf = {
+  /** Summary statistics across all consensus validators. */
+  stats: ValidatorAggStats;
   validators: Validator[];
 };
 
 export type ValidatorList = List & ValidatorListAllOf;
+
+export interface ValidatorsResponse {
+  /** Summary statistics across all consensus validators. */
+  stats: ValidatorAggStats;
+  validator_list: ValidatorList;
+}
 
 /**
  * An entity registered at the consensus layer.
@@ -1965,8 +1983,6 @@ the query would return with limit=infinity.
  */
   total_count: number;
 }
-
-export type ProposalVotes = List & ProposalVotesAllOf;
 
 /**
  * A list of consensus blocks.
@@ -2885,7 +2901,7 @@ export const GetConsensusValidatorsAddress = (
 ) => {
       
       
-      return GetConsensusValidatorsAddressMutator<Validator>(
+      return GetConsensusValidatorsAddressMutator<ValidatorList>(
       {url: `/${encodeURIComponent(String(network))}/consensus/validators/${encodeURIComponent(String(address))}`, method: 'GET', signal
     },
       options);


### PR DESCRIPTION
prep for incoming Nexus changes https://github.com/oasisprotocol/nexus/pull/738 (`validators/address` will return similar response to validators list, but with one item only) 

Requires: 
- [x] Nexus deploy (prod instance)