### PR TITLE
Differentiate transaction amount and fee tickers

### DIFF
--- a/.changelog/1543.bugfix.md
+++ b/.changelog/1543.bugfix.md
@@ -1,0 +1,1 @@
+Differentiate transaction amount and fee tickers

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -146,12 +146,12 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
               },
               {
                 align: TableCellAlign.Right,
-                content: <RoundedBalance value={transaction.charged_fee} ticker={transaction.ticker} />,
+                content: <RoundedBalance value={transaction.charged_fee} ticker={transaction.fee_symbol} />,
                 key: 'fee_amount',
               },
               {
                 align: TableCellAlign.Right,
-                content: <RoundedBalance value={transaction.amount} ticker={transaction.ticker} />,
+                content: <RoundedBalance value={transaction.amount} ticker={transaction.amount_symbol} />,
                 key: 'value',
               },
             ]

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -25,7 +25,6 @@ import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { RuntimeTransactionEvents } from '../../components/Transactions/RuntimeTransactionEvents'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
-import { Ticker } from '../../../types/ticker'
 import { AllTokenPrices, useAllTokenPrices } from '../../../coin-gecko/api'
 import { CurrentFiatValue } from '../../components/CurrentFiatValue'
 import { AddressSwitch, AddressSwitchOption } from '../../components/AddressSwitch'
