### PR TITLE
Display multiple signers for runtime transactions

### DIFF
--- a/.changelog/1705.feature.md
+++ b/.changelog/1705.feature.md
@@ -1,0 +1,1 @@
+Add support for displaying multiple signers of runtime transactions

--- a/src/app/components/Account/ContractCreatorInfo.tsx
+++ b/src/app/components/Account/ContractCreatorInfo.tsx
@@ -25,7 +25,7 @@ const TxSender: FC<{ scope: SearchScope; txHash: string; alwaysTrim?: boolean }>
   }
   const query = useGetRuntimeTransactionsTxHash(scope.network, scope.layer, txHash)
   const tx = query.data?.data.transactions[0]
-  const senderAddress = tx?.sender_0_eth || tx?.sender_0
+  const senderAddress = tx?.signers[0].address_eth ?? tx?.signers[0].address
 
   return query.isLoading ? (
     <Skeleton

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -126,10 +126,11 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
                     <AccountLink
                       labelOnly={
                         !!ownAddress &&
-                        (transaction.sender_0_eth === ownAddress || transaction.sender_0 === ownAddress)
+                        (transaction.signers[0].address_eth === ownAddress ||
+                          transaction.signers[0].address === ownAddress)
                       }
                       scope={transaction}
-                      address={transaction.sender_0_eth || transaction.sender_0}
+                      address={transaction.signers[0].address_eth ?? transaction.signers[0].address}
                       alwaysTrim
                     />
                     {targetAddress && <TransferIcon />}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -72,7 +72,9 @@ export const RuntimeTransactionDetailPage: FC = () => {
           tokenPrices={tokenPrices}
         />
       </SubPageCard>
-      <DappBanner scope={scope} ethAddress={transaction?.sender_0_eth} />
+      {(transaction?.signers ?? []).map((signer, index) => (
+        <DappBanner key={`signer-${index}`} scope={scope} ethAddress={signer.address_eth} />
+      ))}
       <DappBanner scope={scope} ethAddress={transaction?.to_eth} />
       {transaction && (
         <SubPageCard title={t('common.events')}>
@@ -161,15 +163,25 @@ export const RuntimeTransactionDetailView: FC<{
           <dt>{t('common.timestamp')}</dt>
           <dd>{formattedTimestamp}</dd>
 
-          {(transaction?.sender_0 || transaction?.sender_0_eth) && (
+          {!!transaction?.signers.length && (
             <>
               <dt>{t('common.from')}</dt>
-              <dd>
-                <AccountLink
-                  scope={transaction}
-                  address={(transaction?.sender_0_eth ?? transaction?.sender_0) as string}
-                />
-                <CopyToClipboard value={transaction?.sender_0_eth ?? transaction?.sender_0} />
+              <dd
+                style={{
+                  display: 'block',
+                }}
+              >
+                {(transaction?.signers ?? []).map((signer, index) => (
+                  <>
+                    <AccountLink
+                      key={`signer-${index}`}
+                      scope={transaction}
+                      address={(signer.address_eth ?? signer.address) as string}
+                    />
+                    <CopyToClipboard value={signer.address_eth ?? signer.address} />
+                    <br />
+                  </>
+                ))}
               </dd>
             </>
           )}
@@ -239,7 +251,7 @@ export const RuntimeTransactionDetailView: FC<{
 
           <dt>{t('common.nonce')}</dt>
           <dd>
-            <>{transaction.nonce_0.toLocaleString()}</>
+            <>{transaction.signers[0].nonce.toLocaleString()}</>
           </dd>
 
           {!!transaction.body?.data && (

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -281,6 +281,11 @@ export const useGetRuntimeTransactions: typeof generated.useGetRuntimeTransactio
             transactions: data.transactions.map(tx => {
               return {
                 ...tx,
+                // TODO: this workaround can be removed as soon as all deployed Nexus instances
+                // have been updated to at least v0.5.3
+                signers: tx.signers ?? [
+                  { address: tx.sender_0, address_eth: tx.sender_0_eth, nonce: tx.nonce_0 },
+                ],
                 to_eth: tx.to_eth || fallbackEthAddress(tx.to, params?.rel),
                 eth_hash: tx.eth_hash ? `0x${tx.eth_hash}` : undefined,
                 // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
@@ -379,6 +384,11 @@ export const useGetRuntimeTransactionsTxHash: typeof generated.useGetRuntimeTran
             transactions: data.transactions.map(tx => {
               return {
                 ...tx,
+                // TODO: this workaround can be removed as soon as all deployed Nexus instances
+                // have been updated to at least v0.5.3
+                signers: tx.signers ?? [
+                  { address: tx.sender_0, address_eth: tx.sender_0_eth, nonce: tx.nonce_0 },
+                ],
                 eth_hash: tx.eth_hash ? `0x${tx.eth_hash}` : undefined,
                 // TODO: Decimals may not be correct, should not depend on ParaTime decimals, but fee_symbol
                 fee: fromBaseUnits(tx.fee, paraTimesConfig[runtime].decimals),


### PR DESCRIPTION
Sometimes a TX has multiple signers. In that case, we should show them all in the "from" field in the TX details, like this:

Solves:
- #1703

![image](https://github.com/user-attachments/assets/5c96405a-d618-4f4c-8a9f-7e3f46a4f645)

Live sample [here](https://pr-1705.oasis-explorer.pages.dev/testnet/sapphire/tx/9b6f77229709326983fa513d33aa0972a7543197118f4454693fe13541fdf26b).

Depends on:
- [x] https://github.com/oasisprotocol/nexus/pull/885
