### PR TITLE
Hide Pontus-X from the layer selector on mainnet

### DIFF
--- a/.changelog/1709.trivial.md
+++ b/.changelog/1709.trivial.md
@@ -1,0 +1,1 @@
+Hide the disabled Pontus-X option from the layer selector on mainnet

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -69,6 +69,7 @@ invertSpecialScopePaths()
 export const hiddenScopes: SearchScope[] = [
   { network: Network.testnet, layer: Layer.pontusxdev },
   { network: Network.mainnet, layer: Layer.pontusxdev },
+  { network: Network.mainnet, layer: Layer.pontusxtest },
   // { network: Network.mainnet, layer: Layer.sapphire }, // This is only for testing
 ]
 


### PR DESCRIPTION
Currently, the Pontus-X layer is enabled and visible in the layer selector, because the Pontus-X Testnet runtime is running on the Oasis Testnet, and we want to expose it to the public.

![image](https://github.com/user-attachments/assets/f6f1f4dc-3d42-40c2-aad0-60c10c7b59af)

However, we don't have a Pontus-X mainnet, and there are no immediate plans to have one, so in the layer selector for the mainnet, the Pontus-X option is disabled; it says "coming soon".

![image](https://github.com/user-attachments/assets/cecd6efb-79ae-49d4-8756-d8914a7cb4ce)

I think it is not useful to have this disabled option here (on the mainnet), but until now, we couldn't hide it, because we wanted to see this layer on testnet.

However, we have recently gained the ability to show/hide different layers (in the layer selector) per different network, so now we can hide it from the mainnet, while keeping it from the testnet. This commit does that.

![image](https://github.com/user-attachments/assets/da54a0f9-67ac-449e-8534-633a01afad17)
