### PR TITLE
Rely on validator address presence not name in ConsensusAccountLink

### DIFF
--- a/.changelog/1768.bugfix.md
+++ b/.changelog/1768.bugfix.md
@@ -1,0 +1,1 @@
+Rely on validator address presence not name in ConsensusAccountLink

--- a/src/app/components/Account/ConsensusAccountLink.tsx
+++ b/src/app/components/Account/ConsensusAccountLink.tsx
@@ -21,7 +21,7 @@ export const ConsensusAccountLink: FC<ConsensusAccountLinkProps> = ({
 }) => {
   const { data } = useGetConsensusValidatorsAddressNameMap(network)
 
-  if (data?.data?.[address]) {
+  if (data?.data && address in data.data) {
     return (
       <ValidatorLink
         address={address}


### PR DESCRIPTION
`useGetConsensusValidatorsAddressNameMap` returns a map of address and name.

'address': 'name'
'address': undefined // missing validator metadata, but still we need to render validator link

if name if undefined we render AccountLink instead of ValidatorLink.