### PR TITLE
Create ROFL status badges component

### DIFF
--- a/.changelog/1819.bugfix.md
+++ b/.changelog/1819.bugfix.md
@@ -1,0 +1,1 @@
+Create ROFL status badges component

--- a/src/app/components/ContractVerificationIcon/index.tsx
+++ b/src/app/components/ContractVerificationIcon/index.tsx
@@ -1,9 +1,6 @@
-import { FC, ReactNode, useState } from 'react'
+import { FC, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import CancelIcon from '@mui/icons-material/Cancel'
-import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
@@ -11,47 +8,23 @@ import { SearchScope } from '../../../types/searchScope'
 import * as externalLinks from '../../utils/externalLinks'
 import { isLocalnet } from '../../utils/route-utils'
 import { AbiPlaygroundLink } from './AbiPlaygroundLink'
-
-type VerificationStatus = 'verified' | 'unverified'
-
-const statusBgColor: Record<VerificationStatus, string> = {
-  verified: COLORS.honeydew,
-  unverified: COLORS.linen,
-}
-
-const statusFgColor: Record<VerificationStatus, string> = {
-  verified: COLORS.brandExtraDark,
-  unverified: COLORS.brandExtraDark,
-}
-
-const statusIcon: Record<VerificationStatus, ReactNode> = {
-  verified: <CheckCircleIcon color="success" fontSize="small" />,
-  unverified: <CancelIcon color="error" fontSize="small" />,
-}
+import { StatusBadge } from '../common/StatusBadge'
 
 export const verificationIconBoxHeight = 28
 
-const StyledPill = styled(Box, {
-  shouldForwardProp: prop => prop !== 'verified' && prop !== 'address_eth',
-})(({ verified }: { verified: boolean; address_eth: string }) => {
-  const status: VerificationStatus = verified ? 'verified' : 'unverified'
-  return {
-    display: 'flex',
-    flexShrink: 0,
-    justifyContent: 'center',
-    height: verificationIconBoxHeight,
-    fontSize: '12px',
-    backgroundColor: statusBgColor[status],
-    color: statusFgColor[status],
-    borderRadius: 10,
-    padding: 4,
-    paddingLeft: 10,
-    paddingRight: 5,
-    '&&': {
-      textDecoration: 'none',
-    },
-  }
-})
+type ContractStatusProps = {
+  verified: boolean
+}
+
+export const ContractStatus = ({ verified }: ContractStatusProps) => {
+  const { t } = useTranslation()
+  const statusLabel = verified
+    ? t('contract.verification.isVerified')
+    : t('contract.verification.isNotVerified')
+  const statusVariant = verified ? 'success' : 'danger'
+
+  return <StatusBadge label={statusLabel} variant={statusVariant} />
+}
 
 export const VerificationIcon: FC<{
   address_eth: string
@@ -64,11 +37,6 @@ export const VerificationIcon: FC<{
   if (isLocalnet(scope.network)) {
     return null
   }
-  const status: VerificationStatus = verified ? 'verified' : 'unverified'
-  const statusLabel: Record<VerificationStatus, string> = {
-    verified: t('contract.verification.isVerified'),
-    unverified: t('contract.verification.isNotVerified'),
-  }
   const sourcifyLinkProps = {
     href: `${externalLinks.dapps.sourcifyRoot}#/lookup/${address_eth}`,
     rel: 'noopener noreferrer',
@@ -76,16 +44,14 @@ export const VerificationIcon: FC<{
     sx: { fontWeight: 400, color: 'inherit', textDecoration: 'underline' },
     onClick: verified ? undefined : () => setExplainDelay(true),
   }
-  const Component = noLink ? Box : Link
+  const Component = noLink ? Box : (Link as React.ElementType)
   const componentProps = noLink ? {} : sourcifyLinkProps
 
   return (
     <>
-      <StyledPill component={Component} verified={verified} address_eth={address_eth} {...componentProps}>
-        {statusLabel[status]}
-        &nbsp; &nbsp;
-        {statusIcon[status]}
-      </StyledPill>
+      <Component {...componentProps}>
+        <ContractStatus verified={verified} />
+      </Component>
       &nbsp; &nbsp;
       {!noLink &&
         (verified ? (

--- a/src/app/components/Rofl/AppStatus.tsx
+++ b/src/app/components/Rofl/AppStatus.tsx
@@ -1,49 +1,25 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
-import { styled } from '@mui/material/styles'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import CancelIcon from '@mui/icons-material/Cancel'
-import { COLORS } from '../../../styles/theme/colors'
+import { StatusBadge, StatusVariant } from '../common/StatusBadge'
 
 type RoflAppStatusTypes = 'active' | 'inactive' | 'removed'
 
-const statusBgColor: Record<RoflAppStatusTypes, string> = {
-  active: COLORS.honeydew,
-  inactive: COLORS.warningBackground,
-  removed: COLORS.linen,
+const statusVariant: Record<RoflAppStatusTypes, StatusVariant> = {
+  active: 'success',
+  inactive: 'warning',
+  removed: 'danger',
 }
 
-export const statusIcon: Record<RoflAppStatusTypes, ReactNode> = {
-  active: <CheckCircleIcon color="success" fontSize="small" />,
+const statusIcon: Partial<Record<RoflAppStatusTypes, ReactNode>> = {
   inactive: <CheckCircleIcon color="warning" fontSize="small" />,
-  removed: <CancelIcon color="error" fontSize="small" />,
 }
-
-const StyledBadge = styled(Box, {
-  shouldForwardProp: prop => prop !== 'status',
-})(({ status }: { status: RoflAppStatusTypes }) => {
-  return {
-    display: 'inline-flex',
-    gap: 8,
-    flexShrink: 0,
-    justifyContent: 'center',
-    height: 28,
-    fontSize: '12px',
-    backgroundColor: statusBgColor[status],
-    color: COLORS.brandExtraDark,
-    borderRadius: 10,
-    padding: 4,
-    paddingLeft: 10,
-    paddingRight: 5,
-  }
-})
 
 type AppStatusProps = {
   status: RoflAppStatusTypes
 }
 
-export const AppStatus: FC<AppStatusProps> = ({ status }) => {
+export const AppStatus = ({ status }: AppStatusProps) => {
   const { t } = useTranslation()
   const statusLabel: Record<RoflAppStatusTypes, string> = {
     active: t('rofl.active'),
@@ -51,10 +27,5 @@ export const AppStatus: FC<AppStatusProps> = ({ status }) => {
     removed: t('rofl.removed'),
   }
 
-  return (
-    <StyledBadge status={status}>
-      {statusLabel[status]}
-      {statusIcon[status]}
-    </StyledBadge>
-  )
+  return <StatusBadge label={statusLabel[status]} icon={statusIcon[status]} variant={statusVariant[status]} />
 }

--- a/src/app/components/Rofl/AppStatus.tsx
+++ b/src/app/components/Rofl/AppStatus.tsx
@@ -1,0 +1,57 @@
+import { FC, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import { styled } from '@mui/material/styles'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import CancelIcon from '@mui/icons-material/Cancel'
+import { COLORS } from '../../../styles/theme/colors'
+
+type RoflAppStatusTypes = 'active' | 'inactive'
+
+const statusBgColor: Record<RoflAppStatusTypes, string> = {
+  active: COLORS.honeydew,
+  inactive: COLORS.linen,
+}
+
+export const statusIcon: Record<RoflAppStatusTypes, ReactNode> = {
+  active: <CheckCircleIcon color="success" fontSize="small" />,
+  inactive: <CancelIcon color="error" fontSize="small" />,
+}
+
+const StyledBadge = styled(Box, {
+  shouldForwardProp: prop => prop !== 'status',
+})(({ status }: { status: RoflAppStatusTypes }) => {
+  return {
+    display: 'inline-flex',
+    gap: 8,
+    flexShrink: 0,
+    justifyContent: 'center',
+    height: 28,
+    fontSize: '12px',
+    backgroundColor: statusBgColor[status],
+    color: COLORS.brandExtraDark,
+    borderRadius: 10,
+    padding: 4,
+    paddingLeft: 10,
+    paddingRight: 5,
+  }
+})
+
+type AppStatusProps = {
+  status: RoflAppStatusTypes
+}
+
+export const AppStatus: FC<AppStatusProps> = ({ status }) => {
+  const { t } = useTranslation()
+  const statusLabel: Record<RoflAppStatusTypes, string> = {
+    active: t('rofl.active'),
+    inactive: t('rofl.inactive'),
+  }
+
+  return (
+    <StyledBadge status={status}>
+      {statusLabel[status]}
+      {statusIcon[status]}
+    </StyledBadge>
+  )
+}

--- a/src/app/components/Rofl/AppStatus.tsx
+++ b/src/app/components/Rofl/AppStatus.tsx
@@ -6,16 +6,18 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import CancelIcon from '@mui/icons-material/Cancel'
 import { COLORS } from '../../../styles/theme/colors'
 
-type RoflAppStatusTypes = 'active' | 'inactive'
+type RoflAppStatusTypes = 'active' | 'inactive' | 'removed'
 
 const statusBgColor: Record<RoflAppStatusTypes, string> = {
   active: COLORS.honeydew,
-  inactive: COLORS.linen,
+  inactive: COLORS.warningBackground,
+  removed: COLORS.linen,
 }
 
 export const statusIcon: Record<RoflAppStatusTypes, ReactNode> = {
   active: <CheckCircleIcon color="success" fontSize="small" />,
-  inactive: <CancelIcon color="error" fontSize="small" />,
+  inactive: <CheckCircleIcon color="warning" fontSize="small" />,
+  removed: <CancelIcon color="error" fontSize="small" />,
 }
 
 const StyledBadge = styled(Box, {
@@ -46,6 +48,7 @@ export const AppStatus: FC<AppStatusProps> = ({ status }) => {
   const statusLabel: Record<RoflAppStatusTypes, string> = {
     active: t('rofl.active'),
     inactive: t('rofl.inactive'),
+    removed: t('rofl.removed'),
   }
 
   return (

--- a/src/app/components/Rofl/RoflAppStatusBadge.tsx
+++ b/src/app/components/Rofl/RoflAppStatusBadge.tsx
@@ -15,11 +15,11 @@ const statusIcon: Partial<Record<RoflAppStatusTypes, ReactNode>> = {
   inactive: <CheckCircleIcon color="warning" fontSize="small" />,
 }
 
-type AppStatusProps = {
+type RoflAppStatusBadgeProps = {
   status: RoflAppStatusTypes
 }
 
-export const AppStatus = ({ status }: AppStatusProps) => {
+export const RoflAppStatusBadge = ({ status }: RoflAppStatusBadgeProps) => {
   const { t } = useTranslation()
   const statusLabel: Record<RoflAppStatusTypes, string> = {
     active: t('rofl.active'),

--- a/src/app/components/common/StatusBadge.tsx
+++ b/src/app/components/common/StatusBadge.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import { styled } from '@mui/material/styles'
+import { COLORS } from '../../../styles/theme/colors'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import CancelIcon from '@mui/icons-material/Cancel'
+import InfoIcon from '@mui/icons-material/Info'
+import ErrorIcon from '@mui/icons-material/Error'
+
+export type StatusVariant = 'success' | 'warning' | 'danger' | 'info'
+
+const variantStyles: Record<StatusVariant, { bgColor: string; fgColor: string }> = {
+  success: {
+    bgColor: COLORS.honeydew,
+    fgColor: COLORS.brandExtraDark,
+  },
+  warning: {
+    bgColor: COLORS.warningBackground,
+    fgColor: COLORS.brandExtraDark,
+  },
+  danger: {
+    bgColor: COLORS.linen,
+    fgColor: COLORS.brandExtraDark,
+  },
+  info: {
+    bgColor: COLORS.brandLightBlue,
+    fgColor: COLORS.brandExtraDark,
+  },
+}
+
+const variantIcon: Record<StatusVariant, ReactNode> = {
+  success: <CheckCircleIcon color="success" fontSize="small" />,
+  warning: <ErrorIcon color="warning" fontSize="small" />,
+  danger: <CancelIcon color="error" fontSize="small" />,
+  info: <InfoIcon color="info" fontSize="small" />,
+}
+
+export type StatusBadgeProps = {
+  label: string
+  icon?: ReactNode
+  variant?: StatusVariant
+  bgColor?: string
+  fgColor?: string
+}
+
+const StyledBadge = styled(Box, {
+  shouldForwardProp: prop => !['bgColor', 'fgColor'].includes(prop as string),
+})<{ bgColor: string; fgColor: string }>(({ bgColor, fgColor }) => {
+  return {
+    display: 'inline-flex',
+    gap: 8,
+    flexShrink: 0,
+    justifyContent: 'center',
+    height: 28,
+    fontSize: '12px',
+    backgroundColor: bgColor,
+    color: fgColor,
+    borderRadius: 10,
+    padding: 4,
+    paddingLeft: 10,
+    paddingRight: 5,
+  }
+})
+
+export const StatusBadge = ({ label, icon, variant = 'info' }: StatusBadgeProps) => {
+  return (
+    <StyledBadge bgColor={variantStyles[variant].bgColor} fgColor={variantStyles[variant].fgColor}>
+      {label}
+      {icon || variantIcon[variant]}
+    </StyledBadge>
+  )
+}

--- a/src/app/components/common/StatusBadge.tsx
+++ b/src/app/components/common/StatusBadge.tsx
@@ -9,22 +9,18 @@ import ErrorIcon from '@mui/icons-material/Error'
 
 export type StatusVariant = 'success' | 'warning' | 'danger' | 'info'
 
-const variantStyles: Record<StatusVariant, { bgColor: string; fgColor: string }> = {
+const variantStyles: Record<StatusVariant, { bgColor: string }> = {
   success: {
     bgColor: COLORS.honeydew,
-    fgColor: COLORS.brandExtraDark,
   },
   warning: {
     bgColor: COLORS.warningBackground,
-    fgColor: COLORS.brandExtraDark,
   },
   danger: {
     bgColor: COLORS.linen,
-    fgColor: COLORS.brandExtraDark,
   },
   info: {
     bgColor: COLORS.brandLightBlue,
-    fgColor: COLORS.brandExtraDark,
   },
 }
 
@@ -35,17 +31,15 @@ const variantIcon: Record<StatusVariant, ReactNode> = {
   info: <InfoIcon color="info" fontSize="small" />,
 }
 
-export type StatusBadgeProps = {
+type StatusBadgeProps = {
   label: string
   icon?: ReactNode
   variant?: StatusVariant
-  bgColor?: string
-  fgColor?: string
 }
 
 const StyledBadge = styled(Box, {
-  shouldForwardProp: prop => !['bgColor', 'fgColor'].includes(prop as string),
-})<{ bgColor: string; fgColor: string }>(({ bgColor, fgColor }) => {
+  shouldForwardProp: prop => prop !== 'bgColor',
+})<{ bgColor: string }>(({ bgColor }) => {
   return {
     display: 'inline-flex',
     gap: 8,
@@ -54,7 +48,7 @@ const StyledBadge = styled(Box, {
     height: 28,
     fontSize: '12px',
     backgroundColor: bgColor,
-    color: fgColor,
+    color: COLORS.brandExtraDark,
     borderRadius: 10,
     padding: 4,
     paddingLeft: 10,
@@ -64,7 +58,7 @@ const StyledBadge = styled(Box, {
 
 export const StatusBadge = ({ label, icon, variant = 'info' }: StatusBadgeProps) => {
   return (
-    <StyledBadge bgColor={variantStyles[variant].bgColor} fgColor={variantStyles[variant].fgColor}>
+    <StyledBadge bgColor={variantStyles[variant].bgColor}>
       {label}
       {icon || variantIcon[variant]}
     </StyledBadge>

--- a/src/app/pages/ValidatorDetailsPage/ValidatorStatusBadge.tsx
+++ b/src/app/pages/ValidatorDetailsPage/ValidatorStatusBadge.tsx
@@ -1,50 +1,19 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
-import { styled } from '@mui/material/styles'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import CancelIcon from '@mui/icons-material/Cancel'
 import Pending from '@mui/icons-material/Pending'
-import { COLORS } from '../../../styles/theme/colors'
+import { StatusBadge, StatusVariant } from '../../components/common/StatusBadge'
 
 type ValidatorStatus = 'active' | 'waiting' | 'inactive'
 
-const statusBgColor: Record<ValidatorStatus, string> = {
-  active: COLORS.honeydew,
-  waiting: COLORS.brandLightBlue,
-  inactive: COLORS.linen,
+const statusVariant: Record<ValidatorStatus, StatusVariant> = {
+  active: 'success',
+  waiting: 'info',
+  inactive: 'danger',
 }
 
-const statusFgColor: Record<ValidatorStatus, string> = {
-  active: COLORS.brandExtraDark,
-  waiting: COLORS.brandExtraDark,
-  inactive: COLORS.brandExtraDark,
-}
-
-export const statusIcon: Record<ValidatorStatus, ReactNode> = {
-  active: <CheckCircleIcon color="success" fontSize="small" />,
+export const statusIcon: Partial<Record<ValidatorStatus, ReactNode>> = {
   waiting: <Pending color="info" fontSize="small" />,
-  inactive: <CancelIcon color="error" fontSize="small" />,
 }
-
-const StyledBadge = styled(Box, {
-  shouldForwardProp: prop => prop !== 'status',
-})(({ status }: { status: ValidatorStatus }) => {
-  return {
-    display: 'flex',
-    gap: 8,
-    flexShrink: 0,
-    justifyContent: 'center',
-    height: 28,
-    fontSize: '12px',
-    backgroundColor: statusBgColor[status],
-    color: statusFgColor[status],
-    borderRadius: 10,
-    padding: 4,
-    paddingLeft: 10,
-    paddingRight: 5,
-  }
-})
 
 type ValidatorStatusBadgeProps = {
   active: boolean
@@ -56,19 +25,14 @@ const getValidatorBadgeStatus = ({ active, inValidatorSet }: ValidatorStatusBadg
   return active ? 'waiting' : 'inactive'
 }
 
-export const ValidatorStatusBadge: FC<ValidatorStatusBadgeProps> = ({ active, inValidatorSet }) => {
+export const ValidatorStatusBadge = ({ active, inValidatorSet }: ValidatorStatusBadgeProps) => {
   const { t } = useTranslation()
-  const status = getValidatorBadgeStatus({ active, inValidatorSet })
+  const status = getValidatorBadgeStatus({ active, inValidatorSet }) as ValidatorStatus
   const statusLabel: Record<ValidatorStatus, string> = {
     active: t('validator.active'),
     waiting: t('validator.waiting'),
     inactive: t('validator.inactive'),
   }
 
-  return (
-    <StyledBadge status={status}>
-      {statusLabel[status]}
-      {statusIcon[status]}
-    </StyledBadge>
-  )
+  return <StatusBadge label={statusLabel[status]} icon={statusIcon[status]} variant={statusVariant[status]} />
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -653,6 +653,10 @@
     "devnet": "Pontus-X devnet",
     "testnet": "Pontus-X"
   },
+  "rofl": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",
     "error": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -655,7 +655,8 @@
   },
   "rofl": {
     "active": "Active",
-    "inactive": "Inactive"
+    "inactive": "Inactive",
+    "removed": "Removed"
   },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",

--- a/src/stories/Badges.stories.tsx
+++ b/src/stories/Badges.stories.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import { StatusBadge } from '../app/components/common/StatusBadge'
 import { AppStatus } from '../app/components/Rofl/AppStatus'
 import { ValidatorStatusBadge } from '../app/pages/ValidatorDetailsPage/ValidatorStatusBadge'
+import { ContractStatus } from 'app/components/ContractVerificationIcon'
 
 export default {
   title: 'Example/Badges',
@@ -19,7 +20,7 @@ const DefaultBadges: StoryFn = () => {
   )
 }
 
-export const StatusBadgesList: StoryObj = {
+export const StatusBadges: StoryObj = {
   render: DefaultBadges,
   args: {},
 }
@@ -34,7 +35,7 @@ const RoflAppStatusStory: StoryFn = () => {
   )
 }
 
-export const RoflStatusesList: StoryObj = {
+export const RoflStatuses: StoryObj = {
   render: RoflAppStatusStory,
   args: {},
 }
@@ -49,7 +50,21 @@ const ValidatorStatusStory: StoryFn = () => {
   )
 }
 
-export const ValidatorStatusesList: StoryObj = {
+export const ValidatorStatuses: StoryObj = {
   render: ValidatorStatusStory,
+  args: {},
+}
+
+const ContractStatusStory: StoryFn = () => {
+  return (
+    <Box>
+      <ContractStatus verified={true} />
+      <ContractStatus verified={false} />
+    </Box>
+  )
+}
+
+export const ContractStatuses: StoryObj = {
+  render: ContractStatusStory,
   args: {},
 }

--- a/src/stories/Badges.stories.tsx
+++ b/src/stories/Badges.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
+import Box from '@mui/material/Box'
+import { StatusBadge } from '../app/components/common/StatusBadge'
+import { AppStatus } from '../app/components/Rofl/AppStatus'
+import { ValidatorStatusBadge } from '../app/pages/ValidatorDetailsPage/ValidatorStatusBadge'
+
+export default {
+  title: 'Example/Badges',
+} satisfies Meta<any>
+
+const DefaultBadges: StoryFn = () => {
+  return (
+    <Box>
+      <StatusBadge label="Label" variant="success" />
+      <StatusBadge label="Label" variant="info" />
+      <StatusBadge label="Label" variant="warning" />
+      <StatusBadge label="Label" variant="danger" />
+    </Box>
+  )
+}
+
+export const StatusBadgesList: StoryObj = {
+  render: DefaultBadges,
+  args: {},
+}
+
+const RoflAppStatusStory: StoryFn = () => {
+  return (
+    <Box>
+      <AppStatus status="active" />
+      <AppStatus status="inactive" />
+      <AppStatus status="removed" />
+    </Box>
+  )
+}
+
+export const RoflStatusesList: StoryObj = {
+  render: RoflAppStatusStory,
+  args: {},
+}
+
+const ValidatorStatusStory: StoryFn = () => {
+  return (
+    <Box>
+      <ValidatorStatusBadge active={true} inValidatorSet={true} />
+      <ValidatorStatusBadge active={true} inValidatorSet={false} />
+      <ValidatorStatusBadge active={false} inValidatorSet={false} />
+    </Box>
+  )
+}
+
+export const ValidatorStatusesList: StoryObj = {
+  render: ValidatorStatusStory,
+  args: {},
+}

--- a/src/stories/Badges.stories.tsx
+++ b/src/stories/Badges.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react'
 import Box from '@mui/material/Box'
 import { StatusBadge } from '../app/components/common/StatusBadge'
-import { AppStatus } from '../app/components/Rofl/AppStatus'
+import { RoflAppStatusBadge } from '../app/components/Rofl/RoflAppStatusBadge'
 import { ValidatorStatusBadge } from '../app/pages/ValidatorDetailsPage/ValidatorStatusBadge'
 import { ContractStatus } from 'app/components/ContractVerificationIcon'
 
@@ -20,7 +20,7 @@ const DefaultBadges: StoryFn = () => {
   )
 }
 
-export const StatusBadges: StoryObj = {
+export const Default: StoryObj = {
   render: DefaultBadges,
   args: {},
 }
@@ -28,14 +28,14 @@ export const StatusBadges: StoryObj = {
 const RoflAppStatusStory: StoryFn = () => {
   return (
     <Box>
-      <AppStatus status="active" />
-      <AppStatus status="inactive" />
-      <AppStatus status="removed" />
+      <RoflAppStatusBadge status="active" />
+      <RoflAppStatusBadge status="inactive" />
+      <RoflAppStatusBadge status="removed" />
     </Box>
   )
 }
 
-export const RoflStatuses: StoryObj = {
+export const RoflAppStatuses: StoryObj = {
   render: RoflAppStatusStory,
   args: {},
 }


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/explorer/pull/1777

- add ROFL status component
- clean up badge usage a little bit by creating a common StatusBadge component 
- add Storybook

Storybook:
![Screenshot from 2025-03-17 10-57-07](https://github.com/user-attachments/assets/298f458e-06d6-4f7a-83b0-ef97703db7b6)

