### PR TITLE
Un-Skip testing the testnet faucet link

### DIFF
--- a/.changelog/1807.trivial.md
+++ b/.changelog/1807.trivial.md
@@ -1,1 +1,0 @@
-Skip testing the testnet faucet link

--- a/.changelog/1810.trivial.md
+++ b/.changelog/1810.trivial.md
@@ -1,0 +1,1 @@
+Un-Skip testing the testnet faucet link

--- a/src/app/utils/__tests__/externalLinks.test.ts
+++ b/src/app/utils/__tests__/externalLinks.test.ts
@@ -35,7 +35,6 @@ onlyRunOnCI('externalLinks', () => {
         if (url.startsWith(externalLinksModule.github.commit)) continue // We store only partial url in constants
         if (url.startsWith(externalLinksModule.github.releaseTag)) continue // We store only partial url in constants
         if (url.startsWith(externalLinksModule.ipfs.proxyPrefix)) continue // We store only partial url in constants
-        if (url.startsWith(externalLinksModule.faucets.oasisTestnet)) continue // Has an interactive challenge
         if (url.startsWith('mailto')) continue // We can't test email addresses
 
         it.concurrent(`${linksGroupName} ${linkName} ${url}`, async () => {


### PR DESCRIPTION
The settings on the test faucet links have been updated, so this should be OK again.

(This reverts #1807)