### PR TITLE
Set API limit when fetching data for named validators

### DIFF
--- a/.changelog/1673.bugfix.md
+++ b/.changelog/1673.bugfix.md
@@ -1,0 +1,1 @@
+Set API limit when fetching data for named validators


### PR DESCRIPTION
The only change here is `limit: API_MAX_TOTAL_COUNT`. Without it `limit` defaults to 100 which means we are not showing names for all validators and we are not able to find them by name. 

sample `TO` row, master
https://explorer.oasis.io/mainnet/consensus/tx/fa2ff37ed0e231ce1845d7f43b8373056907483af8bebdae116c4003d1776e79

vs
https://pr-1673.oasis-explorer.pages.dev/mainnet/consensus/tx/fa2ff37ed0e231ce1845d7f43b8373056907483af8bebdae116c4003d1776e79