### PR TITLE
Make Pontus-X layer hidden

### DIFF
--- a/.changelog/1575.bugfix.md
+++ b/.changelog/1575.bugfix.md
@@ -1,0 +1,1 @@
+Make Pontus-X layer hidden

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -65,7 +65,7 @@ function invertSpecialScopePaths() {
 
 invertSpecialScopePaths()
 
-export const hiddenLayers: Layer[] = [Layer.pontusxdev]
+export const hiddenLayers: Layer[] = [Layer.pontusxdev, Layer.pontusxtest]
 
 export const isLayerHidden = (layer: Layer): boolean => hiddenLayers.includes(layer)
 


### PR DESCRIPTION
Opening PR just in case.

Is `pontusxtest` a hidden layer or it is fine that we are listing it in prod Explorer ?   