### PR TITLE
Prevent empty span from rendering in AccountLink on mobile

### DIFF
--- a/.changelog/1830.trivial.md
+++ b/.changelog/1830.trivial.md
@@ -1,0 +1,1 @@
+Prevent empty span from rendering in AccountLink on mobile

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -182,14 +182,16 @@ export const AccountLink: FC<Props> = ({
   return (
     <WithTypographyAndLink scope={scope} address={address} mobile labelOnly={labelOnly}>
       <>
-        <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-          {accountMetadata && <AccountMetadataSourceIndicator source={accountMetadata.source} />}
-          <AdaptiveHighlightedText
-            text={showAccountName ? accountName : ''}
-            pattern={highlightedPartOfName}
-            extraTooltip={tooltipTitle}
-          />
-        </Box>
+        {showAccountName && (
+          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+            <AccountMetadataSourceIndicator source={accountMetadata.source} />
+            <AdaptiveHighlightedText
+              text={accountName}
+              pattern={highlightedPartOfName}
+              extraTooltip={tooltipTitle}
+            />
+          </Box>
+        )}
         <AdaptiveTrimmer text={address} strategy="middle" tooltipOverride={tooltipTitle} />
       </>
     </WithTypographyAndLink>


### PR DESCRIPTION
Fixes extra white space on mobile by removing an unnecessary empty <span> in the "From" address field of the Transaction table.

Before:
<img width="512" alt="Screenshot 2025-03-21 at 12 45 10" src="https://github.com/user-attachments/assets/964c02f8-c4b4-4a1d-8adb-cf9e626b58c2" />

After:
<img width="509" alt="Screenshot 2025-03-21 at 12 49 38" src="https://github.com/user-attachments/assets/6e86ab55-f702-4df7-8680-8818529d8e18" />
