### PR TITLE
Fix wrong total balance amount in Consensus accounts list

### DIFF
--- a/.changelog/1655.bugfix.md
+++ b/.changelog/1655.bugfix.md
@@ -1,0 +1,1 @@
+Fix wrong total balance amount in Consensus accounts list

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -418,17 +418,17 @@ export const useGetConsensusAccountsAddress: typeof generated.useGetConsensusAcc
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.Account, headers, status) => {
           if (status !== 200) return data
-          // TODO: remove defaults when API is updated
-          const { available, delegations_balance = 0, debonding_delegations_balance = 0 } = data
           const total =
-            BigInt(data.available) + BigInt(delegations_balance) + BigInt(debonding_delegations_balance)
+            BigInt(data.available) +
+            BigInt(data.delegations_balance) +
+            BigInt(data.debonding_delegations_balance)
           return {
             ...data,
-            available: fromBaseUnits(available, consensusDecimals),
+            available: fromBaseUnits(data.available, consensusDecimals),
             total: fromBaseUnits(total.toString(), consensusDecimals),
-            delegations_balance: fromBaseUnits(delegations_balance.toString(), consensusDecimals),
+            delegations_balance: fromBaseUnits(data.delegations_balance.toString(), consensusDecimals),
             debonding_delegations_balance: fromBaseUnits(
-              debonding_delegations_balance.toString(),
+              data.debonding_delegations_balance.toString(),
               consensusDecimals,
             ),
             layer: Layer.consensus,
@@ -1295,21 +1295,18 @@ export const useGetConsensusAccounts: typeof generated.useGetConsensusAccounts =
           return {
             ...data,
             accounts: data.accounts.map(account => {
-              // TODO: remove when API returns total value, looking at query filters we store that data in Nexus
-              // or sum proper fields when they are available. Currently API does not return correct fields in accounts list endpoint
-              // https://github.com/oasisprotocol/explorer/pull/1160#discussion_r1459577303
-              const total = BigInt(account.available)
-
-              // TODO: remove defaults when API is updated and after re-index
-              const { delegations_balance = 0, debonding_delegations_balance = 0 } = account
+              const total =
+                BigInt(account.available) +
+                BigInt(account.delegations_balance) +
+                BigInt(account.debonding_delegations_balance)
 
               return {
                 ...account,
                 available: fromBaseUnits(account.available, consensusDecimals),
                 total: fromBaseUnits(total.toString(), consensusDecimals),
-                delegations_balance: fromBaseUnits(delegations_balance.toString(), consensusDecimals),
+                delegations_balance: fromBaseUnits(account.delegations_balance.toString(), consensusDecimals),
                 debonding_delegations_balance: fromBaseUnits(
-                  debonding_delegations_balance.toString(),
+                  account.debonding_delegations_balance.toString(),
                   consensusDecimals,
                 ),
                 layer: Layer.consensus,


### PR DESCRIPTION
We are showing wrong size badge and total balance. 
Based on backend feedback we don't need defaults anymore. 

master
![Screenshot from 2024-12-13 15-14-49](https://github.com/user-attachments/assets/65421578-01eb-438b-83b0-32b171c3b810)

vs

![Screenshot from 2024-12-13 15-14-58](https://github.com/user-attachments/assets/3f38c9c6-675c-4fc9-89e5-740f17632215)
