### PR TITLE
Show emitting transaction address in events

### DIFF
--- a/.changelog/1544.feature.md
+++ b/.changelog/1544.feature.md
@@ -1,0 +1,1 @@
+Show emitting transaction address in events

--- a/src/app/components/Account/AccountLinkWithAddressSwitch.tsx
+++ b/src/app/components/Account/AccountLinkWithAddressSwitch.tsx
@@ -1,17 +1,4 @@
 import { AccountLink } from './AccountLink'
 import { withAddressSwitch } from './withAddressSwitch'
-import Box from '@mui/material/Box'
 
 export const AccountLinkWithAddressSwitch = withAddressSwitch(AccountLink)
-
-export const WrappedAccountLinkWithAddressSwitch: typeof AccountLinkWithAddressSwitch = props => (
-  <Box
-    sx={{
-      display: 'inline-flex',
-      maxWidth: '100%',
-      paddingRight: '0.5em',
-    }}
-  >
-    <AccountLinkWithAddressSwitch {...props} />
-  </Box>
-)

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -208,14 +208,8 @@ export const RuntimeEventDetails: FC<{
               fontWeight={400}
             />
             <br />
-            {t('runtimeEvent.fields.emittingContract')}:
-            <br />
-            <WrappedAccountLinkWithAddressSwitch
-              scope={scope}
-              addressSwitchOption={addressSwitchOption}
-              ethAddress={emittingEthAddress}
-              oasisAddress={emittingOasisAddress}
-            />
+            {t('runtimeEvent.fields.emittingContract')}:{' '}
+            <AccountLink scope={scope} alwaysTrim address={emittingEthAddress || emittingOasisAddress} />
           </div>
         )
       }
@@ -250,14 +244,8 @@ export const RuntimeEventDetails: FC<{
             </Table>
           )}
           <br />
-          {t('runtimeEvent.fields.emittingContract')}:
-          <br />
-          <WrappedAccountLinkWithAddressSwitch
-            scope={scope}
-            addressSwitchOption={addressSwitchOption}
-            ethAddress={emittingEthAddress}
-            oasisAddress={emittingOasisAddress}
-          />
+          {t('runtimeEvent.fields.emittingContract')}:{' '}
+          <AccountLink scope={scope} alwaysTrim address={emittingEthAddress || emittingOasisAddress} />
         </div>
       )
     }

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -24,10 +24,7 @@ import StreamIcon from '@mui/icons-material/Stream'
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { MaybeEventErrorLine } from './EventError'
-import {
-  AccountLinkWithAddressSwitch,
-  WrappedAccountLinkWithAddressSwitch,
-} from '../Account/AccountLinkWithAddressSwitch'
+import { AccountLinkWithAddressSwitch } from '../Account/AccountLinkWithAddressSwitch'
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -34,6 +34,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import LanIcon from '@mui/icons-material/Lan'
 import LanOutlinedIcon from '@mui/icons-material/LanOutlined'
 import { MethodIcon } from '../ConsensusTransactionMethod'
