### PR TITLE
Fix transaction Storybook errors

### DIFF
--- a/.changelog/1823.bugfix.md
+++ b/.changelog/1823.bugfix.md
@@ -1,0 +1,1 @@
+Fix transaction Storybook errors

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,8 @@ import { withDefaultTheme } from '../src/app/components/ThemeByScope'
 import { initialize, mswLoader } from 'msw-storybook-addon'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { handlers } from '../internals/mocks/msw-handlers'
+import { LocalSettingsContextProvider } from '../src/app/providers/LocalSettingsProvider'
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -20,7 +22,11 @@ initialize({
 
 const preview: Preview = {
   decorators: [
-    Story => <QueryClientProvider client={queryClient}>{Story()}</QueryClientProvider>,
+    Story => (
+      <LocalSettingsContextProvider>
+        <QueryClientProvider client={queryClient}>{Story()}</QueryClientProvider>
+      </LocalSettingsContextProvider>
+    ),
     Story => withDefaultTheme(<Story />),
   ],
   loaders: [mswLoader],

--- a/src/app/components/Blocks/BlockLink.tsx
+++ b/src/app/components/Blocks/BlockLink.tsx
@@ -12,7 +12,7 @@ import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 export const BlockLink: FC<{ scope: SearchScope; height: number }> = ({ scope, height }) => (
   <Typography variant="mono">
     <Link component={RouterLink} to={RouteUtils.getBlockRoute(scope, height)}>
-      {height.toLocaleString()}
+      {height?.toLocaleString()}
     </Link>
   </Typography>
 )


### PR DESCRIPTION
Transaction Storybook is broken due to: 

- LocalSettings PR 
```
Error: [useLocalSettings] Component not wrapped within a Provider
    at useLocalSettings
```

- guard against incorrectly indexed tx not working anymore 
```
TypeError: Cannot read properties of undefined (reading 'toLocaleString')
```
