### PR TITLE
Preserve tx_method query arg on block prev/next button

### DIFF
--- a/.changelog/1780.bugfix.md
+++ b/.changelog/1780.bugfix.md
@@ -1,0 +1,1 @@
+Preserve tx_method query arg on block prev/next button

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Link as RouterLink } from 'react-router-dom'
+import { Link as RouterLink, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PaginationItem from '@mui/material/PaginationItem'
 import Box from '@mui/material/Box'
@@ -8,16 +8,18 @@ import { SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
 import { RouteUtils } from '../../utils/route-utils'
+import { METHOD_QUERY_ARG_NAME } from '../../hooks/useCommonParams'
 
 const PrevBlockButton: FC<{ scope: SearchScope; currentRound: number }> = ({ scope, currentRound }) => {
   const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
   const disabled = currentRound === 0
   return (
     <Tooltip title={disabled ? t('blocks.viewingFirst') : t('blocks.viewPrevious')} placement="top">
       <Box>
         <PaginationItem
           component={RouterLink}
-          to={RouteUtils.getBlockRoute(scope, currentRound - 1)}
+          to={RouteUtils.getBlockRoute(scope, currentRound - 1, searchParams, [METHOD_QUERY_ARG_NAME])}
           type="previous"
           disabled={disabled}
           sx={{
@@ -40,13 +42,13 @@ const NextBlockButton: FC<{ disabled: boolean; scope: SearchScope; currentRound:
   scope,
 }) => {
   const { t } = useTranslation()
-
+  const [searchParams] = useSearchParams()
   return (
     <Tooltip title={disabled ? t('blocks.viewingLatest') : t('blocks.viewNext')} placement="top">
       <Box>
         <PaginationItem
           component={RouterLink}
-          to={RouteUtils.getBlockRoute(scope, currentRound + 1)}
+          to={RouteUtils.getBlockRoute(scope, currentRound + 1, searchParams, [METHOD_QUERY_ARG_NAME])}
           type="next"
           disabled={disabled}
           sx={{ background: COLORS.grayMediumLight }}

--- a/src/app/components/Select/index.tsx
+++ b/src/app/components/Select/index.tsx
@@ -183,7 +183,15 @@ const SelectOption = <T extends SelectOptionBase>({
 interface SelectCmpProps<T extends SelectOptionBase> {
   label?: ReactNode
   options: T[]
+  /**
+   * If you want to use this component in uncontrolled mode, you can provide the detauls / initial value here.
+   */
   defaultValue?: T['value']
+
+  /**
+   * You can provide a value if you want to use this component in controlled mode
+   */
+  value?: T['value'] | null
   handleChange?: (selectedOption: T['value'] | null) => void
   placement?: PopupProps['placement']
   className?: string
@@ -198,6 +206,7 @@ const SelectCmp = <T extends SelectOptionBase>({
   label,
   options,
   defaultValue,
+  value,
   handleChange,
   placement = 'bottom-start',
   className,
@@ -224,6 +233,7 @@ const SelectCmp = <T extends SelectOptionBase>({
       <CustomSelect<T['value']>
         id={selectId}
         defaultValue={defaultValue}
+        {...(value === undefined || value === null ? {} : { value })}
         onChange={onChange}
         root={root}
         listbox={listbox}

--- a/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
@@ -34,7 +34,7 @@ export const ConsensusTransactionTypeFilter: FC<{
       light={true}
       label={<FilterLabel />}
       options={[{ value: 'any', label: 'Any' }, ...getConsensusTxMethodOptions(t)]}
-      defaultValue={value}
+      value={value}
       handleChange={setValue as any}
     />
   )

--- a/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
@@ -36,7 +36,7 @@ export const RuntimeTransactionTypeFilter: FC<{
       light={true}
       label={<FilterLabel />}
       options={[{ value: 'any', label: 'Any' }, ...getRuntimeTxMethodOptions(t, layer)]}
-      defaultValue={value}
+      value={value}
       handleChange={setValue as any}
     />
   )

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -1,18 +1,22 @@
 import { useTypedSearchParam } from './useTypedSearchParam'
 import { ConsensusTxMethodFilterOption } from '../components/ConsensusTransactionMethod'
 
+export const METHOD_QUERY_ARG_NAME = 'tx_method'
+
 export const useConsensusTxMethodParam = () => {
-  const paramName = 'tx_method'
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>(paramName, 'any', {
-    deleteParams: ['page', 'date'],
-  })
-  return { paramName, method, setMethod }
+  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>(
+    METHOD_QUERY_ARG_NAME,
+    'any',
+    {
+      deleteParams: ['page', 'date'],
+    },
+  )
+  return { method, setMethod }
 }
 
 export const useRuntimeTxMethodParam = () => {
-  const paramName = 'tx_method'
-  const [method, setMethod] = useTypedSearchParam(paramName, 'any', {
+  const [method, setMethod] = useTypedSearchParam(METHOD_QUERY_ARG_NAME, 'any', {
     deleteParams: ['page', 'date'],
   })
-  return { paramName, method, setMethod }
+  return { method, setMethod }
 }

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -1,0 +1,18 @@
+import { useTypedSearchParam } from './useTypedSearchParam'
+import { ConsensusTxMethodFilterOption } from '../components/ConsensusTransactionMethod'
+
+export const useConsensusTxMethodParam = () => {
+  const paramName = 'tx_method'
+  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>(paramName, 'any', {
+    deleteParams: ['page', 'date'],
+  })
+  return { paramName, method, setMethod }
+}
+
+export const useRuntimeTxMethodParam = () => {
+  const paramName = 'tx_method'
+  const [method, setMethod] = useTypedSearchParam(paramName, 'any', {
+    deleteParams: ['page', 'date'],
+  })
+  return { paramName, method, setMethod }
+}

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -12,8 +12,7 @@ import { RouterTabs } from '../../components/RouterTabs'
 import { BalanceDistribution } from './BalanceDistribution'
 import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
-import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 
 export const ConsensusAccountDetailsPage: FC = () => {
@@ -22,9 +21,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
   const account = data?.data

--- a/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
@@ -7,7 +7,7 @@ import { AppErrors } from '../../../types/errors'
 import { SearchScope } from '../../../types/searchScope'
 import { ConsensusBlockDetailsContext } from '.'
 import { LinkableCardLayout } from 'app/components/LinkableCardLayout'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
 import { useScreenSize } from '../../hooks/useScreensize'
 import {
@@ -55,9 +55,7 @@ const TransactionList: FC<{
 }
 
 export const ConsensusBlockTransactionsCard: FC<ConsensusBlockDetailsContext> = ({ scope, blockHeight }) => {
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { method, setMethod } = useConsensusTxMethodParam()
   const { isMobile } = useScreenSize()
 
   if (!blockHeight) {

--- a/src/app/pages/ConsensusDashboardPage/index.tsx
+++ b/src/app/pages/ConsensusDashboardPage/index.tsx
@@ -17,14 +17,13 @@ import { AccountsCard } from './AccountsCard'
 import { LatestConsensusTransactions } from './LatestConsensusTransactions'
 import { ParaTimesCard } from './ParaTimesCard'
 import { SearchScope } from 'types/searchScope'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
-import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
+import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 
 export const ConsensusDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const isLocal = isLocalnet(scope.network)
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('tx_method', 'any')
+  const { method, setMethod } = useConsensusTxMethodParam()
 
   return (
     <PageLayout>

--- a/src/app/pages/ConsensusTransactionsPage/index.tsx
+++ b/src/app/pages/ConsensusTransactionsPage/index.tsx
@@ -16,12 +16,9 @@ import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { VerticalList } from '../../components/VerticalList'
 import { ConsensusTransactionDetailView } from '../ConsensusTransactionDetailPage'
 import { useConsensusListBeforeDate } from '../../hooks/useListBeforeDate'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
-import {
-  getConsensusTransactionMethodFilteringParam,
-  ConsensusTxMethodFilterOption,
-} from '../../components/ConsensusTransactionMethod'
+import { getConsensusTransactionMethodFilteringParam } from '../../components/ConsensusTransactionMethod'
 import Box from '@mui/material/Box'
 
 export const ConsensusTransactionsPage: FC = () => {
@@ -29,9 +26,7 @@ export const ConsensusTransactionsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const pagination = useSearchParamsPagination('page')
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
-    deleteParams: ['date'],
-  })
+  const { method, setMethod } = useConsensusTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
   const scope = useRequiredScopeParam()
   const enablePolling = offset === 0

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -13,13 +13,13 @@ import { PageLayout } from '../../components/PageLayout'
 import { ParaTimeSnapshot } from './ParaTimeSnapshot'
 import { TopTokens } from './TopTokens'
 import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 
 export const ParatimeDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const isLocal = isLocalnet(scope.network)
-  const [method, setMethod] = useTypedSearchParam('tx_method', 'any')
+  const { method, setMethod } = useRuntimeTxMethodParam()
 
   return (
     <PageLayout>

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -14,7 +14,7 @@ import { RuntimeAccountDetailsCard } from './RuntimeAccountDetailsCard'
 import { DappBanner } from '../../components/DappBanner'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { getFiatCurrencyForScope } from '../../../config'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import {
   codeContainerId,
   eventsContainerId,
@@ -37,9 +37,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRequiredScopeParam()
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
-  const [method, setMethod] = useTypedSearchParam('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, { enabled: isContract })

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -19,7 +19,7 @@ import { useRequiredScopeParam } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { RuntimeNextBlockButton, RuntimePrevBlockButton } from '../../components/BlockNavigationButtons'
 import { SearchScope } from 'types/searchScope'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId, transactionsContainerId } from '../../utils/tabAnchors'
 
 export type RuntimeBlockDetailsContext = {
@@ -50,9 +50,7 @@ export const RuntimeBlockDetailPage: FC = () => {
     throw AppErrors.NotFoundBlockHeight
   }
   const block = data?.data
-  const [method, setMethod] = useTypedSearchParam('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { method, setMethod } = useRuntimeTxMethodParam()
   const context: RuntimeBlockDetailsContext = { scope, blockHeight, method, setMethod }
 
   return (

--- a/src/app/pages/RuntimeTransactionsPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionsPage/index.tsx
@@ -18,7 +18,7 @@ import { useAllTokenPrices } from '../../../coin-gecko/api'
 import { VerticalList } from '../../components/VerticalList'
 import { getFiatCurrencyForScope } from '../../../config'
 import { useRuntimeListBeforeDate } from '../../hooks/useListBeforeDate'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import Box from '@mui/material/Box'
@@ -30,9 +30,7 @@ export const RuntimeTransactionsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const pagination = useSearchParamsPagination('page')
-  const [method, setMethod] = useTypedSearchParam('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { method, setMethod } = useRuntimeTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
   const scope = useRequiredScopeParam()
   const enablePolling = offset === 0

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -31,8 +31,7 @@ import { ValidatorStatusBadge } from './ValidatorStatusBadge'
 import { PercentageValue } from '../../components/PercentageValue'
 import { BalancesDiff } from '../../components/BalancesDiff'
 import { RoundedBalance } from '../../components/RoundedBalance'
-import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 
 export const StyledGrid = styled(Grid)(({ theme }) => ({
@@ -45,10 +44,7 @@ export const ValidatorDetailsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>('method', 'any', {
-    deleteParams: ['page'],
-  })
-
+  const { method, setMethod } = useConsensusTxMethodParam()
   const { address } = useLoaderData() as AddressLoaderData
   const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
   const { isLoading, isFetched, data } = validatorQuery

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -80,6 +80,17 @@ export const isScopeHidden = (scope: SearchScope): boolean =>
 
 export const isNotInHiddenScope = (item: HasScope) => !isScopeHidden(item)
 
+const formatPreservedParams = (searchParams: URLSearchParams | undefined, paramsToKeep: string[]): string => {
+  if (!searchParams) return ''
+  const toDelete: string[] = []
+  searchParams.forEach((_, key) => {
+    if (!paramsToKeep.includes(key)) toDelete.push(key)
+  })
+  toDelete.forEach(key => searchParams.delete(key))
+  const formatted = searchParams.toString()
+  return formatted.length ? `?${formatted}` : ''
+}
+
 export abstract class RouteUtils {
   private static ENABLED_LAYERS_FOR_NETWORK = {
     [Network.mainnet]: {
@@ -130,8 +141,13 @@ export abstract class RouteUtils {
     return `${this.getScopeRoute(scope)}/block`
   }
 
-  static getBlockRoute = (scope: SearchScope, blockHeight: number) => {
-    return `${this.getScopeRoute(scope)}/block/${encodeURIComponent(blockHeight)}`
+  static getBlockRoute = (
+    scope: SearchScope,
+    blockHeight: number,
+    searchParams?: URLSearchParams,
+    preserveParams: string[] = [],
+  ) => {
+    return `${this.getScopeRoute(scope)}/block/${encodeURIComponent(blockHeight)}${formatPreservedParams(searchParams, preserveParams)}`
   }
 
   static getTransactionRoute = (scope: SearchScope, txHash: string) => {


### PR DESCRIPTION
Make it so that we preserve the tx method filtering setting when stepping between blocks.

Also fix some smaller issues and do some cleanup under the hood.

Fixes #1743 
Fixes #1779 

(I suggest review commit by commit.)