### PR TITLE
Find Burn and Pontus-X accounts despite being empty

### DIFF
--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -118,7 +118,9 @@ export const useSearchForOasisAccountsByName = (
 
   const textMatcher =
     nameFragment && queryOptions.enabled
-      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+      ? (account: AccountMetadata) => {
+          return hasTextMatch(account.name, [nameFragment]) || hasTextMatch(account.address, [nameFragment])
+        }
       : () => false
 
   const matches =

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -86,7 +86,9 @@ export const useSearchForPontusXAccountsByName = (
 
   const textMatcher =
     nameFragment && queryOptions.enabled
-      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+      ? (account: AccountMetadata) => {
+          return hasTextMatch(account.name, [nameFragment]) || hasTextMatch(account.address, [nameFragment])
+        }
       : () => false
 
   const matches =

--- a/src/app/hooks/useSearchForValidatorsByName.ts
+++ b/src/app/hooks/useSearchForValidatorsByName.ts
@@ -12,7 +12,7 @@ function findAddressesWithMatch(addressMap: ValidatorAddressNameMap, nameFragmen
   const matchedAddresses: AccountNameSearchConsensusMatch[] = []
 
   for (const [address, name] of Object.entries(addressMap)) {
-    if (hasTextMatch(name, [nameFragment])) {
+    if (hasTextMatch(name, [nameFragment]) || hasTextMatch(address, [nameFragment])) {
       matchedAddresses.push({ address, layer: Layer.consensus, network })
     }
   }

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -376,6 +376,14 @@ export const useSearch = (currentScope: SearchScope | undefined, q: SearchParams
     ...(queries.accountsByName.results || []), // Don't filter, keep empty accounts too
     ...(queries.validatorByName.results || []), // Don't filter, keep empty validators too
   ]
+    .reduce((uniq, account) => {
+      const key = [account.network, account.layer, account.address].join(',')
+      // Deduplicate accounts found by address and name
+      if (!uniq.has(key)) uniq.set(key, account)
+      return uniq
+    }, new Map<string, RuntimeAccount | Account>())
+    .values()
+
   const tokens = queries.tokens.results
     .map(l => l.evm_tokens)
     .flat()

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -370,12 +370,12 @@ export const useSearch = (currentScope: SearchScope | undefined, q: SearchParams
   ]
   const transactions = [...(queries.runtimeTxHash.results || []), ...(queries.consensusTxHash.results || [])]
   const accounts = [
-    ...(queries.oasisConsensusAccount.results || []),
-    ...(queries.oasisRuntimeAccount.results || []),
-    ...(queries.evmAccount.results || []),
-    ...(queries.accountsByName.results || []),
-    ...(queries.validatorByName.results || []),
-  ].filter(isAccountNonEmpty)
+    ...(queries.oasisConsensusAccount.results || []).filter(isAccountNonEmpty),
+    ...(queries.oasisRuntimeAccount.results || []).filter(isAccountNonEmpty),
+    ...(queries.evmAccount.results || []).filter(isAccountNonEmpty),
+    ...(queries.accountsByName.results || []), // Don't filter, keep empty accounts too
+    ...(queries.validatorByName.results || []), // Don't filter, keep empty validators too
+  ]
   const tokens = queries.tokens.results
     .map(l => l.evm_tokens)
     .flat()


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/explorer/pull/1785#discussion_r1984966154

By name
http://localhost:1234/search?q=burn
http://localhost:1234/search?q=Pontus-X

By address
http://localhost:1234/search?q=oasis1qzq8u7xs328puu2jy524w3fygzs63rv3u5967970
http://localhost:1234/search?q=oasis1qrg6c89655pmdxeel08qkngs02jnrfll5v9c508v

But don't duplicate
http://localhost:1234/search?q=oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4
