### PR TITLE
Enable Oasis account name lookup on pontus-x runtimes

### DIFF
--- a/.changelog/1795.bugfix.md
+++ b/.changelog/1795.bugfix.md
@@ -1,0 +1,1 @@
+Enable Oasis account name lookup on pontus-x runtimes

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -34,6 +34,10 @@ const dataSources: Record<Network, Partial<Record<Layer, string>>> = {
       'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_emerald.json',
     [Layer.sapphire]:
       'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_sapphire.json',
+    [Layer.pontusxdev]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_pontusxdev.json',
+    [Layer.pontusxtest]:
+      'https://raw.githubusercontent.com/oasisprotocol/nexus/main/named-addresses/testnet_pontusxtest.json',
   },
   [Network.localnet]: {
     [Layer.consensus]: undefined,

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -23,10 +23,10 @@ export const useAccountMetadata = (scope: SearchScope, address: string): Account
     useErrorBoundary: false,
   })
   const oasisData = useOasisAccountMetadata(scope.network, scope.layer, getOasisAddress(address), {
-    enabled: !isPontusX && !isLocalnet(scope.network),
+    enabled: !isLocalnet(scope.network),
     useErrorBoundary: false,
   })
-  const registryData = isPontusX ? pontusXData : oasisData
+  const registryData = isPontusX ? (pontusXData?.metadata ? pontusXData : oasisData) : oasisData
 
   // Also look up self-professed metadata (for tokens)
   const {


### PR DESCRIPTION
On Pontus-X runtimes, we need to look for named accounts in two sources:
 - The named address repository at Oasis Nexus
 - The named address repository at deltaDAO

This commit re-enables the first source, which was somehow lost along the way. (The second source was always working properly. that's why we didn't notice earlier.)

## Example for tx `0x12f2161e312ae060ab97a907a3a18e079712511e58b6320e7f374b42da84da92`

### Before:

![image](https://github.com/user-attachments/assets/3a8a8a53-23d0-472c-a006-38511258d6f0)

### After:

![image](https://github.com/user-attachments/assets/ff526990-ed69-4d01-8ddc-9ba99f39b85a)
