### PR TITLE
Use correct query param in token transfers card

### DIFF
--- a/.changelog/1638.bugfix.md
+++ b/.changelog/1638.bugfix.md
@@ -1,0 +1,1 @@
+Use correct query param in token Transfers card

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -20,7 +20,7 @@ export const AccountTokenTransfersCard: FC<RuntimeAccountDetailsContext> = ({ sc
 
 const AccountTokenTransfers: FC<RuntimeAccountDetailsContext> = ({ scope, address, account }) => {
   const { t } = useTranslation()
-  const { isLoading, isFetched, results } = useTokenTransfers(scope, { address })
+  const { isLoading, isFetched, results } = useTokenTransfers(scope, { rel: address })
 
   const transfers = results.data
 

--- a/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTransfersCard.tsx
@@ -23,7 +23,11 @@ export const TokenTransfersCard: FC<TokenDashboardContext> = ({ scope, address }
 const TokenTransfersView: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
-  const { isLoading: areTransfersLoading, isFetched, results } = useTokenTransfers(scope, { address })
+  const {
+    isLoading: areTransfersLoading,
+    isFetched,
+    results,
+  } = useTokenTransfers(scope, { contract_address: address })
 
   const { isLoading: isTokenLoading } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -36,18 +36,14 @@ export const useTokenInfo = (scope: SearchScope, address: string, enabled = true
   }
 }
 
-export const useTokenTransfers = (scope: SearchScope, params: { address: string }) => {
-  return _useTokenTransfers(scope, { rel: params.address })
-}
-
 export const useNFTInstanceTransfers = (
   scope: SearchScope,
   params: { nft_id: string; contract_address: string },
 ) => {
-  return _useTokenTransfers(scope, { nft_id: params.nft_id, contract_address: params.contract_address })
+  return useTokenTransfers(scope, { nft_id: params.nft_id, contract_address: params.contract_address })
 }
 
-export const _useTokenTransfers = (scope: SearchScope, params: undefined | GetRuntimeEventsParams) => {
+export const useTokenTransfers = (scope: SearchScope, params: undefined | GetRuntimeEventsParams) => {
   if (params && Object.values(params).some(value => value === undefined || value === null)) {
     throw new Error('Must set params=undefined while some values are unavailable')
   }


### PR DESCRIPTION
- Waits for Nexus as query is missing index https://github.com/oasisprotocol/nexus/issues/804

Requested by @ptrus 

> The contract_address only returns event that are emitted by the contract. So this is what we want on the transfer page for contracts.

sample url: https://pr-1638.oasis-explorer.pages.dev/mainnet/sapphire/token/0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8