### PR TITLE
Display number of shares in Sapphire undelegate transactions

### DIFF
--- a/.changelog/1892.bugfix.md
+++ b/.changelog/1892.bugfix.md
@@ -1,0 +1,1 @@
+Display number of shares in Sapphire undelegate transactions

--- a/src/app/components/Transactions/RuntimeTransactions.tsx
+++ b/src/app/components/Transactions/RuntimeTransactions.tsx
@@ -157,7 +157,16 @@ export const RuntimeTransactions: FC<TransactionsProps> = ({
               },
               {
                 align: TableCellAlign.Right,
-                content: <RoundedBalance value={transaction.amount} ticker={transaction.amount_symbol} />,
+                content:
+                  transaction.amount && transaction.amount !== '0' ? (
+                    <RoundedBalance value={transaction.amount} ticker={transaction.amount_symbol} />
+                  ) : (
+                    <RoundedBalance
+                      compactLargeNumbers
+                      value={transaction?.body?.shares}
+                      ticker={t('common.shares')}
+                    />
+                  ),
                 key: 'value',
               },
               {

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -33,6 +33,7 @@ import { MultipleTransactionsWarning } from '../../components/Transactions/Multi
 import { JsonCodeDisplay } from '../..//components/CodeDisplay'
 import { isRoflTransaction } from '../../utils/transaction'
 import Box from '@mui/material/Box'
+import { RoundedBalance } from 'app/components/RoundedBalance'
 
 export const RuntimeTransactionDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -209,6 +210,19 @@ export const RuntimeTransactionDetailView: FC<{
                 })
               : t('common.missing')}
           </dd>
+
+          {transaction?.body?.shares && (
+            <>
+              <dt>{t('common.shares')}</dt>
+              <dd>
+                <RoundedBalance
+                  compactLargeNumbers
+                  value={transaction?.body?.shares}
+                  ticker={t('common.shares')}
+                />
+              </dd>
+            </>
+          )}
 
           {showFiatValues &&
             transaction.amount !== undefined &&


### PR DESCRIPTION
Show undelegated shares on Sapphire instead of Amount field value.

Fixes: [#1599](https://github.com/oasisprotocol/explorer/issues/1599)

https://explorer.dev.oasis.io/testnet/sapphire/tx/6f1b5e74c32422f3295a54b0a56812d49aefe9901db9a75c19c039228164170d
https://explorer.dev.oasis.io/testnet/sapphire/block/8594080



Before:
<img width="377" alt="Screenshot 2025-04-11 at 17 00 19" src="https://github.com/user-attachments/assets/4ebe1c0a-1879-4eb7-90c2-de80be0d08a2" />
<img width="373" alt="Screenshot 2025-04-11 at 17 00 33" src="https://github.com/user-attachments/assets/8428dfa8-fe26-42eb-a29d-61650399eccd" />

After:
<img width="528" alt="Screenshot 2025-04-11 at 17 01 29" src="https://github.com/user-attachments/assets/5048e3de-a0bf-4236-98fa-389994ffbc2b" />
<img width="516" alt="Screenshot 2025-04-11 at 17 02 55" src="https://github.com/user-attachments/assets/dd576013-6f57-4b4e-a33a-26eeeeab0ee3" />
