### PR TITLE
Display contract Source Code and Contract Metadata fields

### DIFF
--- a/src/app/components/CodeDisplay/index.tsx
+++ b/src/app/components/CodeDisplay/index.tsx
@@ -60,7 +60,7 @@ const CodeDisplay: FC<CodeDisplayProps> = ({
           />
         )}
       </Box>
-      <ScrollableDataDisplay data={code} />
+      <ScrollableDataDisplay data={<StyledPre>{code}</StyledPre>} />
     </Box>
   )
 }
@@ -71,13 +71,22 @@ type RawDataDisplayProps = {
   extraTopPadding?: boolean
 }
 
-export const RawDataDisplay: FC<RawDataDisplayProps> = ({ data, label, extraTopPadding }) => {
-  const code = data === undefined ? undefined : base64ToHex(data)
-  if (!code) {
-    return null
-  }
+export const RawDataDisplay: FC<RawDataDisplayProps & { decodeBase64?: boolean }> = ({
+  data,
+  label,
+  decodeBase64 = false,
+}) => {
+  if (!data) return null
+
+  const code = decodeBase64 ? base64ToHex(data) : data
+
   return (
-    <CodeDisplay code={code} copyToClipboardValue={code} label={label} extraTopPadding={extraTopPadding} />
+    <CodeDisplay
+      code={<StyledPre>{code}</StyledPre>}
+      copyToClipboardValue={code}
+      label={label}
+      extraTopPadding={true}
+    />
   )
 }
 

--- a/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
@@ -21,11 +21,27 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
       {contract && (contract.creation_bytecode || contract.runtime_bytecode) && (
         <CardContent>
           <LinkableDiv id={codeContainerId}>
-            <RawDataDisplay data={contract.creation_bytecode} label={t('contract.creationByteCode')} />
+            {contract.verification?.source_files?.map((file, index) => (
+              <RawDataDisplay key={index} data={file.content} label={file.name} />
+            ))}
+
+            {contract.verification?.compilation_metadata && (
+              <RawDataDisplay
+                data={JSON.stringify(contract.verification.compilation_metadata, null, 2)}
+                label={t('contract.contractMetadata')}
+              />
+            )}
+
+            <RawDataDisplay
+              data={contract.creation_bytecode}
+              label={t('contract.creationByteCode')}
+              decodeBase64
+            />
+
             <RawDataDisplay
               data={contract.runtime_bytecode}
               label={t('contract.runtimeByteCode')}
-              extraTopPadding={!!contract.creation_bytecode}
+              decodeBase64
             />
           </LinkableDiv>
         </CardContent>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -165,6 +165,7 @@
   },
   "contract": {
     "code": "Code",
+    "contractMetadata": "Contract Metadata",
     "copyButton": "Copy {{subject}}",
     "creationByteCode": "Creation ByteCode",
     "creator": "Creator",


### PR DESCRIPTION
Add RawDataDisplay fields to display Source Code and Contract Metadata in 'Code' tab for verified contracts as displayed in Sourcify.
Issue: [#1881](https://github.com/oasisprotocol/explorer/issues/1881#issue-2982352948)

Before:
<img width="1784" alt="Screenshot 2025-04-10 at 18 30 56" src="https://github.com/user-attachments/assets/d37d630a-fbc6-42b6-bbe3-0613fb57a3f4" />

After:
<img width="1784" alt="Screenshot 2025-04-10 at 18 31 50" src="https://github.com/user-attachments/assets/4083a9da-9ba1-4bc2-bf34-88efd7446ebf" />
<img width="1795" alt="Screenshot 2025-04-10 at 18 32 08" src="https://github.com/user-attachments/assets/7e71474c-f329-4f73-880c-a174aeffe124" />
<img width="1785" alt="Screenshot 2025-04-10 at 18 32 25" src="https://github.com/user-attachments/assets/7a59bfeb-a218-48eb-9205-2d1e8709a3f2" />
<img width="1784" alt="Screenshot 2025-04-10 at 18 32 54" src="https://github.com/user-attachments/assets/19948cc6-a35a-4371-b453-f96c624a7629" />
<img width="1782" alt="Screenshot 2025-04-10 at 18 33 13" src="https://github.com/user-attachments/assets/6bd3ef77-a4f9-4555-96a5-046083652fc2" />

