### PR TITLE
Extend named accounts with ERC-20 and ERC-721 tokens

### DIFF
--- a/.changelog/1632.feature.md
+++ b/.changelog/1632.feature.md
@@ -1,0 +1,1 @@
+Extend named accounts with ERC-20 and ERC-721 tokens

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -45,6 +45,7 @@ const WithTypographyAndLink: FC<{
 }
 
 interface Props {
+  showAddressAsName?: boolean
   scope: SearchScope
   address: string
 
@@ -79,6 +80,7 @@ interface Props {
 }
 
 export const AccountLink: FC<Props> = ({
+  showAddressAsName,
   scope,
   address,
   alwaysTrim,
@@ -93,7 +95,7 @@ export const AccountLink: FC<Props> = ({
     // isError, // Use this to indicate that we have failed to load the name for this account
   } = useAccountMetadata(scope, address)
   const accountName = accountMetadata?.name // TODO: we should also use the description
-
+  const showAccountName = !showAddressAsName && accountName
   const to = RouteUtils.getAccountRoute(scope, address)
 
   const extraTooltipWithIcon = extraTooltip ? (
@@ -119,13 +121,13 @@ export const AccountLink: FC<Props> = ({
         <MaybeWithTooltip
           title={
             <div>
-              {accountName && <Box sx={{ fontWeight: 'bold' }}>{accountName}</Box>}
+              {showAccountName && <Box sx={{ fontWeight: 'bold' }}>{accountName}</Box>}
               <Box sx={{ fontWeight: 'normal' }}>{address}</Box>
               {extraTooltipWithIcon}
             </div>
           }
         >
-          {accountName ? trimLongString(accountName, 12, 0) : trimLongString(address, 6, 6)}
+          {showAccountName ? trimLongString(accountName, 12, 0) : trimLongString(address, 6, 6)}
         </MaybeWithTooltip>
       </WithTypographyAndLink>
     )
@@ -138,7 +140,7 @@ export const AccountLink: FC<Props> = ({
     return (
       <WithTypographyAndLink to={to} labelOnly={labelOnly}>
         <MaybeWithTooltip title={extraTooltipWithIcon}>
-          {accountName ? (
+          {showAccountName ? (
             <span>
               <HighlightedText text={accountName} pattern={highlightedPartOfName} /> ({address})
             </span>
@@ -157,7 +159,7 @@ export const AccountLink: FC<Props> = ({
     <WithTypographyAndLink to={to} mobile labelOnly={labelOnly}>
       <>
         <AdaptiveHighlightedText
-          text={accountName}
+          text={showAccountName ? accountName : ''}
           pattern={highlightedPartOfName}
           extraTooltip={extraTooltip}
         />

--- a/src/app/components/Account/RuntimeAccountDetailsView.tsx
+++ b/src/app/components/Account/RuntimeAccountDetailsView.tsx
@@ -76,7 +76,12 @@ export const RuntimeAccountDetailsView: FC<RuntimeAccountDetailsViewProps> = ({
         <AccountAvatar account={account} />
       </StyledListTitleWithAvatar>
       <dd>
-        <AccountLink scope={account} address={address!} highlightedPartOfName={highlightedPartOfName} />
+        <AccountLink
+          showAddressAsName
+          scope={account}
+          address={address!}
+          highlightedPartOfName={highlightedPartOfName}
+        />
         <CopyToClipboard value={address!} />
       </dd>
 

--- a/src/app/components/Tokens/TokenDetails.tsx
+++ b/src/app/components/Tokens/TokenDetails.tsx
@@ -59,7 +59,11 @@ export const TokenDetails: FC<{
       <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
       <dd>
         <span>
-          <AccountLink scope={token} address={token.eth_contract_addr ?? token.contract_addr} />
+          <AccountLink
+            showAddressAsName
+            scope={token}
+            address={token.eth_contract_addr ?? token.contract_addr}
+          />
           <CopyToClipboard value={token.eth_contract_addr ?? token.contract_addr} />
         </span>
       </dd>

--- a/src/app/components/Tokens/TokenList.tsx
+++ b/src/app/components/Tokens/TokenList.tsx
@@ -108,6 +108,7 @@ export const TokenList = (props: TokensProps) => {
           content: (
             <span>
               <AccountLink
+                showAddressAsName
                 scope={token}
                 address={token.eth_contract_addr ?? token.contract_addr}
                 alwaysTrim

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -21,19 +21,19 @@ import { hasTextMatch } from '../components/HighlightedText/text-matching'
 const dataSources: Record<Network, Partial<Record<Layer, string>>> = {
   [Network.mainnet]: {
     [Layer.consensus]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_consensus.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/mainnet_consensus.json',
     [Layer.emerald]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_paratime.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/mainnet_emerald.json',
     [Layer.sapphire]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/mainnet_paratime.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/mainnet_sapphire.json',
   },
   [Network.testnet]: {
     [Layer.consensus]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_consensus.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_consensus.json',
     [Layer.emerald]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_paratime.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_emerald.json',
     [Layer.sapphire]:
-      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/account-names/testnet_paratime.json',
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_sapphire.json',
   },
   [Network.localnet]: {
     [Layer.consensus]: undefined,

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -56,7 +56,11 @@ export const TokenDetailsCard: FC<{ scope: SearchScope; address: string; searchT
             )}
             <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
             <dd>
-              <AccountLink scope={account} address={account.address_eth || account.address} />
+              <AccountLink
+                showAddressAsName
+                scope={account}
+                address={account.address_eth || account.address}
+              />
               <CopyToClipboard value={account.address_eth || account.address} />
             </dd>
 


### PR DESCRIPTION
Closes [#1627](https://github.com/oasisprotocol/explorer/issues/1627)
Needs https://github.com/oasisprotocol/nexus/pull/798

sample acc:
https://pr-1632.oasis-explorer.pages.dev/mainnet/sapphire/address/0x8Bba8906467831962Ed5E524F4Bc47733CBF3b27

vs prod
https://explorer.oasis.io/mainnet/sapphire/address/0x8Bba8906467831962Ed5E524F4Bc47733CBF3b27