### PR TITLE
Handle new ROFL instance event

### DIFF
--- a/.changelog/1820.bugfix.md
+++ b/.changelog/1820.bugfix.md
@@ -1,0 +1,1 @@
+Handle new ROFL instance event

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -60,6 +60,8 @@ const getRuntimeEventMethodLabel = (t: TFunction, method: string | undefined) =>
       return t('runtimeEvent.roflAppUpdated')
     case RuntimeEventType.roflapp_removed:
       return t('runtimeEvent.roflAppRemoved')
+    case RuntimeEventType.roflinstance_registered:
+      return t('runtimeEvent.instanceRegistered')
     default:
       return method || t('common.unknown')
   }
@@ -98,6 +100,7 @@ export const EventTypeIcon: FC<{
     [RuntimeEventType.roflapp_created]: <MethodIcon color="green" icon={<MemoryIcon />} {...props} />,
     [RuntimeEventType.roflapp_removed]: <MethodIcon color="orange" icon={<MemoryIcon />} {...props} />,
     [RuntimeEventType.roflapp_updated]: <MethodIcon color="green" icon={<MemoryIcon />} {...props} />,
+    [RuntimeEventType.roflinstance_registered]: <MethodIcon color="green" icon={<MemoryIcon />} {...props} />,
   }
 
   return (
@@ -382,6 +385,23 @@ const RuntimeEventDetailsInner: FC<{
             <MaybeEventErrorLine event={event} />
             <dt>{t('common.id')}</dt>
             <dd>{event.body.id}</dd>
+          </StyledDescriptionList>
+        </div>
+      )
+    case RuntimeEventType.roflinstance_registered:
+      return (
+        <div>
+          <EventTypeIcon eventType={event.type} />
+          <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
+            <MaybeEventErrorLine event={event} />
+            <dt>{t('common.id')}</dt>
+            <dd>{event.body.app_id}</dd>
+            {event.body?.rak?.PublicKey && (
+              <>
+                <dt>{t('rofl.rak')}</dt>
+                <dd>{event.body.rak.PublicKey}</dd>
+              </>
+            )}
           </StyledDescriptionList>
         </div>
       )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -531,6 +531,7 @@
     "roflAppCreated": "ROFL App Created",
     "roflAppUpdated": "ROFL App Updated",
     "roflAppRemoved": "ROFL App Removed",
+    "instanceRegistered": "ROFL Instance Registered",
     "evmLog": "EVM log message",
     "filter": {
       "all": "All events",
@@ -656,6 +657,7 @@
   "rofl": {
     "active": "Active",
     "inactive": "Inactive",
+    "rak": "RAK",
     "removed": "Removed"
   },
   "search": {

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1222,6 +1222,7 @@ export const RuntimeEventType = {
   roflapp_created: 'rofl.app_created',
   roflapp_updated: 'rofl.app_updated',
   roflapp_removed: 'rofl.app_removed',
+  roflinstance_registered: 'rofl.instance_registered',
 } as const;
 
 /**


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/explorer/pull/1777 and https://github.com/oasisprotocol/explorer/pull/1781

We are not handling new ROFL event (dev crash / prod warning)