### PR TITLE
Small improvements on the validator page

### DIFF
--- a/.changelog/1815.trivial.md
+++ b/.changelog/1815.trivial.md
@@ -1,0 +1,1 @@
+Also show validator account balance on validator page

--- a/src/app/components/Validators/ValidatorLink.tsx
+++ b/src/app/components/Validators/ValidatorLink.tsx
@@ -34,8 +34,9 @@ export const ValidatorLink: FC<ValidatorLinkProps> = ({
   const validatorName = useValidatorName(network, address)
 
   const displayName = name ?? validatorName
+  const hasName = displayName?.toLowerCase() !== address.toLowerCase()
 
-  const tooltipTitle = (
+  const tooltipTitle = hasName ? (
     <div>
       {displayName && (
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
@@ -46,12 +47,12 @@ export const ValidatorLink: FC<ValidatorLinkProps> = ({
       )}
       <Box sx={{ fontWeight: 'normal' }}>{address}</Box>
     </div>
-  )
+  ) : undefined
 
   return (
     <MaybeWithTooltip title={tooltipTitle}>
       <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-        <AccountMetadataSourceIndicator source={'SelfProfessed'} />{' '}
+        {hasName && <AccountMetadataSourceIndicator source={'SelfProfessed'} />}
         <Typography variant="mono" component="span" sx={{ color: COLORS.brandDark, fontWeight: 700 }}>
           {isTablet ? (
             <TabletValidatorLink

--- a/src/app/pages/ValidatorDetailsPage/EscrowDistributionCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/EscrowDistributionCard.tsx
@@ -35,11 +35,11 @@ function chartData(t: TFunction, validator: Validator | undefined) {
   ]
 }
 
-export const BalanceDistributionCard: FC<BalanceDistributionCardProps> = ({ validator }) => {
+export const EscrowDistributionCard: FC<BalanceDistributionCardProps> = ({ validator }) => {
   const { t } = useTranslation()
 
   return (
-    <SnapshotCard title={t('validator.balanceDistribution')}>
+    <SnapshotCard title={t('validator.escrowDistribution')}>
       {validator?.escrow.active_balance && (
         <PieChart
           compact

--- a/src/app/pages/ValidatorDetailsPage/ValidatorSnapshot.tsx
+++ b/src/app/pages/ValidatorDetailsPage/ValidatorSnapshot.tsx
@@ -10,7 +10,7 @@ import { ExternalLinkCard } from './ExternalLinkCard'
 import { SearchScope } from '../../../types/searchScope'
 import { UptimeCard } from './UptimeCard'
 import { VotingPowerCard } from './VotingPowerCard'
-import { BalanceDistributionCard } from './BalanceDistributionCard'
+import { EscrowDistributionCard } from './EscrowDistributionCard'
 import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { StyledGrid } from '../../components/Snapshots/Snapshot'
 
@@ -42,7 +42,7 @@ export const ValidatorSnapshot: FC<ValidatorSnapshotProps> = ({ scope, validator
 
       <Grid container rowSpacing={1} columnSpacing={4} columns={22}>
         <StyledGrid item xs={22} md={6}>
-          <BalanceDistributionCard validator={validator} />
+          <EscrowDistributionCard validator={validator} />
         </StyledGrid>
         <StyledGrid item xs={22} md={6}>
           <VotingPowerCard validator={validator} stats={stats} />

--- a/src/app/pages/ValidatorDetailsPage/ValidatorTitleCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/ValidatorTitleCard.tsx
@@ -2,13 +2,13 @@ import { FC } from 'react'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
-import { Validator } from '../../../oasis-nexus/api'
+import { Layer, Validator } from '../../../oasis-nexus/api'
 import { COLORS } from 'styles/theme/colors'
 import { ValidatorImage } from 'app/components/Validators/ValidatorImage'
 import { TitleCard } from 'app/components/PageLayout/TitleCard'
 import { Network } from '../../../types/network'
-import { ValidatorLink } from 'app/components/Validators/ValidatorLink'
 import { ValidatorStatusBadge } from './ValidatorStatusBadge'
+import { AccountLink } from '../../components/Account/AccountLink'
 
 type ValidatorTitleCardProps = {
   isLoading: boolean
@@ -25,10 +25,10 @@ export const ValidatorTitleCard: FC<ValidatorTitleCardProps> = ({ isLoading, net
             <Box sx={{ display: 'flex' }}>
               <ValidatorStatusBadge active={validator.active} inValidatorSet={validator?.in_validator_set} />
               <Box sx={{ paddingLeft: 4 }}>
-                <ValidatorLink
+                <AccountLink
+                  scope={{ network, layer: Layer.consensus }}
                   address={validator.entity_address}
-                  name={validator.entity_address}
-                  network={network}
+                  showOnlyAddress
                 />
               </Box>
               <CopyToClipboard value={validator.entity_address} />

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -41,6 +41,7 @@ import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { AccountLink } from '../../components/Account/AccountLink'
+import { Network } from '../../../types/network'
 
 export const StyledListTitle = styled('dt')(({ theme }) => ({
   marginLeft: theme.spacing(4),
@@ -77,7 +78,13 @@ export const ValidatorDetailsPage: FC = () => {
       <ValidatorTitleCard isLoading={isLoading} network={scope.network} validator={validator} />
       <ValidatorSnapshot scope={scope} validator={validator} stats={stats} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <ValidatorDetailsCard isLoading={isLoading} validator={validator} account={account} stats={stats} />
+      <ValidatorDetailsCard
+        network={scope.network}
+        isLoading={isLoading}
+        validator={validator}
+        account={account}
+        stats={stats}
+      />
       <Grid container spacing={4}>
         <StyledGrid item xs={12} md={6}>
           <StakingTrend address={address} scope={scope} />
@@ -101,17 +108,25 @@ export const ValidatorDetailsPage: FC = () => {
 }
 
 type ValidatorDetailsCardProps = {
+  network: Network
   isLoading: boolean
   validator: Validator | undefined
   account: Account | undefined
   stats: ValidatorAggStats | undefined
 }
 
-const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({ isLoading, validator, account, stats }) => {
+const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({
+  network,
+  isLoading,
+  validator,
+  account,
+  stats,
+}) => {
   return (
     <Card>
       <CardContent>
         <ValidatorDetailsView
+          network={network}
           detailsPage
           isLoading={isLoading}
           validator={validator}
@@ -124,13 +139,14 @@ const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({ isLoading, valida
 }
 
 export const ValidatorDetailsView: FC<{
+  network: Network
   detailsPage?: boolean
   isLoading?: boolean
   validator: Validator | undefined
   account: Account | undefined
   standalone?: boolean
   stats: ValidatorAggStats | undefined
-}> = ({ detailsPage, isLoading, validator, account, standalone = false, stats }) => {
+}> = ({ network, detailsPage, isLoading, validator, account, standalone = false, stats }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const formattedTime = useFormattedTimestampStringWithDistance(validator?.start_date)
@@ -155,11 +171,7 @@ export const ValidatorDetailsView: FC<{
           <dd>{validator.rank}</dd>
           <dt>{t('common.address')}</dt>
           <dd>
-            <AccountLink
-              scope={{ network: 'mainnet', layer: 'consensus' }} // This will only be a label, not a real link, so this doesn't matter
-              address={validator.entity_address}
-              labelOnly
-            />
+            <AccountLink scope={{ network, layer: 'consensus' }} address={validator.entity_address} />
           </dd>
           <dt>
             <strong>{t('account.totalBalance')}</strong>

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -40,6 +40,7 @@ import { RoundedBalance } from '../../components/RoundedBalance'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
+import { AccountLink } from '../../components/Account/AccountLink'
 
 export const StyledListTitle = styled('dt')(({ theme }) => ({
   marginLeft: theme.spacing(4),
@@ -153,7 +154,13 @@ export const ValidatorDetailsView: FC<{
           <dt>{t('common.rank')}</dt>
           <dd>{validator.rank}</dd>
           <dt>{t('common.address')}</dt>
-          <dd>{validator.entity_address}</dd>
+          <dd>
+            <AccountLink
+              scope={{ network: 'mainnet', layer: 'consensus' }} // This will only be a label, not a real link, so this doesn't matter
+              address={validator.entity_address}
+              labelOnly
+            />
+          </dd>
           <dt>
             <strong>{t('account.totalBalance')}</strong>
           </dt>

--- a/src/app/pages/ValidatorsPage/index.tsx
+++ b/src/app/pages/ValidatorsPage/index.tsx
@@ -82,6 +82,7 @@ export const ValidatorsPage: FC = () => {
             {isLoading &&
               [...Array(PAGE_SIZE).keys()].map(key => (
                 <ValidatorDetailsView
+                  network={network}
                   key={key}
                   isLoading={true}
                   validator={undefined}
@@ -93,6 +94,7 @@ export const ValidatorsPage: FC = () => {
             {!isLoading &&
               validatorsData?.validators.map(validator => (
                 <ValidatorDetailsView
+                  network={network}
                   key={validator.entity_address}
                   validator={validator}
                   account={undefined}

--- a/src/app/pages/ValidatorsPage/index.tsx
+++ b/src/app/pages/ValidatorsPage/index.tsx
@@ -85,6 +85,7 @@ export const ValidatorsPage: FC = () => {
                   key={key}
                   isLoading={true}
                   validator={undefined}
+                  account={undefined}
                   stats={undefined}
                   standalone
                 />
@@ -94,6 +95,7 @@ export const ValidatorsPage: FC = () => {
                 <ValidatorDetailsView
                   key={validator.entity_address}
                   validator={validator}
+                  account={undefined}
                   stats={validatorsQuery.data?.data.stats}
                   standalone
                 />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -723,7 +723,6 @@
   "validator": {
     "active": "Active",
     "amount": "Amount",
-    "balanceDistribution": "Balance Distribution",
     "blockWithHeight": "Block {{height}}",
     "boundsNotSet": "No bounds set (0% - 100%)",
     "change": "Change (24h)",
@@ -737,6 +736,7 @@
     "emptyDebondingList": "No one is debonding delegations from this validator.",
     "emptyDelegationsList": "No one is delegating to this validator.",
     "entityId": "Entity ID",
+    "escrowDistribution": "Escrow Distribution",
     "externalLink": "External Link",
     "externalLinkDescription": "Oasis is not responsible for any content on external pages.",
     "groupStatus": "{{status}} validators",


### PR DESCRIPTION
- [x] Also show validator account balance on - closes #1811
- [x] Fix address display (ie. tooltip) in the title line
- [x]  Fix address display in the details - enable address highlighting
- [x] Use actual link for the address in the validator details table
- [x] Provide a link to the account page (somehere ... maybe in the title?)
- [x] Validator dashboard: Balance Distribution -> Escrow Distribution

# Changes:

## Balance displayed on the validator page

![image](https://github.com/user-attachments/assets/45b996e9-a8f0-4746-bfa0-ac0495b270e0)

## Address link in the title

### Before

![image](https://github.com/user-attachments/assets/819b7d3c-88fb-4df7-8a4c-f32ea80d8001)

- Link points to this same validator page.
- There is the gray tick before the address

### After

![image](https://github.com/user-attachments/assets/62057c14-2d27-49a7-8e18-edd3ca1954cd)

- Link points to account page
- No gray tick, since there is no identity mentioned here

## Address displayed in details

### Before

![image](https://github.com/user-attachments/assets/2e7bd4d4-06a9-4ab1-baeb-5e8fe9c1e6af)

- Doesn't participates in address highlighting

### After

![image](https://github.com/user-attachments/assets/27e3e44b-248b-439c-bf11-319be53cc8c4)

- Participates in address highlighting