### PR TITLE
Fix case sensitivity in Pontus-X account name resolution

### DIFF
--- a/.changelog/1685.bugfix.md
+++ b/.changelog/1685.bugfix.md
@@ -1,0 +1,1 @@
+Fix case sensitivity in Pontus-X account name resolution

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -30,7 +30,7 @@ const getPontusXAccountsMetadata = async (): Promise<PontusXAccountsMetadata> =>
       address: getOasisAddress(evmAddress),
       name: name as string,
     }
-    map.set(evmAddress, account)
+    map.set(evmAddress.toLowerCase(), account)
     list.push(account)
   })
   return {
@@ -57,7 +57,7 @@ export const usePontusXAccountMetadata = (
     console.log('Failed to load Pontus-X account names', error)
   }
   return {
-    metadata: allData?.map.get(address),
+    metadata: allData?.map.get(address.toLowerCase()),
     isLoading,
     isError,
   }


### PR DESCRIPTION
This fix has been in production on the Pontus-X branch (and instance) for a while, now pulling it to the master branch.