### PR TITLE
Swap Fee and Value columns in list of transactions

### DIFF
--- a/.changelog/1548.bugfix.md
+++ b/.changelog/1548.bugfix.md
@@ -1,0 +1,1 @@
+Swap Fee and Value labels in columns in list of transactions

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -63,8 +63,8 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
           { key: 'type', content: t('common.type') },
           { key: 'from', content: t('common.from'), width: '150px' },
           { key: 'to', content: t('common.to'), width: '150px' },
-          { key: 'value', align: TableCellAlign.Right, content: t('common.amount'), width: '250px' },
           { key: 'txnFee', content: t('common.fee'), align: TableCellAlign.Right, width: '250px' },
+          { key: 'value', align: TableCellAlign.Right, content: t('common.amount'), width: '250px' },
         ]
       : []),
   ]


### PR DESCRIPTION
This was a bug since #1514.