### PR TITLE
Support for more granular configuration for hiding layers

### DIFF
--- a/.changelog/1686.trivial.md
+++ b/.changelog/1686.trivial.md
@@ -1,0 +1,1 @@
+Support for more granular configuration for hiding layers

--- a/src/app/components/LayerPicker/LayerMenu.tsx
+++ b/src/app/components/LayerPicker/LayerMenu.tsx
@@ -9,7 +9,7 @@ import Tooltip from '@mui/material/Tooltip'
 import { COLORS } from '../../../styles/theme/colors'
 import { Layer } from '../../../oasis-nexus/api'
 import { getLayerLabels } from '../../utils/content'
-import { isLayerHidden, RouteUtils } from '../../utils/route-utils'
+import { isScopeHidden, RouteUtils } from '../../utils/route-utils'
 import { Network } from '../../../types/network'
 import { orderByLayer } from '../../../types/layers'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -113,7 +113,11 @@ export const LayerMenu: FC<LayerMenuProps> = ({
   const [hoveredLayer, setHoveredLayer] = useState<undefined | Layer>()
   const options = Object.values(Layer)
     // Don't show hidden layers, unless we are already viewing them.
-    .filter(layer => !isLayerHidden(layer) || layer === currentScope?.layer)
+    .filter(
+      layer =>
+        !isScopeHidden({ network: selectedNetwork, layer }) ||
+        (layer === currentScope?.layer && selectedNetwork === currentScope?.network),
+    )
     .map(layer => ({
       layer,
       enabled: RouteUtils.getAllLayersForNetwork(selectedNetwork || network).enabled.includes(layer),

--- a/src/app/pages/ConsensusDashboardPage/ParaTimesCard.tsx
+++ b/src/app/pages/ConsensusDashboardPage/ParaTimesCard.tsx
@@ -8,12 +8,13 @@ import Grid from '@mui/material/Unstable_Grid2'
 import { styled } from '@mui/material/styles'
 import { Layer, Runtime } from '../../../oasis-nexus/api'
 import { CardHeaderWithCounter } from '../../components/CardHeaderWithCounter'
-import { isNotOnHiddenLayer, RouteUtils } from '../../utils/route-utils'
+import { isNotInHiddenScope, RouteUtils } from '../../utils/route-utils'
 import { SearchScope } from '../../../types/searchScope'
 import { EnabledRuntimePreview, DisabledRuntimePreview } from './RuntimePreview'
+import { Network } from '../../../types/network'
 
-function shouldIncludeLayer(layer: Layer) {
-  return layer !== Layer.consensus && isNotOnHiddenLayer({ layer })
+function shouldIncludeLayer(network: Network, layer: Layer) {
+  return layer !== Layer.consensus && isNotInHiddenScope({ network, layer })
 }
 
 const StyledInnerGrid = styled(Grid)(({ theme }) => ({
@@ -40,8 +41,8 @@ export const ParaTimesCard: FC<ParaTimesCardProps> = ({ scope }) => {
   const { t } = useTranslation()
   const { network } = scope
   const { enabled, disabled } = RouteUtils.getAllLayersForNetwork(network)
-  const enabledRuntimes = enabled.filter(shouldIncludeLayer) as Runtime[]
-  const disabledRuntimes = disabled.filter(shouldIncludeLayer) as Runtime[]
+  const enabledRuntimes = enabled.filter(layer => shouldIncludeLayer(network, layer)) as Runtime[]
+  const disabledRuntimes = disabled.filter(layer => shouldIncludeLayer(network, layer)) as Runtime[]
   const runtimesNumber = enabledRuntimes.length + disabledRuntimes.length
   const [firstEnabledRuntime, ...restEnabledRuntimes] = enabledRuntimes
   const spaceForSecondaryParaTimes = enabledRuntimes.length > 2


### PR DESCRIPTION
Now we can hide different layers on different networks.

(This is required for the Pontus-X deployment)