### PR TITLE
Show precise balance in chart tooltip

### DIFF
--- a/.changelog/1600.bugfix.md
+++ b/.changelog/1600.bugfix.md
@@ -1,0 +1,1 @@
+Show precise balance in chart tooltip

--- a/src/app/components/charts/Tooltip.tsx
+++ b/src/app/components/charts/Tooltip.tsx
@@ -17,7 +17,7 @@ export const StyledPaper = styled(Paper)(({ theme }) => ({
 
 export type Formatters = {
   formatters?: {
-    data?: (value: number) => string
+    data?: (value: number, payload?: { [key: string]: string | number }) => string
     label?: (value: string) => string
   }
 }
@@ -36,7 +36,6 @@ export const TooltipContent = ({
   if (!active || !payload || !payload.length) {
     return null
   }
-
   const { [payload[0].dataKey!]: value, ...rest } = payload[0].payload
   const labelKey = dataLabelKey || Object.keys(rest)[0]
 
@@ -46,7 +45,7 @@ export const TooltipContent = ({
         {formatters?.label ? formatters.label(payload[0].payload[labelKey]) : payload[0].payload[labelKey]}
       </Typography>
       <Typography paragraph={false} sx={{ fontSize: 12, fontWeight: 600 }}>
-        {formatters?.data ? formatters.data(payload[0].value!) : payload[0].value}
+        {formatters?.data ? formatters.data(payload[0].value!, payload[0].payload.payload) : payload[0].value}
       </Typography>
     </StyledPaper>
   )

--- a/src/app/pages/ConsensusAccountDetailsPage/BalanceDistribution.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/BalanceDistribution.tsx
@@ -53,17 +53,21 @@ const BalanceDistributionContent: FC<BalanceDistributionContentProps> = ({ accou
     return <ConsensusAccountCardEmptyState label={t('account.noBalances')} />
   }
 
+  // value props have rounding issues. Avoid displaying in text, but they are fine for visualization
   const data = [
     {
       label: t('account.available'),
+      preciseValue: account.available,
       value: Number(account.available),
     },
     {
       label: t('common.staked'),
+      preciseValue: account.delegations_balance,
       value: Number(account.delegations_balance),
     },
     {
       label: t('account.debonding'),
+      preciseValue: account.debonding_delegations_balance,
       value: Number(account.debonding_delegations_balance),
     },
   ]
@@ -88,9 +92,9 @@ const BalanceDistributionContent: FC<BalanceDistributionContentProps> = ({ accou
           data={data}
           dataKey="value"
           formatters={{
-            data: (value: number) =>
+            data: (value, payload) =>
               t('common.valueInToken', {
-                ...getPreciseNumberFormat(value.toString()),
+                ...getPreciseNumberFormat(String(payload!.preciseValue)),
                 ticker: account.ticker,
               }),
             label: (label: string) => label,

--- a/src/app/pages/ValidatorDetailsPage/BalanceDistributionCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/BalanceDistributionCard.tsx
@@ -20,13 +20,16 @@ function chartData(t: TFunction, validator: Validator | undefined) {
     return []
   }
 
+  // value props have rounding issues. Avoid displaying in text, but they are fine for visualization
   return [
     {
       label: t('validator.self'),
+      preciseValue: validator.escrow.self_delegation_balance,
       value: Number(validator.escrow.self_delegation_balance),
     },
     {
       label: t('validator.others'),
+      preciseValue: validator.escrow.self_delegation_balance,
       value: Number(validator.escrow.otherBalance),
     },
   ]
@@ -59,9 +62,9 @@ export const BalanceDistributionCard: FC<BalanceDistributionCardProps> = ({ vali
           data={chartData(t, validator)}
           dataKey="value"
           formatters={{
-            data: (value: number) =>
+            data: (value, payload) =>
               t('common.valueInToken', {
-                ...getPreciseNumberFormat(value.toString()),
+                ...getPreciseNumberFormat(String(payload!.preciseValue)),
                 ticker: validator.ticker,
               }),
             label: (label: string) => label,


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/explorer/issues/1520

recharts expects value to be a number and that's a place where we loose precision. Introduce additional, optional data prop that can be extracted in formatters

acc
https://pr-1600.oasis-explorer.pages.dev/mainnet/consensus/address/oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p
https://explorer.dev.oasis.io/mainnet/consensus/address/oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p

validator
https://pr-1600.oasis-explorer.pages.dev/mainnet/consensus/validators/oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe
https://explorer.dev.oasis.io/mainnet/consensus/validators/oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe