### PR TITLE
Skip testing the testnet faucet link

### DIFF
--- a/.changelog/1807.trivial.md
+++ b/.changelog/1807.trivial.md
@@ -1,0 +1,1 @@
+Skip testing the testnet faucet link

--- a/src/app/utils/__tests__/externalLinks.test.ts
+++ b/src/app/utils/__tests__/externalLinks.test.ts
@@ -35,6 +35,7 @@ onlyRunOnCI('externalLinks', () => {
         if (url.startsWith(externalLinksModule.github.commit)) continue // We store only partial url in constants
         if (url.startsWith(externalLinksModule.github.releaseTag)) continue // We store only partial url in constants
         if (url.startsWith(externalLinksModule.ipfs.proxyPrefix)) continue // We store only partial url in constants
+        if (url.startsWith(externalLinksModule.faucets.oasisTestnet)) continue // Has an interactive challenge
         if (url.startsWith('mailto')) continue // We can't test email addresses
 
         it.concurrent(`${linksGroupName} ${linkName} ${url}`, async () => {


### PR DESCRIPTION
There is a regression in our CI tests.
When testing the availability of faucet.testnet.oasis.io, we hit a problem because of an interactive challenge which had to be recently activated because of attacks.

So we just skip that link, in order not to fail the test.