### PR TITLE
Clean up name attribution by Oasis/deltaDAO

### DIFF
--- a/.changelog/1796.trivial.md
+++ b/.changelog/1796.trivial.md
@@ -1,0 +1,1 @@
+Clean up name attribution by Oasis/deltaDAO

--- a/src/app/components/Account/AccountMetadataSourceIndicator.tsx
+++ b/src/app/components/Account/AccountMetadataSourceIndicator.tsx
@@ -62,8 +62,10 @@ export const AccountMetadataSourceIndicator: FC<AccountMetadataSourceIndicatorPr
     )
 
   switch (source) {
-    case 'Registry':
+    case 'OasisRegistry':
       return renderWithOrWithoutLabel(t('account.namedByOasis'), !!withText, <OasisNameIndicator />)
+    case 'DeltaDaoRegistry':
+      return renderWithOrWithoutLabel(t('account.namedByDeltaDao'), !!withText, <OasisNameIndicator />)
     case 'SelfProfessed':
       return renderWithOrWithoutLabel(t('account.namedBySelf'), !!withText, <SelfAcclaimedNameIndicator />)
     default:

--- a/src/app/data/named-accounts.ts
+++ b/src/app/data/named-accounts.ts
@@ -1,7 +1,7 @@
 import { Network } from '../../types/network'
 import { Account, Layer, Runtime, RuntimeAccount } from '../../oasis-nexus/api'
 
-export type AccountMetadataSource = 'Registry' | 'SelfProfessed'
+export type AccountMetadataSource = 'OasisRegistry' | 'DeltaDaoRegistry' | 'SelfProfessed'
 
 export type AccountMetadata = {
   address: string

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -57,7 +57,7 @@ const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise
   const list: AccountMetadata[] = []
   Array.from(response.data).forEach((entry: any) => {
     const metadata: AccountMetadata = {
-      source: 'Registry',
+      source: 'OasisRegistry',
       address: entry.Address,
       name: entry.Name,
       description: entry.Description,

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -27,7 +27,7 @@ const getPontusXAccountsMetadata = async (): Promise<PontusXAccountsMetadata> =>
   const list: AccountMetadata[] = []
   Object.entries(response.data).forEach(([evmAddress, name]) => {
     const account: AccountMetadata = {
-      source: 'Registry',
+      source: 'DeltaDaoRegistry',
       address: getOasisAddress(evmAddress),
       name: name as string,
     }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -15,6 +15,7 @@
     "ERC721": "ERC-721",
     "listTitle": "Accounts",
     "namedByOasis": "Name appointed by Oasis",
+    "namedByDeltaDao": "Identified by deltaDAO",
     "namedBySelf": "Name self-acclaimed",
     "noTokens": "This account holds no tokens",
     "noBalances": "This account currently has no balances.",


### PR DESCRIPTION
Some account names come from Oasis, some from deltaDAO.
This commit makes the difference clear in the tooltips.

Built on (depends on):
- [ ] #1795 

### Tooltip for Oasis identities:

![image](https://github.com/user-attachments/assets/0e79c5fa-ae04-42da-925f-18153f160160)

### Tooltip for pontus-x (deltaDAO) identities:

![image](https://github.com/user-attachments/assets/a59edcb6-46a1-47a1-a493-32442218bac4)

### Tooltip for self-acclaimed names (not changed):

![image](https://github.com/user-attachments/assets/6387de3b-f46f-472e-b9c1-85a584e630c3)
