### PR TITLE
Prevent crash when network error occur while fetching account names

### DIFF
--- a/.changelog/1578.bugfix.md
+++ b/.changelog/1578.bugfix.md
@@ -1,0 +1,1 @@
+Prevent crash when network error occur while fetching account names

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -15,6 +15,7 @@ export const useAccountMetadata = (scope: SearchScope, address: string): Account
   const isPontusX = scope.layer === Layer.pontusxtest || scope.layer === Layer.pontusxdev
   const pontusXData = usePontusXAccountMetadata(address, { enabled: isPontusX })
   const oasisData = useOasisAccountMetadata(scope.network, scope.layer, getOasisAddress(address), {
+    useErrorBoundary: false,
     enabled: !isPontusX,
   })
   return isPontusX ? pontusXData : oasisData


### PR DESCRIPTION
Make Explorer usable (gracefully handle network errors) when account names feature is not working.

For some reason I cannot access raw.githubusercontent.com today (works when I switch to another Internet provider).
Turns out that we are not handling axios errors correctly when fetching account names. We're not handling potential issues like network issues, server unreachability, or certificate errors. When such error occurs Explorer is unusable.
  
![Screenshot from 2024-10-18 10-37-55](https://github.com/user-attachments/assets/746831a2-69b6-4930-a08d-b8574d341d09)
can be repro with
https://explorer.oasis.io/mainnet/sapphire -> dev tools -> mainnet_consensus.json -> block request domain