### PR TITLE
Provide missing data to ROFL apps list

### DIFF
--- a/.changelog/1842.trivial.md
+++ b/.changelog/1842.trivial.md
@@ -1,0 +1,1 @@
+Provide missing data to ROFL apps list

--- a/src/app/components/Rofl/RoflAppsList.tsx
+++ b/src/app/components/Rofl/RoflAppsList.tsx
@@ -4,6 +4,7 @@ import { RoflApp } from '../../../oasis-nexus/api'
 import { Table, TableCellAlign, TableColProps } from '..//Table'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { TableHeaderAge } from '../TableHeaderAge'
+import { TableCellAge } from '../TableCellAge'
 import { RoflAppStatusBadge } from './RoflAppStatusBadge'
 import { RoflAppLink } from './RoflAppLink'
 
@@ -24,8 +25,8 @@ export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, paginati
     { key: 'instances', content: t('rofl.instances'), align: TableCellAlign.Right },
     { key: 'created', content: t('rofl.created'), align: TableCellAlign.Right },
     {
-      key: 'lastActvity',
-      content: <TableHeaderAge label={t('rofl.lastActvity')} />,
+      key: 'lastActivity',
+      content: <TableHeaderAge label={t('rofl.lastActivity')} />,
       align: TableCellAlign.Right,
     },
   ]
@@ -73,13 +74,16 @@ export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, paginati
               } satisfies Intl.DateTimeFormatOptions,
             },
           }),
-          key: 'firstActivity',
+          key: 'created',
         },
         {
           align: TableCellAlign.Right,
-          // TODO: Replace with last activity when available
-          content: t('common.missing'),
-          key: 'timestamp',
+          content: app.last_activity ? (
+            <TableCellAge sinceTimestamp={app.last_activity} />
+          ) : (
+            t('common.missing')
+          ),
+          key: 'lastActivity',
         },
       ],
     }

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -51,7 +51,7 @@ export const RoflAppDetailsView: FC<{
           },
         })}
       </dd>
-      <dt>{t('rofl.lastActvity')}</dt>
+      <dt>{t('rofl.lastActivity')}</dt>
       <dd>{t('common.missing')}</dd>
     </StyledDescriptionList>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -660,7 +660,7 @@
     "rakAbbreviation": "RAK",
     "rak": "Runtime Attestation Key",
     "removed": "Removed",
-    "lastActvity": "Last activity",
+    "lastActivity": "Last activity",
     "appId": "App ID",
     "emptyRoflAppsList": "No ROFL apps found.",
     "created": "Date created",


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/explorer/pull/1777. Last missing piece for apps list was added to Nexus lately. 
![Screenshot from 2025-03-27 12-40-42](https://github.com/user-attachments/assets/4e99ce45-f33a-426a-9dbe-c50a05559a7a)