+import { TransactionLink } from '../Transactions/TransactionLink'
 
 const getRuntimeEventMethodLabel = (t: TFunction, method: string | undefined) => {
   switch (method) {
@@ -160,7 +161,7 @@ const EvmLogRow: FC<{
   )
 }
 
-export const RuntimeEventDetails: FC<{
+const RuntimeEventDetailsInner: FC<{
   scope: SearchScope
   event: RuntimeEvent
   addressSwitchOption: AddressSwitchOption
@@ -428,4 +429,24 @@ export const RuntimeEventDetails: FC<{
         </div>
       )
   }
+}
+
+export const RuntimeEventDetails: FC<{
+  scope: SearchScope
+  event: RuntimeEvent
+  addressSwitchOption: AddressSwitchOption
+  showTxHash: boolean
+}> = ({ scope, event, addressSwitchOption, showTxHash }) => {
+  const { t } = useTranslation()
+  return (
+    <div>
+      <RuntimeEventDetailsInner scope={scope} event={event} addressSwitchOption={addressSwitchOption} />
+      {showTxHash && event.tx_hash && (
+        <p>
+          {t('runtimeEvent.fields.emittingTransaction')}:{' '}
+          <TransactionLink scope={event} alwaysTrim hash={event.eth_tx_hash || event.tx_hash} />
+        </p>
+      )}
+    </div>
+  )
 }

--- a/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
@@ -10,20 +10,6 @@ import { RuntimeEventDetails } from './RuntimeEventDetails'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 
-const RuntimeEventDetailsWithSeparator: FC<{
-  scope: SearchScope
-  event: RuntimeEvent
-  isFirst: boolean
-  addressSwitchOption: AddressSwitchOption
-}> = ({ scope, event, isFirst, addressSwitchOption }) => {
-  return (
-    <>
-      {!isFirst && <Divider variant="card" />}
-      <RuntimeEventDetails scope={scope} event={event} addressSwitchOption={addressSwitchOption} />
-    </>
-  )
-}
-
 export const RuntimeEventsDetailedList: FC<{
   scope: SearchScope
   events: RuntimeEvent[] | undefined
@@ -39,13 +25,10 @@ export const RuntimeEventsDetailedList: FC<{
       {isLoading && <TextSkeleton numberOfRows={10} />}
       {events &&
         events.map((event, index) => (
-          <RuntimeEventDetailsWithSeparator
-            key={`event-${index}`}
-            scope={scope}
-            isFirst={!index}
-            event={event}
-            addressSwitchOption={addressSwitchOption}
-          />
+          <div key={`event-${index}`}>
+            {index > 0 && <Divider variant="card" />}
+            <RuntimeEventDetails scope={scope} event={event} addressSwitchOption={addressSwitchOption} />
+          </div>
         ))}
       {pagination && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
@@ -17,7 +17,8 @@ export const RuntimeEventsDetailedList: FC<{
   isError: boolean
   addressSwitchOption: AddressSwitchOption
   pagination: false | TablePaginationProps
-}> = ({ scope, events, isLoading, isError, addressSwitchOption, pagination }) => {
+  showTxHash: boolean
+}> = ({ scope, events, isLoading, isError, addressSwitchOption, pagination, showTxHash }) => {
   const { t } = useTranslation()
   return (
     <>
@@ -27,7 +28,12 @@ export const RuntimeEventsDetailedList: FC<{
         events.map((event, index) => (
           <div key={`event-${index}`}>
             {index > 0 && <Divider variant="card" />}
-            <RuntimeEventDetails scope={scope} event={event} addressSwitchOption={addressSwitchOption} />
+            <RuntimeEventDetails
+              scope={scope}
+              event={event}
+              addressSwitchOption={addressSwitchOption}
+              showTxHash={showTxHash}
+            />
           </div>
         ))}
       {pagination && (

--- a/src/app/components/Transactions/RuntimeTransactionEvents.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionEvents.tsx
@@ -41,6 +41,7 @@ export const RuntimeTransactionEvents: FC<{
         isTotalCountClipped: data?.data.is_total_count_clipped,
         rowsPerPage: limit,
       }}
+      showTxHash={false}
     />
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
@@ -31,6 +31,7 @@ export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = ({ scope, add
           isTotalCountClipped,
           rowsPerPage: limit,
         }}
+        showTxHash
       />
     </LinkableCardLayout>
   )

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -56,6 +56,7 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
         isTotalCountClipped: data?.data.is_total_count_clipped,
         rowsPerPage: limit,
       }}
+      showTxHash
     />
   )
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -485,6 +485,7 @@
       "amount": "Amount",
       "data": "Data",
       "emittingContract": "Emitting contract",
+      "emittingTransaction": "Transaction",
       "topics": "Topics",
       "owner": "Owner",
       "activeShares": "Active Shares",


### PR DESCRIPTION
Useful for account events and block events that come from different transactions

https://explorer.dev.oasis.io/mainnet/sapphire/address/0xC3ecf872F643C6238Aa20673798eed6F7dA199e9/events#events
![image](https://github.com/user-attachments/assets/3602d9a1-79f4-4a40-88e2-6996a5d1e6f9)

