### PR TITLE
 Handle runtime consensus transactions status

### DIFF
--- a/.changelog/1647.bugfix.md
+++ b/.changelog/1647.bugfix.md
@@ -1,0 +1,1 @@
+Handle runtime consensus transactions status

--- a/src/app/components/RuntimeEvents/EventError.tsx
+++ b/src/app/components/RuntimeEvents/EventError.tsx
@@ -33,7 +33,7 @@ export const EventError: FC<EventErrorProps> = ({ event }) => {
   const errorMessage = `${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module}`
   return (
     <>
-      <StyledBox success={false} error={undefined} withText={true}>
+      <StyledBox status="failure" withText>
         {t('common.failed')}
         &nbsp;
         <CancelIcon color="error" fontSize="inherit" />

--- a/src/app/components/RuntimeEvents/EventError.tsx
+++ b/src/app/components/RuntimeEvents/EventError.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import CancelIcon from '@mui/icons-material/Cancel'
 import { RuntimeEvent } from '../../../oasis-nexus/api'
-import { ErrorBox, StyledBox } from '../StatusIcon'
+import { StatusDetails, StyledBox } from '../StatusIcon'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { RuntimeEventType } from '../../../oasis-nexus/api'
@@ -38,7 +38,7 @@ export const EventError: FC<EventErrorProps> = ({ event }) => {
         &nbsp;
         <CancelIcon color="error" fontSize="inherit" />
       </StyledBox>
-      <ErrorBox>{errorMessage}</ErrorBox>
+      <StatusDetails error>{errorMessage}</StatusDetails>
     </>
   )
 }

--- a/src/app/components/StatusIcon/index.tsx
+++ b/src/app/components/StatusIcon/index.tsx
@@ -58,14 +58,16 @@ export const StyledBox = styled(Box, {
   }
 })
 
-export const ErrorBox = styled(Box)(() => ({
+export const StatusDetails = styled(Box, {
+  shouldForwardProp: prop => prop !== 'error',
+})(({ error }: { error?: boolean }) => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
   minHeight: '28px',
   fontSize: '12px',
   backgroundColor: COLORS.grayLight,
-  color: COLORS.errorIndicatorBackground,
+  color: error ? COLORS.errorIndicatorBackground : COLORS.warningColor,
   borderRadius: 10,
   paddingLeft: 12,
   paddingRight: 12,
@@ -94,7 +96,10 @@ const pendingMethodLabels = {
   'consensus.Undelegate': 'transaction.undelegate',
 } as const
 
-const getPendingLabel = (t: TFunction, method: string | undefined) => {
+const getPendingLabel = (t: TFunction, method: string | undefined, withText?: boolean) => {
+  if (withText) {
+    return t('transaction.started')
+  }
   const translationKey = pendingMethodLabels[method as keyof typeof pendingMethodLabels]
   const translatedMethod = translationKey ? t(translationKey) : method
   return t('transaction.startedDescription', { method: translatedMethod })
@@ -114,7 +119,7 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText, meth
     unknown: t('common.unknown'),
     success: t('common.success'),
     failure: t('common.failed'),
-    pending: getPendingLabel(t, method),
+    pending: getPendingLabel(t, method, withText),
   }
   const errorMessage = useTxErrorMessage(error)
 
@@ -126,7 +131,8 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText, meth
           &nbsp;
           {statusIcon[status]}
         </StyledBox>
-        {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
+        {errorMessage && <StatusDetails error>{errorMessage}</StatusDetails>}
+        {!errorMessage && status === 'pending' && <StatusDetails>{getPendingLabel(t, method)}</StatusDetails>}
       </>
     )
   } else {

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -74,7 +74,9 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
       key: `${transaction.hash}${transaction.index}`,
       data: [
         {
-          content: <StatusIcon success={transaction.success} error={transaction.error} />,
+          content: (
+            <StatusIcon success={transaction.success} error={transaction.error} method={transaction.method} />
+          ),
           key: 'success',
         },
         ...(verbose && canHaveEncryption

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -61,6 +61,7 @@ export const RuntimeTransactionDetailPage: FC = () => {
   if (!transaction && !isLoading) {
     throw AppErrors.NotFoundTxHash
   }
+
   return (
     <PageLayout>
       <MultipleTransactionsWarning enable={warningMultipleTransactionsSameHash} />
@@ -133,7 +134,12 @@ export const RuntimeTransactionDetailView: FC<{
 
           <dt>{t('common.status')}</dt>
           <dd style={{ flexWrap: 'wrap', gap: '10px' }}>
-            <StatusIcon success={transaction.success} error={transaction.error} withText={true} />
+            <StatusIcon
+              success={transaction.success}
+              error={transaction.error}
+              withText={true}
+              method={transaction.method}
+            />
           </dd>
 
           <dt>{t('common.block')}</dt>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -459,13 +459,19 @@
     }
   },
   "transaction": {
+    "delegate": "Delegate",
+    "deposit": "Deposit",
     "header": "Transaction",
-    "warningMultipleTransactionsSameHash": "Please make sure you're looking at the right transaction. There is more than one transaction with this hash, which is extremely rare. We are showing the most recent successful one.",
     "rawData": "Raw Data",
+    "started": "Started",
+    "startedDescription": "{{ method }} has started, final result will be known in the next block",
     "tooltips": {
       "txEncrypted": "This transaction is encrypted.",
       "txNotEncrypted": "This transaction is <strong>not</strong> encrypted."
-    }
+    },
+    "undelegate": "Undelegate",
+    "warningMultipleTransactionsSameHash": "Please make sure you're looking at the right transaction. There is more than one transaction with this hash, which is extremely rare. We are showing the most recent successful one.",
+    "withdraw": "Withdraw"
   },
   "event": {
     "cantLoadEvents": "Unfortunately we couldn't load the list of events. Please try again later.",


### PR DESCRIPTION
Sync with https://github.com/oasisprotocol/nexus/pull/820

Fixes https://github.com/oasisprotocol/explorer/issues/528

For some runtime Consensus.* methods we want to show more meaningful status when `success` prop does not exist.

![Screenshot from 2024-12-06 11-05-56](https://github.com/user-attachments/assets/86ecb8e1-ee55-4133-813e-7ab5f012bb13)
![Screenshot from 2024-12-06 11-21-07](https://github.com/user-attachments/assets/87384a28-3750-476b-99a0-aa190eb900a6)
