### PR TITLE
Indicate self-professed nature of validator name

### DIFF
--- a/.changelog/1813.trivial.md
+++ b/.changelog/1813.trivial.md
@@ -1,0 +1,1 @@
+ndicate self-professed nature of validator name

--- a/src/app/components/Validators/ValidatorLink.tsx
+++ b/src/app/components/Validators/ValidatorLink.tsx
@@ -9,6 +9,9 @@ import { COLORS } from '../../../styles/theme/colors'
 import { Network } from '../../../types/network'
 import { HighlightedText } from '../HighlightedText'
 import { useValidatorName } from '../../hooks/useValidatorName'
+import Box from '@mui/material/Box'
+import { AccountMetadataSourceIndicator } from '../Account/AccountMetadataSourceIndicator'
+import { MaybeWithTooltip } from '../AdaptiveTrimmer/MaybeWithTooltip'
 
 type ValidatorLinkProps = {
   address: string
@@ -29,25 +32,45 @@ export const ValidatorLink: FC<ValidatorLinkProps> = ({
   const to = RouteUtils.getValidatorRoute(network, address)
   const validatorName = useValidatorName(network, address)
 
-  return (
-    <Typography variant="mono" component="span" sx={{ color: COLORS.brandDark, fontWeight: 700 }}>
-      {isTablet ? (
-        <TabletValidatorLink
-          address={address}
-          name={name || validatorName}
-          to={to}
-          highlightedPart={highlightedPartOfName}
-        />
-      ) : (
-        <DesktopValidatorLink
-          address={address}
-          alwaysTrim={alwaysTrim}
-          name={name || validatorName}
-          to={to}
-          highlightedPart={highlightedPartOfName}
-        />
+  const displayName = name ?? validatorName
+
+  const tooltipTitle = (
+    <div>
+      {displayName && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+          <Box sx={{ fontWeight: 'bold' }}>{displayName}</Box>
+          <span>-</span>
+          <AccountMetadataSourceIndicator source={'SelfProfessed'} withText />
+        </Box>
       )}
-    </Typography>
+      <Box sx={{ fontWeight: 'normal' }}>{address}</Box>
+    </div>
+  )
+
+  return (
+    <MaybeWithTooltip title={tooltipTitle}>
+      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+        <AccountMetadataSourceIndicator source={'SelfProfessed'} />{' '}
+        <Typography variant="mono" component="span" sx={{ color: COLORS.brandDark, fontWeight: 700 }}>
+          {isTablet ? (
+            <TabletValidatorLink
+              address={address}
+              name={displayName}
+              to={to}
+              highlightedPart={highlightedPartOfName}
+            />
+          ) : (
+            <DesktopValidatorLink
+              address={address}
+              alwaysTrim={alwaysTrim}
+              name={displayName}
+              to={to}
+              highlightedPart={highlightedPartOfName}
+            />
+          )}
+        </Typography>
+      </Box>
+    </MaybeWithTooltip>
   )
 }
 


### PR DESCRIPTION
When showing validator links with names, we need to indicate the source of the those names, just like we do with other names coming from a registry.

### Before:

![image](https://github.com/user-attachments/assets/d3bdacbe-e54a-4282-a9b8-bb25997868b1)

![image](https://github.com/user-attachments/assets/a4eb5865-1369-41a3-9000-14a77b5bf79a)

### After: 

![image](https://github.com/user-attachments/assets/97a4ead8-7eba-4b96-8f25-d664d027edcb)

![image](https://github.com/user-attachments/assets/837fcc4c-b7c6-4ecb-bd7e-ba946a848976)
