### PR TITLE
Don't resolve name on token dashboard

### DIFF
--- a/.changelog/1797.trivial.md
+++ b/.changelog/1797.trivial.md
@@ -1,0 +1,1 @@
+Don't resolve contract name on token dashboard title

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -33,6 +33,7 @@ export const TokenTitleCard: FC<{ scope: SearchScope; address: string; searchTer
               <AccountLink
                 scope={token}
                 address={token.eth_contract_addr || token.contract_addr}
+                showOnlyAddress
                 alwaysTrim
               />
               <CopyToClipboard value={token.eth_contract_addr || token.contract_addr} />


### PR DESCRIPTION
When showing token smart contract addresses, usually we are replacing it with the name of the token.

That is all good in transactions, but we should not do this in the title on the token dashboard page, when we explicitly want to see the address. (Showing the name would be redundant.)

### Before

![image](https://github.com/user-attachments/assets/55936dee-f3fe-42b0-b4f5-460fc7966524)

### After

![image](https://github.com/user-attachments/assets/ab36b9a2-9585-4f1b-886c-6fbcf75b3c3a)
