### PR TITLE
Create ROFL app metadata and policy cards

### DIFF
--- a/.changelog/1840.bugfix.md
+++ b/.changelog/1840.bugfix.md
@@ -1,0 +1,1 @@
+Create ROFL app metadata and policy cards

--- a/src/app/pages/RoflAppDetailPage/EmptyStateCard.tsx
+++ b/src/app/pages/RoflAppDetailPage/EmptyStateCard.tsx
@@ -1,0 +1,40 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
+import DataObjectIcon from '@mui/icons-material/DataObject'
+import { COLORS } from '../../../styles/theme/colors'
+
+const StyledBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  [theme.breakpoints.down('sm')]: {
+    minHeight: '150px',
+  },
+  [theme.breakpoints.up('sm')]: {
+    minHeight: '200px',
+  },
+}))
+
+export const EmptyStateCard: FC = () => {
+  const { t } = useTranslation()
+
+  return (
+    <StyledBox gap={3}>
+      <DataObjectIcon sx={{ color: COLORS.grayMedium, fontSize: 40, opacity: 0.5 }} />
+      <Typography
+        sx={{
+          color: COLORS.grayMedium,
+          fontWeight: 700,
+          textAlign: 'center',
+          opacity: 0.5,
+        }}
+      >
+        {t('rofl.noData')}
+      </Typography>
+    </StyledBox>
+  )
+}

--- a/src/app/pages/RoflAppDetailPage/GridRow.tsx
+++ b/src/app/pages/RoflAppDetailPage/GridRow.tsx
@@ -1,0 +1,42 @@
+import { FC, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { styled } from '@mui/material/styles'
+import Grid from '@mui/material/Grid'
+import Tooltip from '@mui/material/Tooltip'
+import InfoIcon from '@mui/icons-material/Info'
+import { COLORS } from '../../../styles/theme/colors'
+
+export const StyledGrid = styled(Grid)(({ theme }) => ({
+  display: 'flex',
+  gap: 3,
+  alignContent: 'center',
+  borderBottom: 'solid 1px #F4F5F7',
+  paddingTop: theme.spacing(3),
+  paddingBottom: theme.spacing(3),
+}))
+
+type GridRowProps = {
+  children?: ReactNode
+  label: string
+  tooltip?: ReactNode
+}
+
+export const GridRow: FC<GridRowProps> = ({ label, children, tooltip }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <StyledGrid item xs={12} md={5}>
+        {label}:
+        {tooltip && (
+          <Tooltip title={tooltip} placement="top">
+            <InfoIcon htmlColor={COLORS.brandDark} fontSize="small" />
+          </Tooltip>
+        )}
+      </StyledGrid>
+      <StyledGrid item xs={12} md={7}>
+        {children ? <strong>{children}</strong> : t('common.missing')}
+      </StyledGrid>
+    </>
+  )
+}

