### PR TITLE
Fix regression on global search 404 page

### DIFF
--- a/.changelog/1678.bugfix.md
+++ b/.changelog/1678.bugfix.md
@@ -1,0 +1,1 @@
+Fix regression on global search 404 page

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -15,7 +15,7 @@ export function useRedirectIfSingleResult(
   results: SearchResults,
 ) {
   const navigate = useNavigate()
-  const { data: validatorsData } = useGetConsensusValidatorsAddressNameMap(results[0].network)
+  const { data: validatorsData } = useGetConsensusValidatorsAddressNameMap(results[0]?.network)
   const { searchTerm, accountNameFragment, evmAccount, consensusAccount } = searchParams
 
   let shouldRedirect = results.length === 1


### PR DESCRIPTION
Before fix:

![image](https://github.com/user-attachments/assets/7a248b28-9463-443e-893e-4318a0a6e69b)

After fix:

![image](https://github.com/user-attachments/assets/3c2414ca-c334-4f66-9c90-7ece5aa38830)
