### PR TITLE
Add support for filtering TX lists for method type

### DIFF
--- a/.changelog/1679.feature.md
+++ b/.changelog/1679.feature.md
@@ -1,0 +1,1 @@
+Add support for filtering latest TX list for method type

--- a/.changelog/1679.feature.md
+++ b/.changelog/1679.feature.md
@@ -1,1 +1,1 @@
-Add support for filtering latest TX list for method type
+Add support for filtering transactions by method type

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -18,6 +18,8 @@ import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
 import { ConsensusTxMethod } from '../../../oasis-nexus/api'
 import { COLORS } from '../../../styles/theme/colors'
+import { SelectOptionBase } from '../Select'
+import { exhaustedTypeWarning } from '../../../types/errors'
 
 type MethodIconProps = {
   border?: boolean
@@ -171,30 +173,9 @@ const MethodIconWithTruncatedLabel: FC<MethodIconProps> = props => {
 }
 
 const getConsensusTransactionLabel = (t: TFunction, method: ConsensusTxMethod | undefined): string => {
-  /**
-   * TODO: Missing values:
-   *
-   *  consensusMeta
-   *  keymanagerPublishEphemeralSecret
-   *  keymanagerPublishMasterSecret
-   *  keymanagerUpdatePolicy
-   *  registryDeregisterEntity
-   *  registryProveFreshness
-   *  registryUnfreezeNode
-   *  roothashEvidence
-   *  roothashSubmitMsg
-   *  stakingBurn
-   *  keymanager/churpApply
-   *  keymanager/churpConfirm
-   *  keymanager/churpCreate
-   *  keymanager/churpUpdate
-   *  vaultAuthorizeAction
-   *  vaultCancelAction
-   *  vaultCreate
-   */
-
   // Please note: when updating this, keep it in sync
   // with the knownConsensusTxMethods array below!
+
   switch (method) {
     case ConsensusTxMethod.stakingTransfer:
       return t('transactions.method.stakingTransfer')
@@ -228,10 +209,97 @@ const getConsensusTransactionLabel = (t: TFunction, method: ConsensusTxMethod | 
       return t('transactions.method.beaconPVSSReveal')
     case ConsensusTxMethod.beaconVRFProve:
       return t('transactions.method.beaconVRFProve')
+    case ConsensusTxMethod.consensusMeta:
+      return t('transactions.method.consensus.meta')
+    case ConsensusTxMethod.keymanagerPublishEphemeralSecret:
+      return t('transactions.method.keyManager.publishEphemeralSecret')
+    case ConsensusTxMethod.keymanagerPublishMasterSecret:
+      return t('transactions.method.keyManager.publishMasterSecret')
+    case ConsensusTxMethod.keymanagerUpdatePolicy:
+      return t('transactions.method.keyManager.updatePolicy')
+    case ConsensusTxMethod['keymanager/churpApply']:
+      return t('transactions.method.keyManager.churp.apply')
+    case ConsensusTxMethod['keymanager/churpConfirm']:
+      return t('transactions.method.keyManager.churp.confirm')
+    case ConsensusTxMethod['keymanager/churpCreate']:
+      return t('transactions.method.keyManager.churp.create')
+    case ConsensusTxMethod['keymanager/churpUpdate']:
+      return t('transactions.method.keyManager.churp.update')
+    case ConsensusTxMethod.registryDeregisterEntity:
+      return t('transactions.method.registryDeregisterEntity')
+    case ConsensusTxMethod.registryProveFreshness:
+      return t('transactions.method.registryProveFreshness')
+    case ConsensusTxMethod.registryUnfreezeNode:
+      return t('transactions.method.registryUnfreezeNode')
+    case ConsensusTxMethod.roothashEvidence:
+      return t('transactions.method.roothashEvidence')
+    case ConsensusTxMethod.roothashSubmitMsg:
+      return t('transactions.method.roothashSubmitMessage')
+    case ConsensusTxMethod.stakingBurn:
+      return t('transactions.method.stakingBurn')
+    case ConsensusTxMethod.vaultAuthorizeAction:
+      return t('transactions.method.vault.authorizeAction')
+    case ConsensusTxMethod.vaultCancelAction:
+      return t('transactions.method.vault.cancelAction')
+    case ConsensusTxMethod.vaultCreate:
+      return t('transactions.method.vault.create')
+    case undefined:
+      return t('common.missing')
     default:
+      exhaustedTypeWarning('Unexpected consensus transaction method', method)
       return method || t('common.unknown')
   }
 }
+
+// List of known consensus ts types, to offer in filter
+// Please keep them in alphabetical order
+const knownConsensusTxMethods = [
+  ConsensusTxMethod.stakingAllow,
+  ConsensusTxMethod.stakingAmendCommissionSchedule,
+  ConsensusTxMethod.governanceCastVote,
+  ConsensusTxMethod.stakingBurn,
+  ConsensusTxMethod.consensusMeta,
+  ConsensusTxMethod.stakingWithdraw,
+  ConsensusTxMethod.registryDeregisterEntity,
+  ConsensusTxMethod.roothashExecutorCommit,
+  ConsensusTxMethod.roothashExecutorProposerTimeout,
+  ConsensusTxMethod['keymanager/churpApply'],
+  ConsensusTxMethod['keymanager/churpConfirm'],
+  ConsensusTxMethod['keymanager/churpCreate'],
+  ConsensusTxMethod['keymanager/churpUpdate'],
+  ConsensusTxMethod.keymanagerPublishEphemeralSecret,
+  ConsensusTxMethod.keymanagerPublishMasterSecret,
+  ConsensusTxMethod.keymanagerUpdatePolicy,
+  ConsensusTxMethod.beaconPVSSCommit,
+  ConsensusTxMethod.beaconPVSSReveal,
+  ConsensusTxMethod.registryRegisterEntity,
+  ConsensusTxMethod.registryRegisterNode,
+  ConsensusTxMethod.registryRegisterRuntime,
+  ConsensusTxMethod.registryProveFreshness,
+  ConsensusTxMethod.registryUnfreezeNode,
+  ConsensusTxMethod.roothashEvidence,
+  ConsensusTxMethod.roothashSubmitMsg,
+  ConsensusTxMethod.stakingAddEscrow,
+  ConsensusTxMethod.stakingReclaimEscrow,
+  ConsensusTxMethod.governanceSubmitProposal,
+  ConsensusTxMethod.stakingTransfer,
+  ConsensusTxMethod.beaconVRFProve,
+  ConsensusTxMethod.vaultAuthorizeAction,
+  ConsensusTxMethod.vaultCancelAction,
+  ConsensusTxMethod.vaultCreate,
+] satisfies ConsensusTxMethod[]
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const typeTestExhaustiveArray =
+  undefined as unknown as ConsensusTxMethod satisfies (typeof knownConsensusTxMethods)[number]
+
+export const getConsensusTxMethodOptions = (t: TFunction): SelectOptionBase[] =>
+  knownConsensusTxMethods.map(
+    (method): SelectOptionBase => ({
+      value: method,
+      label: getConsensusTransactionLabel(t, method),
+    }),
+  )
 
 const getConsensusTransactionMethod = (
   t: TFunction,
@@ -275,7 +343,27 @@ const getConsensusTransactionMethod = (
       return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.beaconVRFProve:
       return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
+    case ConsensusTxMethod['keymanager/churpApply']: // TODO: provide dedicated icon
+    case ConsensusTxMethod['keymanager/churpConfirm']: // TODO: provide dedicated icon
+    case ConsensusTxMethod['keymanager/churpCreate']: // TODO: provide dedicated icon
+    case ConsensusTxMethod['keymanager/churpUpdate']: // TODO: provide dedicated icon
+    case ConsensusTxMethod.vaultCreate: // TODO: provide dedicated icon
+    case ConsensusTxMethod.keymanagerPublishEphemeralSecret: // TODO: provide dedicated icon
+    case ConsensusTxMethod.keymanagerPublishMasterSecret: // TODO: provide dedicated icon
+    case ConsensusTxMethod.keymanagerUpdatePolicy: // TODO: provide dedicated icon
+    case ConsensusTxMethod.registryDeregisterEntity: // TODO: provide dedicated icon
+    case ConsensusTxMethod.registryProveFreshness: // TODO: provide dedicated icon
+    case ConsensusTxMethod.registryUnfreezeNode: // TODO: provide dedicated icon
+    case ConsensusTxMethod.roothashEvidence: // TODO: provide dedicated icon
+    case ConsensusTxMethod.roothashSubmitMsg: // TODO: provide dedicated icon
+    case ConsensusTxMethod.vaultAuthorizeAction: // TODO: provide dedicated icon
+    case ConsensusTxMethod.vaultCancelAction: // TODO: provide dedicated icon
+    case ConsensusTxMethod.consensusMeta: // TODO: provide dedicated icon
+    case ConsensusTxMethod.stakingBurn: // TODO: provide dedicated icon
+    case undefined:
+      return <MethodIcon color="gray" icon={<QuestionMarkIcon />} label={label} {...props} />
     default:
+      exhaustedTypeWarning('Unexpected consensus transaction method', method)
       return <MethodIcon color="gray" icon={<QuestionMarkIcon />} label={label} {...props} />
   }
 }

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -170,6 +170,69 @@ const MethodIconWithTruncatedLabel: FC<MethodIconProps> = props => {
   )
 }
 
+const getConsensusTransactionLabel = (t: TFunction, method: ConsensusTxMethod | undefined): string => {
+  /**
+   * TODO: Missing values:
+   *
+   *  consensusMeta
+   *  keymanagerPublishEphemeralSecret
+   *  keymanagerPublishMasterSecret
+   *  keymanagerUpdatePolicy
+   *  registryDeregisterEntity
+   *  registryProveFreshness
+   *  registryUnfreezeNode
+   *  roothashEvidence
+   *  roothashSubmitMsg
+   *  stakingBurn
+   *  keymanager/churpApply
+   *  keymanager/churpConfirm
+   *  keymanager/churpCreate
+   *  keymanager/churpUpdate
+   *  vaultAuthorizeAction
+   *  vaultCancelAction
+   *  vaultCreate
+   */
+
+  // Please note: when updating this, keep it in sync
+  // with the knownConsensusTxMethods array below!
+  switch (method) {
+    case ConsensusTxMethod.stakingTransfer:
+      return t('transactions.method.stakingTransfer')
+    case ConsensusTxMethod.stakingAddEscrow:
+      return t('transactions.method.stakingAddEscrow')
+    case ConsensusTxMethod.stakingReclaimEscrow:
+      return t('transactions.method.stakingReclaimEscrow')
+    case ConsensusTxMethod.stakingAmendCommissionSchedule:
+      return t('transactions.method.stakingAmendCommissionSchedule')
+    case ConsensusTxMethod.stakingAllow:
+      return t('transactions.method.stakingAllow')
+    case ConsensusTxMethod.stakingWithdraw:
+      return t('transactions.method.stakingWithdraw')
+    case ConsensusTxMethod.roothashExecutorCommit:
+      return t('transactions.method.roothashExecutorCommit')
+    case ConsensusTxMethod.roothashExecutorProposerTimeout:
+      return t('transactions.method.roothashExecutorProposerTimeout')
+    case ConsensusTxMethod.registryRegisterEntity:
+      return t('transactions.method.registryRegisterEntity')
+    case ConsensusTxMethod.registryRegisterNode:
+      return t('transactions.method.registryRegisterNode')
+    case ConsensusTxMethod.registryRegisterRuntime:
+      return t('transactions.method.registryRegisterRuntime')
+    case ConsensusTxMethod.governanceCastVote:
+      return t('transactions.method.governanceCastVote')
+    case ConsensusTxMethod.governanceSubmitProposal:
+      return t('transactions.method.governanceSubmitProposal')
+    case ConsensusTxMethod.beaconPVSSCommit:
+      return t('transactions.method.beaconPVSSCommit')
+    case ConsensusTxMethod.beaconPVSSReveal:
+      return t('transactions.method.beaconPVSSReveal')
+    case ConsensusTxMethod.beaconVRFProve:
+      return t('transactions.method.beaconVRFProve')
+    default:
+      return method || t('common.unknown')
+  }
+}
+
 const getConsensusTransactionMethod = (
   t: TFunction,
   method: ConsensusTxMethod | undefined,
@@ -178,135 +241,42 @@ const getConsensusTransactionMethod = (
   const props = {
     truncate,
   }
+  const label = getConsensusTransactionLabel(t, method)
   switch (method) {
     case ConsensusTxMethod.stakingTransfer:
-      return (
-        <MethodIcon
-          color="green"
-          icon={<ArrowForwardIcon />}
-          label={t('transactions.method.stakingTransfer')}
-          {...props}
-        />
-      )
+      return <MethodIcon color="green" icon={<ArrowForwardIcon />} label={label} {...props} />
     case ConsensusTxMethod.stakingAddEscrow:
-      return (
-        <MethodIcon
-          color="green"
-          icon={<ExitToAppIcon />}
-          label={t('transactions.method.stakingAddEscrow')}
-          {...props}
-        />
-      )
+      return <MethodIcon color="green" icon={<ExitToAppIcon />} label={label} {...props} />
     case ConsensusTxMethod.stakingReclaimEscrow:
-      return (
-        <MethodIcon
-          icon={<ExitToAppIcon />}
-          label={t('transactions.method.stakingReclaimEscrow')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<ExitToAppIcon />} label={label} {...props} />
     case ConsensusTxMethod.stakingAmendCommissionSchedule:
-      return (
-        <MethodIcon
-          icon={<PriceChangeIcon />}
-          label={t('transactions.method.stakingAmendCommissionSchedule')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<PriceChangeIcon />} label={label} {...props} />
     case ConsensusTxMethod.stakingAllow:
-      return (
-        <MethodIcon icon={<LibraryAddCheckIcon />} label={t('transactions.method.stakingAllow')} {...props} />
-      )
+      return <MethodIcon icon={<LibraryAddCheckIcon />} label={label} {...props} />
     case ConsensusTxMethod.stakingWithdraw:
-      return (
-        <MethodIcon
-          color="green"
-          icon={<ArrowDownwardIcon />}
-          label={t('transactions.method.stakingWithdraw')}
-          {...props}
-        />
-      )
+      return <MethodIcon color="green" icon={<ArrowDownwardIcon />} label={label} {...props} />
     case ConsensusTxMethod.roothashExecutorCommit:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.roothashExecutorCommit')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.roothashExecutorProposerTimeout:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.roothashExecutorProposerTimeout')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.registryRegisterEntity:
-      return (
-        <MethodIcon
-          icon={<PersonIcon />}
-          label={t('transactions.method.registryRegisterEntity')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<PersonIcon />} label={label} {...props} />
     case ConsensusTxMethod.registryRegisterNode:
-      return (
-        <MethodIcon icon={<DnsIcon />} label={t('transactions.method.registryRegisterNode')} {...props} />
-      )
+      return <MethodIcon icon={<DnsIcon />} label={label} {...props} />
     case ConsensusTxMethod.registryRegisterRuntime:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.registryRegisterRuntime')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.governanceCastVote:
-      return (
-        <MethodIcon icon={<HowToVoteIcon />} label={t('transactions.method.governanceCastVote')} {...props} />
-      )
+      return <MethodIcon icon={<HowToVoteIcon />} label={label} {...props} />
     case ConsensusTxMethod.governanceSubmitProposal:
-      return (
-        <MethodIcon
-          icon={<AccountBalanceIcon />}
-          label={t('transactions.method.governanceSubmitProposal')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<AccountBalanceIcon />} label={label} {...props} />
     case ConsensusTxMethod.beaconPVSSCommit:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.beaconPVSSCommit')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.beaconPVSSReveal:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.beaconPVSSReveal')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     case ConsensusTxMethod.beaconVRFProve:
-      return (
-        <MethodIcon
-          icon={<MiscellaneousServicesIcon />}
-          label={t('transactions.method.beaconVRFProve')}
-          {...props}
-        />
-      )
+      return <MethodIcon icon={<MiscellaneousServicesIcon />} label={label} {...props} />
     default:
-      return (
-        <MethodIcon
-          color="gray"
-          icon={<QuestionMarkIcon />}
-          label={method || t('common.unknown')}
-          {...props}
-        />
-      )
+      return <MethodIcon color="gray" icon={<QuestionMarkIcon />} label={label} {...props} />
   }
 }
 

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -16,7 +16,7 @@ import PriceChangeIcon from '@mui/icons-material/PriceChange'
 import QuestionMarkIcon from '@mui/icons-material/QuestionMark'
 import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
-import { ConsensusTxMethod } from '../../../oasis-nexus/api'
+import { ConsensusTxMethod, GetConsensusTransactionsParams } from '../../../oasis-nexus/api'
 import { COLORS } from '../../../styles/theme/colors'
 import { SelectOptionBase } from '../Select'
 import { exhaustedTypeWarning } from '../../../types/errors'
@@ -378,3 +378,9 @@ export const ConsensusTransactionMethod: FC<ConsensusTransactionMethodProps> = (
 
   return <>{getConsensusTransactionMethod(t, method, truncate)}</>
 }
+
+export type ConsensusTxMethodFilterOption = ConsensusTxMethod | 'any'
+
+export const getConsensusTransactionMethodFilteringParam = (
+  method: ConsensusTxMethodFilterOption,
+): Partial<GetConsensusTransactionsParams> => (method === 'any' ? {} : { method })

--- a/src/app/components/LinkableCardLayout/index.tsx
+++ b/src/app/components/LinkableCardLayout/index.tsx
@@ -9,12 +9,13 @@ type LinkableCardLayoutProps = {
   children: ReactNode
   containerId: string
   title: ReactNode
+  action?: ReactNode | undefined
 }
-export const LinkableCardLayout: FC<LinkableCardLayoutProps> = ({ children, containerId, title }) => {
+export const LinkableCardLayout: FC<LinkableCardLayoutProps> = ({ children, containerId, title, action }) => {
   return (
     <Card>
       <LinkableDiv id={containerId}>
-        <CardHeader disableTypography component="h3" title={title} />
+        <CardHeader disableTypography component="h3" title={title} action={action} />
       </LinkableDiv>
       <CardContent>
         <ErrorBoundary light={true}>{children}</ErrorBoundary>

--- a/src/app/components/SubPageCard/index.tsx
+++ b/src/app/components/SubPageCard/index.tsx
@@ -14,6 +14,10 @@ type StyledComponentProps = {
   title?: ReactNode
   subheader?: string
   action?: ReactNode
+  /**
+   * An optional second title which will be displayed under title / subheader / action
+   */
+  title2?: ReactNode
   noPadding?: boolean
   mainTitle?: boolean
 }
@@ -69,6 +73,7 @@ export const SubPageCard: FC<SubPageCardProps> = ({
   title,
   subheader,
   action,
+  title2,
   noPadding = false,
   mainTitle = false,
 }) => {
@@ -95,6 +100,17 @@ export const SubPageCard: FC<SubPageCardProps> = ({
             {subheader}
           </Typography>
           {action && <Box sx={{ marginLeft: 'auto' }}>{action}</Box>}
+        </Box>
+      )}
+      {title2 && (
+        <Box
+          sx={{
+            color: theme.palette.layout.titleOnBackground,
+            mb: 4,
+            mx: 4,
+          }}
+        >
+          {title2}
         </Box>
       )}
       <StyledCard featured={featured} noPadding={noPadding}>

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -12,6 +12,7 @@ import { useScreenSize } from '../../hooks/useScreensize'
 import { COLORS } from '../../../styles/theme/colors'
 import { TablePagination, TablePaginationProps } from './TablePagination'
 import { backgroundColorAnimation } from '../../../styles/theme/animations'
+import { CardEmptyState } from '../CardEmptyState'
 
 type SkeletonTableRowsProps = {
   rowsNumber: number
@@ -78,6 +79,13 @@ type TableProps = {
   stickyColumn?: boolean
   extraHorizontalSpaceOnMobile?: boolean | undefined
   alwaysWaitWhileLoading?: boolean | undefined
+  /**
+   * Optional message to display when there are zero entries, instead of the table.
+   *
+   * This will only be displayed when loading finishes and there are no records.
+   * If not given, the table will simply be hidden without any trace.
+   */
+  emptyMessage?: string | undefined
 }
 
 const stickyColumnStyles = {
@@ -101,14 +109,15 @@ export const Table: FC<TableProps> = ({
   stickyColumn = false,
   extraHorizontalSpaceOnMobile = false,
   alwaysWaitWhileLoading = false,
+  emptyMessage = undefined,
 }) => {
   const { isMobile } = useScreenSize()
 
-  if (!isLoading && !rows?.length) {
-    return null
-  }
-
-  return (
+  return !isLoading && !rows?.length ? ( // This is known to be empty
+    emptyMessage ? ( // If we have a message, show it
+      <CardEmptyState label={emptyMessage} />
+    ) : null // otherwise just show nothing
+  ) : (
     <>
       <TableContainer>
         <MuiTable aria-label={name}>

--- a/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react'
+import { getConsensusTxMethodOptions, ConsensusTxMethodFilterOption } from '../ConsensusTransactionMethod'
+import { useTranslation } from 'react-i18next'
+import { Select } from '../Select'
+import Typography from '@mui/material/Typography'
+
+const FilterLabel: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <Typography
+      component={'span'}
+      sx={{
+        fontStyle: 'normal',
+        fontWeight: 700,
+        fontSize: 16,
+        lineHeight: '150%',
+        marginRight: 4,
+      }}
+    >
+      {t('transactions.filterByType')}
+    </Typography>
+  )
+}
+
+export const ConsensusTransactionTypeFilter: FC<{
+  value: ConsensusTxMethodFilterOption
+  setValue: (value: ConsensusTxMethodFilterOption) => void
+  expand?: boolean
+}> = ({ value, setValue, expand }) => {
+  const { t } = useTranslation()
+  return (
+    <Select
+      className={expand ? 'expand' : undefined}
+      light={true}
+      label={<FilterLabel />}
+      options={[{ value: 'any', label: 'Any' }, ...getConsensusTxMethodOptions(t)]}
+      defaultValue={value}
+      handleChange={setValue as any}
+    />
+  )
+}

--- a/src/app/components/Transactions/ConsensusTransactions.tsx
+++ b/src/app/components/Transactions/ConsensusTransactions.tsx
@@ -31,6 +31,7 @@ type ConsensusTransactionsProps = {
   limit: number
   pagination: false | TablePaginationProps
   verbose?: boolean
+  filtered: boolean
 }
 
 export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
@@ -40,6 +41,7 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
   transactions,
   ownAddress,
   verbose = true,
+  filtered,
 }) => {
   const { t } = useTranslation()
 
@@ -142,6 +144,7 @@ export const ConsensusTransactions: FC<ConsensusTransactionsProps> = ({
       name={t('transactions.latest')}
       isLoading={isLoading}
       pagination={pagination}
+      emptyMessage={filtered ? t('tableSearch.noMatchingResults') : t('account.emptyTransactionList')}
     />
   )
 }

--- a/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react'
+import { getRuntimeTxMethodOptions } from '../RuntimeTransactionMethod'
+import { useTranslation } from 'react-i18next'
+import { Select } from '../Select'
+import Typography from '@mui/material/Typography'
+
+const FilterLabel: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <Typography
+      component={'span'}
+      sx={{
+        fontStyle: 'normal',
+        fontWeight: 700,
+        fontSize: 16,
+        lineHeight: '150%',
+        marginRight: 4,
+      }}
+    >
+      {t('transactions.filterByType')}
+    </Typography>
+  )
+}
+
+export const RuntimeTransactionTypeFilter: FC<{
+  value: string
+  setValue: (value: string) => void
+  expand?: boolean
+}> = ({ value, setValue, expand }) => {
+  const { t } = useTranslation()
+  return (
+    <Select
+      className={expand ? 'expand' : undefined}
+      light={true}
+      label={<FilterLabel />}
+      options={[{ value: 'any', label: 'Any' }, ...getRuntimeTxMethodOptions(t)]}
+      defaultValue={value}
+      handleChange={setValue as any}
+    />
+  )
+}

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -31,6 +31,7 @@ type TransactionsProps = {
   transactions?: TableRuntimeTransaction[]
   ownAddress?: string
   isLoading: boolean
+  filtered: boolean
   limit: number
   pagination: false | TablePaginationProps
   verbose?: boolean
@@ -43,6 +44,7 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
   transactions,
   ownAddress,
   verbose = true,
+  filtered,
 }) => {
   const { t } = useTranslation()
   // We only want to show encryption status of we are listing transactions
@@ -176,6 +178,7 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
       name={t('transactions.latest')}
       isLoading={isLoading}
       pagination={pagination}
+      emptyMessage={filtered ? t('tableSearch.noMatchingResults') : t('account.emptyTransactionList')}
     />
   )
 }

--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -1,4 +1,5 @@
 export const NUMBER_OF_ITEMS_ON_DASHBOARD = 5
+export const FILTERING_ON_DASHBOARD = true
 export const NUMBER_OF_ITEMS_ON_SEPARATE_PAGE = 10
 export const REFETCH_INTERVAL = 5000
 export const API_MAX_TOTAL_COUNT = 1000

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountEventsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountEventsCard.tsx
@@ -50,12 +50,12 @@ export const ConsensusAccountEventsList: FC<ConsensusAccountDetailsContext> = ({
   )
 }
 
-export const ConsensusAccountEventsCard: FC<ConsensusAccountDetailsContext> = ({ scope, address }) => {
+export const ConsensusAccountEventsCard: FC<ConsensusAccountDetailsContext> = context => {
   const { t } = useTranslation()
 
   return (
     <LinkableCardLayout containerId={eventsContainerId} title={t('common.events')}>
-      <ConsensusAccountEventsList scope={scope} address={address} />
+      <ConsensusAccountEventsList {...context} />
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
@@ -38,7 +38,9 @@ const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scop
 
   return (
     <>
-      {isFetched && !transactions?.length && <CardEmptyState label={t('account.emptyTransactionList')} />}
+      {isFetched && !transactions?.length && (
+        <CardEmptyState label={t('account.emptyAccountTransactionList')} />
+      )}
       <ConsensusTransactions
         transactions={transactions}
         ownAddress={address}

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
@@ -3,28 +3,43 @@ import { useTranslation } from 'react-i18next'
 import { useGetConsensusTransactions } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../config'
 import { ConsensusTransactions } from '../../components/Transactions'
-import { CardEmptyState } from '../../components/CardEmptyState'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { ConsensusAccountDetailsContext } from './hooks'
 import { LinkableCardLayout } from 'app/components/LinkableCardLayout'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import Box from '@mui/material/Box'
 
 const consensusAccountTransactionsContainerId = 'transactions'
 
-export const ConsensusAccountTransactionsCard: FC<ConsensusAccountDetailsContext> = ({ scope, address }) => {
+export const ConsensusAccountTransactionsCard: FC<ConsensusAccountDetailsContext> = context => {
   const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+  const { method, setMethod } = context
 
   return (
     <LinkableCardLayout
       containerId={consensusAccountTransactionsContainerId}
-      title={t('common.transactions')}
+      title={
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 6,
+            alignItems: 'center',
+          }}
+        >
+          {t('common.transactions')}
+          {!isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />}
+        </Box>
+      }
     >
-      <ConsensusAccountTransactions scope={scope} address={address} />
+      {isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />}
+      <ConsensusAccountTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scope, address }) => {
-  const { t } = useTranslation()
+const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scope, address, method }) => {
   const { network } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -32,28 +47,25 @@ const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scop
     limit,
     offset,
     rel: address,
+    method: method === 'any' ? undefined : method,
   })
-  const { isFetched, isLoading, data } = transactionsQuery
+  const { isLoading, data } = transactionsQuery
   const transactions = data?.data.transactions
 
   return (
-    <>
-      {isFetched && !transactions?.length && (
-        <CardEmptyState label={t('account.emptyAccountTransactionList')} />
-      )}
-      <ConsensusTransactions
-        transactions={transactions}
-        ownAddress={address}
-        isLoading={isLoading}
-        limit={limit}
-        pagination={{
-          selectedPage: pagination.selectedPage,
-          linkToPage: pagination.linkToPage,
-          totalCount: data?.data.total_count,
-          isTotalCountClipped: data?.data.is_total_count_clipped,
-          rowsPerPage: limit,
-        }}
-      />
-    </>
+    <ConsensusTransactions
+      transactions={transactions}
+      ownAddress={address}
+      isLoading={isLoading}
+      limit={limit}
+      pagination={{
+        selectedPage: pagination.selectedPage,
+        linkToPage: pagination.linkToPage,
+        totalCount: data?.data.total_count,
+        isTotalCountClipped: data?.data.is_total_count_clipped,
+        rowsPerPage: limit,
+      }}
+      filtered={method !== 'any'}
+    />
   )
 }

--- a/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
@@ -1,9 +1,12 @@
 import { useOutletContext } from 'react-router-dom'
 import { SearchScope } from '../../../types/searchScope'
+import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
 
 export type ConsensusAccountDetailsContext = {
   scope: SearchScope
   address: string
+  method: ConsensusTxMethodFilterOption
+  setMethod: (value: ConsensusTxMethodFilterOption) => void
 }
 
 export const useConsensusAccountDetailsProps = () => useOutletContext<ConsensusAccountDetailsContext>()

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -13,6 +13,8 @@ import { BalanceDistribution } from './BalanceDistribution'
 import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
 import { eventsContainerId } from './ConsensusAccountEventsCard'
+import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 export const ConsensusAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -20,12 +22,15 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
+  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
+    deleteParams: ['page'],
+  })
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
   const account = data?.data
   const transactionsLink = useHref('')
   const eventsLink = useHref(`events#${eventsContainerId}`)
-  const context: ConsensusAccountDetailsContext = { scope, address }
+  const context: ConsensusAccountDetailsContext = { scope, address, method, setMethod }
 
   return (
     <PageLayout>

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -8,16 +8,31 @@ import Link from '@mui/material/Link'
 import { useGetConsensusTransactions } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { ConsensusTransactions } from '../../components/Transactions'
-import { NUMBER_OF_ITEMS_ON_DASHBOARD as limit } from '../../config'
+import { NUMBER_OF_ITEMS_ON_DASHBOARD as limit, FILTERING_ON_DASHBOARD as shouldFilter } from '../../config'
 import { RouteUtils } from '../../utils/route-utils'
+import {
+  getConsensusTransactionMethodFilteringParam,
+  ConsensusTxMethodFilterOption,
+} from '../../components/ConsensusTransactionMethod'
+import Box from '@mui/material/Box'
+import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import { useScreenSize } from '../../hooks/useScreensize'
 
-export const LatestConsensusTransactions: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const LatestConsensusTransactions: FC<{
+  scope: SearchScope
+  method: ConsensusTxMethodFilterOption
+  setMethod: (value: ConsensusTxMethodFilterOption) => void
+}> = ({ scope, method, setMethod }) => {
+  const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const { network } = scope
 
   const transactionsQuery = useGetConsensusTransactions(
     network,
-    { limit },
+    {
+      ...getConsensusTransactionMethodFilteringParam(method),
+      limit,
+    },
     {
       query: {
         cacheTime: 0,
@@ -30,13 +45,29 @@ export const LatestConsensusTransactions: FC<{ scope: SearchScope }> = ({ scope 
       <CardHeader
         disableTypography
         component="h3"
-        title={t('transactions.latest')}
+        title={
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 6,
+              alignItems: 'center',
+            }}
+          >
+            {t('transactions.latest')}
+            {shouldFilter && !isMobile && (
+              <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />
+            )}
+          </Box>
+        }
         action={
           <Link component={RouterLink} to={RouteUtils.getLatestTransactionsRoute(scope)}>
             {t('common.viewAll')}
           </Link>
         }
       />
+      {shouldFilter && isMobile && (
+        <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />
+      )}
       <CardContent>
         <ConsensusTransactions
           transactions={transactionsQuery.data?.data.transactions}
@@ -44,6 +75,7 @@ export const LatestConsensusTransactions: FC<{ scope: SearchScope }> = ({ scope 
           limit={limit}
           pagination={false}
           verbose={false}
+          filtered={method !== 'any'}
         />
       </CardContent>
     </Card>

--- a/src/app/pages/ConsensusDashboardPage/index.tsx
+++ b/src/app/pages/ConsensusDashboardPage/index.tsx
@@ -17,11 +17,14 @@ import { AccountsCard } from './AccountsCard'
 import { LatestConsensusTransactions } from './LatestConsensusTransactions'
 import { ParaTimesCard } from './ParaTimesCard'
 import { SearchScope } from 'types/searchScope'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
 
 export const ConsensusDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const isLocal = isLocalnet(scope.network)
+  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('tx_method', 'any')
 
   return (
     <PageLayout>
@@ -39,7 +42,7 @@ export const ConsensusDashboardPage: FC = () => {
       <ValidatorsCard scope={scope} />
       {!isLocal && <ParaTimesCard scope={scope} />}
       <AccountsCard scope={scope} />
-      <LatestConsensusTransactions scope={scope} />
+      <LatestConsensusTransactions scope={scope} method={method} setMethod={setMethod} />
       {!isLocal && (
         <>
           <NetworkProposalsCard scope={scope} />

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -13,17 +13,19 @@ import { PageLayout } from '../../components/PageLayout'
 import { ParaTimeSnapshot } from './ParaTimeSnapshot'
 import { TopTokens } from './TopTokens'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 export const ParatimeDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const isLocal = isLocalnet(scope.network)
+  const [method, setMethod] = useTypedSearchParam('tx_method', 'any')
 
   return (
     <PageLayout>
       {!isLocal && <ParaTimeSnapshot scope={scope} />}
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <LatestRuntimeTransactions scope={scope} />
+      <LatestRuntimeTransactions scope={scope} method={method} setMethod={setMethod} />
       <Grid container spacing={4}>
         <Grid item xs={12} md={6} sx={{ display: 'flex', order: isMobile ? 1 : 0 }}>
           <LearningMaterials scope={scope} />

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTokenTransfersCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTokenTransfersCard.tsx
@@ -9,11 +9,11 @@ import { RuntimeAccountDetailsContext } from './index'
 
 export const accountTokenTransfersContainerId = 'transfers'
 
-export const AccountTokenTransfersCard: FC<RuntimeAccountDetailsContext> = ({ scope, address, account }) => {
+export const AccountTokenTransfersCard: FC<RuntimeAccountDetailsContext> = context => {
   const { t } = useTranslation()
   return (
     <LinkableCardLayout containerId={accountTokenTransfersContainerId} title={t('common.transfers')}>
-      <AccountTokenTransfers scope={scope} address={address} account={account} />
+      <AccountTokenTransfers {...context} />
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
@@ -3,46 +3,62 @@ import { useTranslation } from 'react-i18next'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { RuntimeTransactions } from '../../components/Transactions'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../config'
-import { CardEmptyState } from '../../components/CardEmptyState'
 import { useAccountTransactions } from './hook'
 import { RuntimeAccountDetailsContext } from './index'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import Box from '@mui/material/Box'
 
 export const accountTransactionsContainerId = 'transactions'
 
-export const AccountTransactionsCard: FC<RuntimeAccountDetailsContext> = ({ scope, address }) => {
+export const AccountTransactionsCard: FC<RuntimeAccountDetailsContext> = context => {
+  const { method, setMethod } = context
+
   const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
 
   return (
     <LinkableCardLayout
       containerId={accountTransactionsContainerId}
-      title={t('account.transactionsListTitle')}
+      title={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {t('account.transactionsListTitle')}
+          {!isMobile && <RuntimeTransactionTypeFilter value={method} setValue={setMethod} />}
+        </Box>
+      }
     >
-      <AccountTransactions scope={scope} address={address} />
+      {isMobile && <RuntimeTransactionTypeFilter value={method} setValue={setMethod} expand />}
+      <AccountTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const AccountTransactions: FC<RuntimeAccountDetailsContext> = ({ scope, address }) => {
-  const { t } = useTranslation()
-
-  const { isLoading, isFetched, transactions, pagination, totalCount, isTotalCountClipped } =
-    useAccountTransactions(scope, address)
+const AccountTransactions: FC<RuntimeAccountDetailsContext> = ({ scope, address, method }) => {
+  const { isLoading, transactions, pagination, totalCount, isTotalCountClipped } = useAccountTransactions(
+    scope,
+    address,
+    method,
+  )
   return (
-    <>
-      {isFetched && !transactions?.length && <CardEmptyState label={t('account.emptyTransactionList')} />}
-      <RuntimeTransactions
-        transactions={transactions}
-        ownAddress={address}
-        isLoading={isLoading}
-        limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
-        pagination={{
-          selectedPage: pagination.selectedPage,
-          linkToPage: pagination.linkToPage,
-          totalCount,
-          isTotalCountClipped,
-          rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
-        }}
-      />
-    </>
+    <RuntimeTransactions
+      transactions={transactions}
+      ownAddress={address}
+      isLoading={isLoading}
+      limit={NUMBER_OF_ITEMS_ON_SEPARATE_PAGE}
+      pagination={{
+        selectedPage: pagination.selectedPage,
+        linkToPage: pagination.linkToPage,
+        totalCount,
+        isTotalCountClipped,
+        rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
+      }}
+      filtered={method !== 'any'}
+    />
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/hook.ts
+++ b/src/app/pages/RuntimeAccountDetailsPage/hook.ts
@@ -8,6 +8,7 @@ import { AppErrors } from '../../../types/errors'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../config'
 import { SearchScope } from '../../../types/searchScope'
+import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 
 export const useAccount = (scope: SearchScope, address: string) => {
   const { network, layer } = scope
@@ -23,7 +24,7 @@ export const useAccount = (scope: SearchScope, address: string) => {
   return { account, isLoading, isError, isFetched }
 }
 
-export const useAccountTransactions = (scope: SearchScope, address: string) => {
+export const useAccountTransactions = (scope: SearchScope, address: string, method: string) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -40,6 +41,7 @@ export const useAccountTransactions = (scope: SearchScope, address: string) => {
       limit,
       offset: offset,
       rel: address,
+      ...getRuntimeTransactionMethodFilteringParam(method),
     },
   )
   const { isFetched, isLoading, data } = query

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -18,11 +18,14 @@ import { eventsContainerId } from './AccountEventsCard'
 import { DappBanner } from '../../components/DappBanner'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { getFiatCurrencyForScope } from '../../../config'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 export type RuntimeAccountDetailsContext = {
   scope: SearchScope
   address: string
   account?: RuntimeAccount
+  method: string
+  setMethod: (value: string) => void
 }
 
 export const useRuntimeAccountDetailsProps = () => useOutletContext<RuntimeAccountDetailsContext>()
@@ -32,6 +35,9 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRequiredScopeParam()
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
+  const [method, setMethod] = useTypedSearchParam('method', 'any', {
+    deleteParams: ['page'],
+  })
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, isContract)
@@ -49,7 +55,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const isLoading = isAccountLoading || isTokenLoading
 
-  const context: RuntimeAccountDetailsContext = { scope, address, account }
+  const context: RuntimeAccountDetailsContext = { scope, address, account, method, setMethod }
 
   return (
     <PageLayout>

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -55,16 +55,16 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
   )
 }
 
-export const RuntimeBlockEventsCard: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
+export const RuntimeBlockEventsCard: FC<RuntimeBlockDetailsContext> = props => {
   const { t } = useTranslation()
 
-  if (!blockHeight) {
+  if (!props.blockHeight) {
     return null
   }
 
   return (
     <LinkableCardLayout containerId={eventsContainerId} title={t('common.events')}>
-      <EventsList scope={scope} blockHeight={blockHeight} />
+      <EventsList {...props} />
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
@@ -7,10 +7,14 @@ import { Layer, useGetRuntimeTransactions } from '../../../oasis-nexus/api'
 import { RuntimeTransactions } from '../../components/Transactions'
 import { AppErrors } from '../../../types/errors'
 import { RuntimeBlockDetailsContext } from '.'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
+import Box from '@mui/material/Box'
 
 export const transactionsContainerId = 'transactions'
 
-const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
+const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, method }) => {
   const txsPagination = useSearchParamsPagination('page')
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
   if (scope.layer === Layer.consensus) {
@@ -22,6 +26,7 @@ const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight })
     block: blockHeight,
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
     offset: txsOffset,
+    ...getRuntimeTransactionMethodFilteringParam(method),
   })
 
   const { isLoading, isFetched, data } = transactionsQuery
@@ -44,20 +49,38 @@ const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight })
         isTotalCountClipped: data?.data.is_total_count_clipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
+      filtered={method !== 'any'}
     />
   )
 }
 
-export const RuntimeBlockTransactionsCard: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
+export const RuntimeBlockTransactionsCard: FC<RuntimeBlockDetailsContext> = props => {
   const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
+  const { blockHeight, method, setMethod } = props
 
   if (!blockHeight) {
     return null
   }
 
   return (
-    <LinkableCardLayout containerId={transactionsContainerId} title={t('common.transactions')}>
-      <TransactionList scope={scope} blockHeight={blockHeight} />
+    <LinkableCardLayout
+      containerId={transactionsContainerId}
+      title={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {t('common.transactions')}
+          {!isMobile && <RuntimeTransactionTypeFilter value={method} setValue={setMethod} />}
+        </Box>
+      }
+    >
+      {isMobile && <RuntimeTransactionTypeFilter value={method} setValue={setMethod} expand />}
+      <TransactionList {...props} />
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -21,10 +21,13 @@ import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { eventsContainerId } from './RuntimeBlockEventsCard'
 import { RuntimeNextBlockButton, RuntimePrevBlockButton } from '../../components/BlockNavigationButtons'
 import { SearchScope } from 'types/searchScope'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 export type RuntimeBlockDetailsContext = {
   scope: SearchScope
   blockHeight?: number
+  method: string
+  setMethod: (method: string) => void
 }
 
 export const useRuntimeBlockDetailsProps = () => useOutletContext<RuntimeBlockDetailsContext>()
@@ -48,7 +51,10 @@ export const RuntimeBlockDetailPage: FC = () => {
     throw AppErrors.NotFoundBlockHeight
   }
   const block = data?.data
-  const context: RuntimeBlockDetailsContext = { scope, blockHeight }
+  const [method, setMethod] = useTypedSearchParam('method', 'any', {
+    deleteParams: ['page'],
+  })
+  const context: RuntimeBlockDetailsContext = { scope, blockHeight, method, setMethod }
 
   return (
     <PageLayout>

--- a/src/app/pages/ValidatorDetailsPage/hooks.ts
+++ b/src/app/pages/ValidatorDetailsPage/hooks.ts
@@ -1,9 +1,12 @@
 import { useOutletContext } from 'react-router-dom'
 import { SearchScope } from '../../../types/searchScope'
+import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
 
 export type ValidatorDetailsContext = {
   scope: SearchScope
   address: string
+  method: ConsensusTxMethodFilterOption
+  setMethod: (method: ConsensusTxMethodFilterOption) => void
 }
 
 export const useValidatorDetailsProps = () => useOutletContext<ValidatorDetailsContext>()

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -32,6 +32,8 @@ import { eventsContainerId } from './../../pages/ConsensusAccountDetailsPage/Con
 import { PercentageValue } from '../../components/PercentageValue'
 import { BalancesDiff } from '../../components/BalancesDiff'
 import { RoundedBalance } from '../../components/RoundedBalance'
+import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 export const StyledGrid = styled(Grid)(({ theme }) => ({
   [theme.breakpoints.up('sm')]: {
@@ -43,6 +45,10 @@ export const ValidatorDetailsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
+  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
+    deleteParams: ['page'],
+  })
+
   const { address } = useLoaderData() as AddressLoaderData
   const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
   const { isLoading, isFetched, data } = validatorQuery
@@ -52,7 +58,7 @@ export const ValidatorDetailsPage: FC = () => {
   const eventsLink = useHref(`events#${eventsContainerId}`)
   const delegatorsLink = useHref(`delegators#${delegatorsContainerId}`)
   const debondingDelegationsLink = useHref(`debonding-delegations#${debondingContainerId}`)
-  const context: ValidatorDetailsContext = { scope, address }
+  const context: ValidatorDetailsContext = { scope, address, method, setMethod }
 
   return (
     <PageLayout>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -422,14 +422,20 @@
     "filterByType": "Filter by type",
     "latest": "Latest Transactions",
     "method": {
+      "stakingBurn": "Burn",
       "stakingTransfer": "Transfer",
       "stakingAddEscrow": "Start Delegate",
       "stakingReclaimEscrow": "Start Undelegate",
       "stakingAmendCommissionSchedule": "Amend Commission Schedule",
       "stakingAllow": "Allowance Change",
       "stakingWithdraw": "Continued Delegate",
+      "registryDeregisterEntity": "Deregister Entity",
+      "registryUnfreezeNode": "Registry: Unfreeze Node",
       "roothashExecutorCommit": "Executor Commit",
+      "roothashEvidence": "RootHash Evidence",
+      "roothashSubmitMessage": "RootHash: Submit Message",
       "roothashExecutorProposerTimeout": "Executor Proposer Timeout",
+      "registryProveFreshness": "Registry: Prove Freshness",
       "registryRegisterEntity": "Register Entity",
       "registryRegisterNode": "Register Node",
       "registryRegisterRuntime": "Register Runtime",
@@ -445,6 +451,7 @@
       "consensus": {
         "deposit": "Consensus Deposit",
         "delegate": "Consensus Delegate",
+        "meta": "Consensus Meta",
         "undelegate": "Consensus Undelegate",
         "withdraw": "Consensus Withdraw"
       },
@@ -452,11 +459,27 @@
         "call": "Contract Call",
         "create": "Contract Creation"
       },
+      "keyManager": {
+        "churp": {
+          "apply": "Key Manager: Churp Apply",
+          "confirm": "Key Manager: Churp Confirm",
+          "create": "Key Manager: Churp Create",
+          "update": "Key Manager: Churp Update"
+        },
+        "publishEphemeralSecret": "Key Manager: Publish Ephemeral Secret",
+        "publishMasterSecret": "Key Manager: Publish Master Secret",
+        "updatePolicy": "Key Manager: Update Policy"
+      },
       "rofl": {
         "create": "ROFL Create",
         "register": "ROFL Register",
         "remove": "ROFL Remove",
         "update": "ROFL Update"
+      },
+      "vault": {
+        "authorizeAction": "Vault: Authorize Action",
+        "cancelAction": "Vault: Cancel Action",
+        "create": "Vault: Create"
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -6,7 +6,8 @@
     "cantLoadDetails": "Unfortunately we couldn't load the account details at this time. Please try again later.",
     "debonding": "Debonding",
     "emptyTokenList": "This account holds no {{spec}} {{description}}.",
-    "emptyTransactionList": "There are no transactions on record for this account.",
+    "emptyAccountTransactionList": "There are no transactions on record for this account.",
+    "emptyTransactionList": "No transactions found.",
     "emptyTokenTransferList": "There are no token transfers on record for this account.",
     "failedToLookUpTickers": "We don't have the price for: {{tickers}}",
     "firstActivity": "First activity",
@@ -418,6 +419,7 @@
       "publicKey": "Public Key",
       "resultNonce": "Result Nonce"
     },
+    "filterByType": "Filter by type",
     "latest": "Latest Transactions",
     "method": {
       "stakingTransfer": "Transfer",

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -19,6 +19,7 @@ const ConsensusListStory: StoryFn = () => {
         limit={100}
         pagination={false}
         transactions={mockedTransactions}
+        filtered={false}
       />
     </Box>
   )

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -19,3 +19,10 @@ html {
 svg.recharts-surface {
   overflow: visible;
 }
+
+.expand {
+  width: 100%;
+  display: inline-flex;
+  justify-content: space-between;
+  align-items: center;
+}


### PR DESCRIPTION
This PR exposes the runtime tx method search feature added to Nexus in https://github.com/oasisprotocol/nexus/pull/824.

It adds support for filtering runtime TX lists for method type.

Depends on:
- [x] https://github.com/oasisprotocol/nexus/pull/890
 
It also adds the same feature for consensus TX lists, for which the Nexus support has been there for a while.

It works on all consensus and runtime dashboards, transaction list, also including transactions for blocks, accounts and validators.

I suggest reviewing the PR commit by commit, because there are multiple semi-independent small changes.

## The account transactions page looks like this:

![image](https://github.com/user-attachments/assets/f6b44d0b-ffa7-44c9-b869-fb44e21cc5f0)

Or this, when there are no results: 

![image](https://github.com/user-attachments/assets/b1cf0812-be62-4846-8dbf-06aa27ee19aa)

## Latest transactions page, on mobile:

![image](https://github.com/user-attachments/assets/e10ca10a-9db8-4521-a420-736adc6926e6)

## For consensus:

![image](https://github.com/user-attachments/assets/17770313-e7f8-4a9c-b816-6bb968b5a410)

