### PR TITLE
When auto-redirecting from landing page, preserve scope 

### DIFF
--- a/.changelog/1794.trivial.md
+++ b/.changelog/1794.trivial.md
@@ -1,0 +1,1 @@
+When auto-redirecting from landing page, restore stored scope

--- a/src/app/components/PageLayout/NetworkSelector.tsx
+++ b/src/app/components/PageLayout/NetworkSelector.tsx
@@ -13,6 +13,7 @@ import { LayerPicker } from './../LayerPicker'
 import { fixedLayer, fixedNetwork, RouteUtils } from '../../utils/route-utils'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
 import { SearchScope } from '../../../types/searchScope'
+import { useLocalSettings } from '../../hooks/useLocalSettings'
 
 export const StyledBox = styled(Box)(({ theme }) => ({
   marginLeft: `-${theme.spacing(1)}`,
@@ -62,6 +63,7 @@ const NetworkSelectorView: FC<NetworkSelectorViewProps> = ({ isOutOfDate, layer,
   const { isMobile, isTablet } = useScreenSize()
   const labels = getNetworkNames(t)
   const [openDrawer, setOpenDrawer] = useState(false)
+  const { changeSetting } = useLocalSettings()
   const handleDrawerClose = () => setOpenDrawer(false)
   const handleDrawerOpen = () => setOpenDrawer(true)
 
@@ -78,6 +80,7 @@ const NetworkSelectorView: FC<NetworkSelectorViewProps> = ({ isOutOfDate, layer,
         onClose={handleDrawerClose}
         onConfirm={(scope: SearchScope) => {
           handleDrawerClose()
+          changeSetting('preferredScope', scope)
           navigate(RouteUtils.getDashboardRoute(scope))
         }}
         isOutOfDate={isOutOfDate}

--- a/src/app/providers/LocalSettingsContext.ts
+++ b/src/app/providers/LocalSettingsContext.ts
@@ -3,7 +3,7 @@ import { LocalSettings } from '../../types/local-settings'
 
 export interface LocalSettingsProviderContext {
   readonly settings: LocalSettings
-  changeSetting: (key: keyof LocalSettings, value: any) => void
+  changeSetting<T extends keyof LocalSettings>(key: T, value: LocalSettings[T]): void
 }
 
 export const LocalSettingsContext = createContext<LocalSettingsProviderContext>(

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -66,6 +66,7 @@ import { ConsensusAccountTransactionsCard } from './app/pages/ConsensusAccountDe
 import { FC, useEffect } from 'react'
 import { AnalyticsConsentProvider } from './app/components/AnalyticsConsent'
 import { HighlightingContextProvider } from './app/components/HighlightingContext'
+import { useLocalSettings } from './app/hooks/useLocalSettings'
 
 const ScopeSpecificPart = () => {
   const { network, layer } = useRequiredScopeParam()
@@ -83,18 +84,26 @@ const ScopeSpecificPart = () => {
  */
 const RedirectToDashboard: FC = () => {
   const navigate = useNavigate()
+  const {
+    settings: { preferredScope },
+  } = useLocalSettings()
 
-  useEffect(() =>
-    navigate(
-      RouteUtils.getDashboardRoute({
-        network:
-          (fixedNetwork ?? fixedLayer)
-            ? RouteUtils.getEnabledNetworksForLayer(fixedLayer)[0]!
-            : RouteUtils.getEnabledScopes()[0].network,
-        layer: fixedLayer ?? RouteUtils.getEnabledScopes()[0].layer,
-      }),
-    ),
-  )
+  const getPreferredScope = () =>
+    !preferredScope
+      ? undefined
+      : RouteUtils.getEnabledScopes().find(
+          scope => scope.network === preferredScope.network && scope.layer === preferredScope.layer,
+        )
+
+  const getDefaultScope = (): SearchScope => ({
+    network:
+      (fixedNetwork ?? fixedLayer)
+        ? RouteUtils.getEnabledNetworksForLayer(fixedLayer)[0]!
+        : RouteUtils.getEnabledScopes()[0].network,
+    layer: fixedLayer ?? RouteUtils.getEnabledScopes()[0].layer,
+  })
+
+  useEffect(() => navigate(RouteUtils.getDashboardRoute(getPreferredScope() ?? getDefaultScope())))
   return null
 }
 

--- a/src/types/local-settings.ts
+++ b/src/types/local-settings.ts
@@ -1,12 +1,15 @@
 import { TableAgeType } from './table-age-type'
+import { SearchScope } from './searchScope'
 
 /**
  * This is where we store local state
  */
 export interface LocalSettings {
   ageHeaderType: TableAgeType
+  preferredScope: SearchScope | undefined
 }
 
 export const defaultLocalSettings: LocalSettings = {
   ageHeaderType: TableAgeType.Distance,
+  preferredScope: undefined,
 }


### PR DESCRIPTION
There are some network / layer configurations that (if configured in the `.env`) result in not showing the graph on the landing page, but instead immediately redirecting to the dashboard of a Runtime.

This change makes it so that if we change to a layer using the layer selector, that layer is preserved, and next time we redirect from the landing page, we go to this layer.

This was a feature request for the Pontus-X browser.

This implementation depends on:
- [x] #1793. 

(Hint for testing: uncomment `REACT_APP_FIXED_LAYER` in .env, or see this live in action on the pontus-x branch: https://pr-1355.oasis-explorer.pages.dev/)