--- a/src/app/pages/RoflAppDetailPage/MetaDataCard.tsx
+++ b/src/app/pages/RoflAppDetailPage/MetaDataCard.tsx
@@ -1,0 +1,92 @@
+import { FC } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { styled } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import Grid from '@mui/material/Grid'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { RoflAppMetadata } from '../../../oasis-nexus/api'
+import { COLORS } from '../../../styles/theme/colors'
+import { EmptyStateCard } from './EmptyStateCard'
+import { GridRow } from './GridRow'
+
+export const StyledLink = styled(Link)(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  wordBreak: 'break-all',
+  gap: 5,
+}))
+
+type MetaDataCardProps = {
+  isFetched: boolean
+  metadata: RoflAppMetadata | undefined
+}
+
+// Nexus is not parsing ROFL app metadata, but we can expect props with net.oasis.rofl prefix
+// and object to be similar to this:
+// https://github.com/oasisprotocol/cli/blob/bb1a57c13ce7bed635e5ce4306cba8ec33c9a651/build/rofl/manifest.go#L185
+
+export const MetaDataCard: FC<MetaDataCardProps> = ({ isFetched, metadata }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Card sx={{ flex: 1 }}>
+      <CardHeader
+        titleTypographyProps={{ variant: 'h1' }}
+        disableTypography
+        component="h3"
+        title={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <Box sx={{ flex: 1, whiteSpace: 'nowrap' }}>{t('rofl.metadata')}</Box>
+            <Typography component="span" sx={{ fontSize: '12px', color: COLORS.grayDark }}>
+              {t('rofl.metadataInfo')}
+            </Typography>
+          </Box>
+        }
+      />
+      <CardContent>
+        {isFetched && !metadata && <EmptyStateCard />}
+        {metadata && (
+          <>
+            <Grid container spacing={4}>
+              <GridRow label={t('rofl.roflName')}>{metadata['net.oasis.rofl.name']}</GridRow>
+              <GridRow label={t('rofl.description')}>{metadata['net.oasis.rofl.description']}</GridRow>
+              <GridRow label={t('rofl.author')}>{metadata['net.oasis.rofl.author']}</GridRow>
+              <GridRow label={t('rofl.license')}>{metadata['net.oasis.rofl.license']}</GridRow>
+              <GridRow
+                label={t('rofl.repositoryUrl')}
+                tooltip={
+                  <Trans
+                    i18nKey="rofl.verifyCommand"
+                    t={t}
+                    components={{
+                      Command: (
+                        <Typography variant="mono" component="span">
+                          oasis rofl build --verify
+                        </Typography>
+                      ),
+                    }}
+                  />
+                }
+              >
+                {metadata['net.oasis.rofl.repository'] ? (
+                  <StyledLink
+                    href={metadata['net.oasis.rofl.repository']}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {metadata['net.oasis.rofl.repository']} <OpenInNewIcon sx={{ fontSize: 20 }} />
+                  </StyledLink>
+                ) : undefined}
+              </GridRow>
+            </Grid>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/pages/RoflAppDetailPage/PolicyCard.tsx
+++ b/src/app/pages/RoflAppDetailPage/PolicyCard.tsx
@@ -1,0 +1,88 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import Grid from '@mui/material/Grid'
+import Typography from '@mui/material/Typography'
+import { Layer, RoflAppPolicy, useGetRuntimeRoflAppsIdTransactions } from '../../../oasis-nexus/api'
+import { TransactionLink } from '../../components/Transactions/TransactionLink'
+import { EmptyStateCard } from './EmptyStateCard'
+import { GridRow } from './GridRow'
+
+type PolicyCardProps = {
+  id: string
+  isFetched: boolean
+  network: any
+  policy: RoflAppPolicy | undefined
+}
+
+// Nexus is not parsing ROFL app policy, but we can expect object to be similar to this:
+// https://github.com/oasisprotocol/oasis-sdk/blame/main/tests/runtimes/components-ronl/src/lib.rs#L120
+
+// feePolicy can be 1 for InstancePays and 2 for EndorsingNodePays
+// https://github.com/oasisprotocol/oasis-sdk/blob/41480106d585debd33391cb0dfcad32d2f3cdc9d/runtime-sdk/src/modules/rofl/policy.rs#L48
+
+export const PolicyCard: FC<PolicyCardProps> = ({ id, isFetched, network, policy }) => {
+  const { t } = useTranslation()
+  const { data } = useGetRuntimeRoflAppsIdTransactions(network, Layer.sapphire, id, {
+    limit: 1,
+    method: 'rofl.Update' as unknown as string[],
+  })
+  const transaction = data?.data.transactions[0]
+  const feePolicy =
+    policy?.fees === 1 ? t('rofl.instancePays') : policy?.fees === 2 ? t('rofl.endorsingNodePays') : undefined
+
+  return (
+    <Card sx={{ flex: 1 }}>
+      <CardHeader disableTypography component="h3" title={t('rofl.policy')} />
+      <CardContent>
+        {isFetched && !policy && <EmptyStateCard />}
+        {policy && (
+          <>
+            <Grid container spacing={4}>
+              <GridRow label={t('rofl.validity')}>
+                {policy.quotes?.pcs?.tcb_validity_period
+                  ? t('rofl.validityPeriodDays', { value: policy.quotes?.pcs?.tcb_validity_period })
+                  : undefined}
+              </GridRow>
+              <GridRow label={t('rofl.evaluation')}>
+                {policy.quotes?.pcs?.min_tcb_evaluation_data_number ? (
+                  <>
+                    {policy.quotes?.pcs?.min_tcb_evaluation_data_number}
+                    <Typography component="span" sx={{ pl: 2 }}>
+                      {t('rofl.min')}
+                    </Typography>
+                  </>
+                ) : undefined}
+              </GridRow>
+              <GridRow label={t('rofl.feePolicy')}>{feePolicy}</GridRow>
+              <GridRow label={t('rofl.update')}>
+                {transaction ? (
+                  <>
+                    {t('common.formattedDateTime', {
+                      value: transaction.timestamp,
+                      formatParams: {
+                        timestamp: {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        } satisfies Intl.DateTimeFormatOptions,
+                      },
+                    })}
+                    <br />
+                    <TransactionLink
+                      scope={transaction}
+                      alwaysTrim
+                      hash={transaction.eth_hash || transaction.hash}
+                    />
+                  </>
+                ) : undefined}
+              </GridRow>
+            </Grid>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -678,7 +678,16 @@
     "author": "Author",
     "license": "License",
     "repositoryUrl": "Repository URL",
-    "verifyCommand": "Run <Command /> to verify."
+    "verifyCommand": "Run <Command /> to verify.",
+    "policy": "Policy",
+    "instancePays": "Instance pays",
+    "endorsingNodePays": "Endorsing node pays",
+    "validity": "Validity period",
+    "evaluation": "TCB data evaluation",
+    "feePolicy": "Fee policy",
+    "validityPeriodDays": "{{value}} days",
+    "min": "(minimum)",
+    "update": "Update"
   },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -669,7 +669,8 @@
     "nameNotProvided": "Name not provided",
     "nodeId": "Node ID",
     "expirationEpoch": "Expiration epoch",
-    "emptyInstancesList": "No ROFL app instances found."
+    "emptyInstancesList": "No ROFL app instances found.",
+    "noData": "No data available"
   },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -670,7 +670,15 @@
     "nodeId": "Node ID",
     "expirationEpoch": "Expiration epoch",
     "emptyInstancesList": "No ROFL app instances found.",
-    "noData": "No data available"
+    "noData": "No data available",
+    "metadata": "Meta data",
+    "metadataInfo": "This info provided by deployer, Oasis does not verify this information.",
+    "roflName": "ROFL name",
+    "description": "Description",
+    "author": "Author",
+    "license": "License",
+    "repositoryUrl": "Repository URL",
+    "verifyCommand": "Run <Command /> to verify."
   },
   "search": {
     "placeholder": "Address, Block, Contract, Transaction hash, Token name, etc.",


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/explorer/pull/1777

Two cards needed to build ROFL app details page. Both, metadta and policy are are defined as `{ [key: string]: any }`. Created issue to update method filter across app https://github.com/oasisprotocol/explorer/issues/1839

![Screenshot from 2025-03-26 10-14-10](https://github.com/user-attachments/assets/81db3920-eac9-4796-91ba-493d3bea7f06)

