### PR TITLE
Display link to proposer in consensus block data

### DIFF
--- a/.changelog/1706.trivial.md
+++ b/.changelog/1706.trivial.md
@@ -1,0 +1,1 @@
+Show proposer link in consensus block details

--- a/src/app/pages/ConsensusBlockDetailPage/index.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/index.tsx
@@ -4,7 +4,7 @@ import { useHref, useOutletContext, useParams } from 'react-router-dom'
 import Typography from '@mui/material/Typography'
 import { AppErrors } from '../../../types/errors'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { Block, Layer, useGetConsensusBlockByHeight } from '../../../oasis-nexus/api'
+import { Block, EntityMetadata, Layer, useGetConsensusBlockByHeight } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { useFormattedTimestampStringWithDistance } from '../../hooks/useFormattedTimestamp'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
@@ -19,6 +19,7 @@ import { SubPageCard } from '../../components/SubPageCard'
 import { AdaptiveTrimmer } from '../../components/AdaptiveTrimmer/AdaptiveTrimmer'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { eventsContainerId } from './ConsensusBlockEventsCard'
+import { ValidatorLink } from '../../components/Validators/ValidatorLink'
 
 export type BlockDetailConsensusBlock = Block & {
   markAsNew?: boolean
@@ -132,6 +133,19 @@ export const ConsensusBlockDetailView: FC<{
         </>
       )}
 
+      {!!block.proposer?.entity_address && (
+        <>
+          <dt>{t('common.proposer')}</dt>
+          <dd>
+            <ValidatorLink
+              name={(block.proposer?.entity_metadata as EntityMetadata)?.name}
+              address={block.proposer?.entity_address}
+              alwaysTrim
+              network={block.network}
+            />
+          </dd>
+        </>
+      )}
       <dt>{t('common.timestamp')}</dt>
       <dd>{formattedTime}</dd>
 


### PR DESCRIPTION
When displaying consensus block details, we should also include a link to the validator that has proposed the block.
Other explorers do that, too.

![image](https://github.com/user-attachments/assets/fd112bd4-dbe1-4247-9fb6-5e609ac4ba3a)

Please note that this data has been already been displayed in the latest block list, like this:

![image](https://github.com/user-attachments/assets/64d7e1c3-e28e-48ad-98cb-af253880f648)

It was only missing from the individual block detail pages, because it was not served by the backend, but that limitation is now gone, so we can display it.

Depends on:
- [x] Nexus: https://github.com/oasisprotocol/nexus/pull/888