### PR TITLE
Format probable base unit values in events as #.##e18

### DIFF
--- a/.changelog/1885.bugfix.md
+++ b/.changelog/1885.bugfix.md
@@ -1,0 +1,1 @@
+Format probable base unit values in events as #.##e18

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -144,7 +144,7 @@ const EvmEventParamData: FC<{
           <Tooltip
             arrow
             placement="top"
-            title={param.value_raw}
+            title={t('common.valueLong', getPreciseNumberFormat(param.value_raw as string))}
             enterDelay={tooltipDelay}
             enterNextDelay={tooltipDelay}
           >
@@ -178,7 +178,7 @@ const EvmEventParamData: FC<{
           <Tooltip
             arrow
             placement="top"
-            title={param.value as string}
+            title={t('common.valueLong', getPreciseNumberFormat(param.value as string))}
             enterDelay={tooltipDelay}
             enterNextDelay={tooltipDelay}
           >

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -34,6 +34,7 @@ import { TransactionLink } from '../Transactions/TransactionLink'
 import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
 import { PlaceholderLabel } from '../../utils/PlaceholderLabel'
+import { fromBaseUnits } from '../../utils/number-utils'
 
 const getRuntimeEventMethodLabel = (t: TFunction, method: RuntimeEventType | undefined) => {
   switch (method) {
@@ -137,7 +138,7 @@ const EvmEventParamData: FC<{
       return address ? (
         <AccountLink address={address} scope={scope} alwaysTrimOnTablet={alwaysTrimOnTable} />
       ) : null
-    case 'uint256':
+    case 'uint256': {
       if (param.evm_token?.type === 'ERC20') {
         return (
           <Tooltip
@@ -168,6 +169,27 @@ const EvmEventParamData: FC<{
           />
         )
       }
+
+      const commonEvmContractDecimals = 18
+      const maybeParsedBaseUnits = fromBaseUnits(param.value as string, commonEvmContractDecimals)
+      if (!maybeParsedBaseUnits.startsWith('0.0000')) {
+        // Don't parse suspiciously low values.
+        return (
+          <Tooltip
+            arrow
+            placement="top"
+            title={param.value as string}
+            enterDelay={tooltipDelay}
+            enterNextDelay={tooltipDelay}
+          >
+            <span>
+              {t('common.valueLong', getPreciseNumberFormat(maybeParsedBaseUnits))}
+              {`e${commonEvmContractDecimals}`}
+            </span>
+          </Tooltip>
+        )
+      }
+
       return (
         <span>
           {t('common.valueLong', {
@@ -175,6 +197,7 @@ const EvmEventParamData: FC<{
           })}
         </span>
       )
+    }
     default:
       return <span>{JSON.stringify(param.value, null, '  ')}</span>
   }


### PR DESCRIPTION
Related https://github.com/oasisprotocol/explorer/issues/1843

https://explorer.dev.oasis.io/mainnet/sapphire/tx/0x97b1dadd5e467779d45c263026bf51a79a4cb0a0f29f6ae3e3d6e3eb232e8e84
Before | After
![image](https://github.com/user-attachments/assets/ec932c2d-53a0-4816-83fe-13cb4796631d)
