### PR TITLE
ROFL apps minor UI tweaks

### DIFF
--- a/.changelog/1861.trivial.md
+++ b/.changelog/1861.trivial.md
@@ -1,0 +1,1 @@
+ROFL apps minor UI tweaks

--- a/src/app/components/VerticalList/index.tsx
+++ b/src/app/components/VerticalList/index.tsx
@@ -1,4 +1,3 @@
-import { COLORS } from 'styles/theme/colors'
 import { styled } from '@mui/material/styles'
 import Box from '@mui/material/Box'
 
@@ -6,5 +5,5 @@ export const VerticalList = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: `0 ${theme.spacing(2)}`,
-  backgroundColor: COLORS.brandDark,
+  backgroundColor: theme.palette.background.default,
 }))

--- a/src/app/pages/RoflAppDetailsPage/GridRow.tsx
+++ b/src/app/pages/RoflAppDetailsPage/GridRow.tsx
@@ -26,7 +26,7 @@ export const GridRow: FC<GridRowProps> = ({ label, children, tooltip }) => {
 
   return (
     <>
-      <StyledGrid item xs={12} md={5}>
+      <StyledGrid item xs={4} md={5}>
         {label}:
         {tooltip && (
           <Tooltip title={tooltip} placement="top">
@@ -34,7 +34,7 @@ export const GridRow: FC<GridRowProps> = ({ label, children, tooltip }) => {
           </Tooltip>
         )}
       </StyledGrid>
-      <StyledGrid item xs={12} md={7}>
+      <StyledGrid item xs={8} md={7}>
         {children ? <strong>{children}</strong> : t('common.missing')}
       </StyledGrid>
     </>

--- a/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
+++ b/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
@@ -2,9 +2,17 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatDistanceStrict } from 'date-fns'
 import Box from '@mui/material/Box'
+import { styled } from '@mui/material/styles'
 import { RuntimeTransaction } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { TransactionLink } from '../../components/Transactions/TransactionLink'
+import { useScreenSize } from '../../hooks/useScreensize'
+
+const StyledBox = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 5,
+}))
 
 type LastActivityProps = {
   transaction: RuntimeTransaction | undefined
@@ -13,17 +21,25 @@ type LastActivityProps = {
 
 export const LastActivity: FC<LastActivityProps> = ({ scope, transaction }) => {
   const { t } = useTranslation()
+  const { isTablet } = useScreenSize()
 
   return (
     <>
       {transaction ? (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <TransactionLink scope={scope} hash={transaction.eth_hash ?? transaction.hash} />(
-          {formatDistanceStrict(transaction.timestamp, new Date(), {
-            addSuffix: true,
-          })}
-          )
-        </Box>
+        <StyledBox>
+          <TransactionLink
+            scope={scope}
+            hash={transaction.eth_hash ?? transaction.hash}
+            alwaysTrim={isTablet}
+          />
+          <span>
+            (
+            {formatDistanceStrict(transaction.timestamp, new Date(), {
+              addSuffix: true,
+            })}
+            )
+          </span>
+        </StyledBox>
       ) : (
         t('common.missing')
       )}

--- a/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
+++ b/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { formatDistanceStrict } from 'date-fns'
+import Box from '@mui/material/Box'
+import { RuntimeTransaction } from '../../../oasis-nexus/api'
+import { SearchScope } from '../../../types/searchScope'
+import { TransactionLink } from '../../components/Transactions/TransactionLink'
+
+type LastActivityProps = {
+  transaction: RuntimeTransaction | undefined
+  scope: SearchScope
+}
+
+export const LastActivity: FC<LastActivityProps> = ({ scope, transaction }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {transaction ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+          <TransactionLink scope={scope} hash={transaction.eth_hash ?? transaction.hash} />(
+          {formatDistanceStrict(transaction.timestamp, new Date(), {
+            addSuffix: true,
+          })}
+          )
+        </Box>
+      ) : (
+        t('common.missing')
+      )}
+    </>
+  )
+}

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -143,6 +143,7 @@ export const RoflAppDetailsView: FC<{
             <AccountLink
               scope={{ network: app.network, layer: app.layer }}
               address={app.admin_eth ?? app.admin}
+              alwaysTrimOnTablet
             />
             <CopyToClipboard value={app.admin_eth ?? app.admin} />
           </dd>

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -1,8 +1,6 @@
 import { FC } from 'react'
 import { useHref, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { formatDistanceStrict } from 'date-fns'
-import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
@@ -21,7 +19,6 @@ import { RoflAppStatusBadge } from '../../components/Rofl/RoflAppStatusBadge'
 import { RoflAppLink } from '../../components/Rofl/RoflAppLink'
 import { AccountLink } from '../../components/Account/AccountLink'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
-import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { TeeType } from './TeeType'
 import { Endorsement } from './Endorsement'
 import { Enclaves } from './Enclaves'
@@ -31,6 +28,7 @@ import { instancesContainerId } from '../../utils/tabAnchors'
 import { RoflAppDetailsContext } from '../RoflAppDetailsPage/hooks'
 import { MetaDataCard } from './MetaDataCard'
 import { PolicyCard } from './PolicyCard'
+import { LastActivity } from './LastActivity'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -193,21 +191,10 @@ export const RoflAppDetailsView: FC<{
         <>
           <dt>{t('rofl.lastActivity')}</dt>
           <dd>
-            {app.last_activity_tx ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                <TransactionLink
-                  scope={{ network: app.network, layer: app.layer }}
-                  hash={app.last_activity_tx.eth_hash || app.last_activity_tx.hash}
-                />
-                (
-                {formatDistanceStrict(app.last_activity_tx.timestamp, new Date(), {
-                  addSuffix: true,
-                })}
-                )
-              </Box>
-            ) : (
-              t('common.missing')
-            )}
+            <LastActivity
+              scope={{ network: app.network, layer: app.layer }}
+              transaction={app.last_activity_tx}
+            />
           </dd>
 
           <dt>{t('rofl.activeInstances')}</dt>

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -140,8 +140,11 @@ export const RoflAppDetailsView: FC<{
 
           <dt>{t('rofl.adminAccount')}</dt>
           <dd>
-            <AccountLink scope={{ network: app.network, layer: app.layer }} address={app.admin} />
-            <CopyToClipboard value={app.admin} />
+            <AccountLink
+              scope={{ network: app.network, layer: app.layer }}
+              address={app.admin_eth ?? app.admin}
+            />
+            <CopyToClipboard value={app.admin_eth ?? app.admin} />
           </dd>
 
           <dt>{t('rofl.stakedAmount')}</dt>

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -209,7 +209,7 @@ export const RoflAppDetailsView: FC<{
             )}
           </dd>
 
-          <dt>{t('rofl.instances')}</dt>
+          <dt>{t('rofl.activeInstances')}</dt>
           <dd>{app.num_active_instances.toLocaleString()}</dd>
 
           <dt>{t('rofl.endorsement')}</dt>

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -24,6 +24,7 @@ import { Endorsement } from './Endorsement'
 import { Enclaves } from './Enclaves'
 import { Secrets } from './Secrets'
 import { RouterTabs } from '../../components/RouterTabs'
+import { TableCellAge } from '../../components/TableCellAge'
 import { instancesContainerId } from '../../utils/tabAnchors'
 import { RoflAppDetailsContext } from '../RoflAppDetailsPage/hooks'
 import { MetaDataCard } from './MetaDataCard'
@@ -169,6 +170,8 @@ export const RoflAppDetailsView: FC<{
           <dd>
             <RoflAppLink id={app.id} network={app.network} withSourceIndicator={false} />
           </dd>
+          <dt>{t('rofl.instances')}</dt>
+          <dd>{app.num_active_instances.toLocaleString()}</dd>
           <dt>{t('rofl.created')}</dt>
           <dd>
             {t('common.formattedDateTime', {
@@ -183,7 +186,7 @@ export const RoflAppDetailsView: FC<{
             })}
           </dd>
           <dt>{t('rofl.lastActivity')}</dt>
-          <dd>{t('common.missing')}</dd>
+          <dd>{<TableCellAge sinceTimestamp={app.last_activity} />}</dd>
         </>
       )}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -658,6 +658,7 @@
   },
   "rofl": {
     "active": "Active",
+    "activeInstances": "Active instances",
     "inactive": "Inactive",
     "rakAbbreviation": "RAK",
     "rak": "Runtime Attestation Key",

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -1263,12 +1263,14 @@ Use the `{runtime}/rofl_apps/{id}/instances` endpoint to retrieve all instances.
   active_instances: RoflInstance[];
   /** The application administrator address. */
   admin: string;
+  /** The Ethereum address of the application administrator (only provided if known). */
+  admin_eth?: string;
   /** The date and time when the application was created. */
   date_created: string;
   /** The identifier of the ROFL application. */
   id: string;
   /** The date and time when the application was last active. */
-  last_activity?: string;
+  last_activity: string;
   /** The most recent transaction associated with this ROFL app.
 This field is only present when querying a single ROFL app.
  */


### PR DESCRIPTION
Random UI tweaks:
- use new optional `admin_eth` prop 
- label updates
- trim admin account on mobile
- mobile last activity row fix
- add missing data to vertical list
- fix vertical list background color in testnet
- mobile metadata and policy cards fix