@@ -169,8 +168,8 @@ export const RuntimeTransactionDetailView: FC<{
   const from = isOasisAddressFormat ? transaction?.sender_0 : transaction?.sender_0_eth
   const to = isOasisAddressFormat ? transaction?.to : transaction?.to_eth
 
-  const ticker = transaction?.ticker || Ticker.ROSE
-  const tokenPriceInfo = tokenPrices[ticker]
+  // @ts-expect-error Ignore index type error
+  const amountSymbolPriceInfo = tokenPrices[transaction?.amount_symbol]
 
   const gasPrice = getGasPrice({ fee: transaction?.charged_fee, gasUsed: transaction?.gas_used.toString() })
 
@@ -286,21 +285,21 @@ export const RuntimeTransactionDetailView: FC<{
             {transaction.amount != null
               ? t('common.valueInToken', {
                   ...getPreciseNumberFormat(transaction.amount),
-                  ticker: ticker,
+                  ticker: transaction.amount_symbol,
                 })
               : t('common.missing')}
           </dd>
 
           {showFiatValues &&
             transaction.amount !== undefined &&
-            !!tokenPriceInfo &&
-            !tokenPriceInfo.isLoading &&
-            !tokenPriceInfo.isFree &&
-            tokenPriceInfo.price !== undefined && (
+            !!amountSymbolPriceInfo &&
+            !amountSymbolPriceInfo.isLoading &&
+            !amountSymbolPriceInfo.isFree &&
+            amountSymbolPriceInfo.price !== undefined && (
               <>
                 <dt>{t('currentFiatValue.title')}</dt>
                 <dd>
-                  <CurrentFiatValue amount={transaction.amount} {...tokenPriceInfo} />
+                  <CurrentFiatValue amount={transaction.amount} {...amountSymbolPriceInfo} />
                 </dd>
               </>
             )}
@@ -309,7 +308,7 @@ export const RuntimeTransactionDetailView: FC<{
           <dd>
             {t('common.valueInToken', {
               ...getPreciseNumberFormat(transaction.charged_fee),
-              ticker: ticker,
+              ticker: transaction.fee_symbol,
             })}
           </dd>
 
@@ -319,7 +318,7 @@ export const RuntimeTransactionDetailView: FC<{
               <dd>
                 {t('common.valueInToken', {
                   ...getPreciseNumberFormat(convertToNano(gasPrice)),
-                  ticker: `n${ticker}`,
+                  ticker: `n${transaction.fee_symbol}`,
                 })}
               </dd>
             </>

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -215,6 +215,11 @@ const adjustRuntimeTransactionMethod = (
   isLikelyNativeTokenTransfer: boolean | undefined,
 ) => (isLikelyNativeTokenTransfer ? 'accounts.Transfer' : method)
 
+function normalizeSymbol(rawSymbol: string | undefined, scope: SearchScope) {
+  const symbol = rawSymbol || getTokensForScope(scope)[0].ticker
+  return symbol
+}
+
 export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactions = (
   network,
   runtime,
@@ -235,12 +240,14 @@ export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactio
               return {
                 ...tx,
                 eth_hash: tx.eth_hash ? `0x${tx.eth_hash}` : undefined,
-                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but tx itself
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
                 fee: fromBaseUnits(tx.fee, paraTimesConfig[runtime].decimals),
-                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but tx itself
+                fee_symbol: normalizeSymbol(tx.fee_symbol, { network, layer: runtime }),
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
                 charged_fee: fromBaseUnits(tx.charged_fee, paraTimesConfig[runtime].decimals),
-                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but tx itself
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but amount_symbol
                 amount: tx.amount ? fromBaseUnits(tx.amount, paraTimesConfig[runtime].decimals) : undefined,
+                amount_symbol: normalizeSymbol(tx.amount_symbol, { network, layer: runtime }),
                 layer: runtime,
                 network,
                 method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),
@@ -316,9 +323,14 @@ export const useGetRuntimeTransactionsTxHash: typeof generated.useGetRuntimeTran
               return {
                 ...tx,
                 eth_hash: tx.eth_hash ? `0x${tx.eth_hash}` : undefined,
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
                 fee: fromBaseUnits(tx.fee, paraTimesConfig[runtime].decimals),
+                fee_symbol: normalizeSymbol(tx.fee_symbol, { network, layer: runtime }),
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
                 charged_fee: fromBaseUnits(tx.charged_fee, paraTimesConfig[runtime].decimals),
+                // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but amount_symbol
                 amount: tx.amount ? fromBaseUnits(tx.amount, paraTimesConfig[runtime].decimals) : undefined,
+                amount_symbol: normalizeSymbol(tx.amount_symbol, { network, layer: runtime }),
                 layer: runtime,
                 network,
                 method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -43,7 +43,6 @@ declare module './generated/api' {
   export interface RuntimeTransaction {
     network: Network
     layer: Layer
-    ticker: Ticker
   }
 
   export interface Block {
@@ -244,8 +243,6 @@ export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactio
                 amount: tx.amount ? fromBaseUnits(tx.amount, paraTimesConfig[runtime].decimals) : undefined,
                 layer: runtime,
                 network,
-                ticker:
-                  tx.body?.amount?.Denomination || getTokensForScope({ network, layer: runtime })[0].ticker,
                 method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),
               }
             }),
@@ -324,8 +321,6 @@ export const useGetRuntimeTransactionsTxHash: typeof generated.useGetRuntimeTran
                 amount: tx.amount ? fromBaseUnits(tx.amount, paraTimesConfig[runtime].decimals) : undefined,
                 layer: runtime,
                 network,
-                ticker:
-                  tx.body?.amount?.Denomination || getTokensForScope({ network, layer: runtime })[0].ticker,
                 method: adjustRuntimeTransactionMethod(tx.method, tx.is_likely_native_token_transfer),
               }
             }),


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/explorer/pull/1539, but for transaction fields

Transactions that transfer EUROe but pay fees in TEST
https://explorer.dev.oasis.io/testnet/pontusxdev/tx/40cd07b27f7edb42bbea128d473066a43877b12ba8be9f1253233dd79f283afc
| Before | After |
| --- | --- |
| ![explorer dev oasis io_testnet_pontusxdev_tx_40cd07b27f7edb42bbea128d473066a43877b12ba8be9f1253233dd79f283afc](https://github.com/user-attachments/assets/7cddc18f-d633-46ee-a6b7-f30bec011c83) | ![localhost_1234_testnet_pontusxdev_tx_40cd07b27f7edb42bbea128d473066a43877b12ba8be9f1253233dd79f283afc](https://github.com/user-attachments/assets/dfa42d9b-b977-410e-98ad-2c247baabc31) |


Tx missing new fields still works
https://explorer.dev.oasis.io/mainnet/emerald/tx/0xee5d8af74e955fffde2e801d0b400107b769458aa4cd9b297763dc9630ba0933
| Before | After |
| --- | --- |
| ![explorer dev oasis io_mainnet_emerald_tx_0xee5d8af74e955fffde2e801d0b400107b769458aa4cd9b297763dc9630ba0933](https://github.com/user-attachments/assets/50b9e7d4-3ba9-4b2b-9fa6-c4cb016a9251) | ![localhost_1234_mainnet_emerald_tx_0xee5d8af74e955fffde2e801d0b400107b769458aa4cd9b297763dc9630ba0933](https://github.com/user-attachments/assets/b1a52ffe-940e-4e69-9835-fa578de72bc1) |
