### PR TITLE
Get pontusX account metadata by oasis address instead of hex address

### DIFF
--- a/.changelog/1903.trivial.md
+++ b/.changelog/1903.trivial.md
@@ -1,0 +1,1 @@
+Get pontusX account metadata by oasis address instead of hex address

--- a/src/app/data/named-accounts.ts
+++ b/src/app/data/named-accounts.ts
@@ -1,10 +1,10 @@
 import { Network } from '../../types/network'
-import { Account, Layer, Runtime, RuntimeAccount } from '../../oasis-nexus/api'
+import { Account, Address, Layer, Runtime, RuntimeAccount } from '../../oasis-nexus/api'
 
 export type AccountMetadataSource = 'OasisRegistry' | 'DeltaDaoRegistry' | 'SelfProfessed'
 
 export type AccountMetadata = {
-  address: string
+  address: Address
   name?: string
   description?: string
   source: AccountMetadataSource
@@ -16,7 +16,7 @@ export type AccountMetadataInfo = {
   isError: boolean
 }
 
-export type AccountMap = Map<string, AccountMetadata>
+export type AccountMap = Map<Address, AccountMetadata>
 
 export type AccountData = {
   map: AccountMap
@@ -26,19 +26,19 @@ export type AccountData = {
 export type AccountNameSearchMatch = {
   network: Network
   layer: Layer
-  address: string
+  address: Address
 }
 
 export type AccountNameSearchRuntimeMatch = {
   network: Network
   layer: Runtime
-  address: string
+  address: Address
 }
 
 export type AccountNameSearchConsensusMatch = {
   network: Network
   layer: typeof Layer.consensus
-  address: string
+  address: Address
 }
 
 export type AccountNameSearchResults = {

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -18,6 +18,7 @@ import {
 } from './named-accounts'
 import { hasTextMatch } from '../components/HighlightedText/text-matching'
 import * as externalLinks from '../utils/externalLinks'
+import { getOasisAddress } from '../utils/helpers'
 
 const dataSources: Record<Network, Partial<Record<Layer, string>>> = {
   [Network.mainnet]: {
@@ -51,7 +52,7 @@ const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise
   Array.from(response.data).forEach((entry: any) => {
     const metadata: AccountMetadata = {
       source: 'OasisRegistry',
-      address: entry.Address,
+      address: getOasisAddress(entry.Address),
       name: entry.Name,
       description: entry.Description,
     }

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -79,7 +79,7 @@ const useOasisAccountsMetadata = (
 export const useOasisAccountMetadata = (
   network: Network,
   layer: Layer,
-  address: string,
+  oasisAddress: string,
   queryOptions: UseQueryOptions<AccountData, unknown, AccountData, string[]>,
 ): AccountMetadataInfo => {
   const { isLoading, isError, error, data: allData } = useOasisAccountsMetadata(network, layer, queryOptions)
@@ -87,7 +87,7 @@ export const useOasisAccountMetadata = (
     console.log('Failed to load Oasis account metadata', error)
   }
   return {
-    metadata: allData?.map.get(address),
+    metadata: allData?.map.get(oasisAddress),
     isLoading,
     isError,
   }

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -30,7 +30,7 @@ const getPontusXAccountsMetadata = async (): Promise<PontusXAccountsMetadata> =>
       address: getOasisAddress(evmAddress),
       name: name as string,
     }
-    map.set(evmAddress.toLowerCase(), account)
+    map.set(account.address, account)
     list.push(account)
   })
   return {
@@ -49,7 +49,7 @@ export const usePontusXAccountsMetadata = (
 }
 
 export const usePontusXAccountMetadata = (
-  address: string,
+  oasisAddress: string,
   queryOptions: UseQueryOptions<PontusXAccountsMetadata, unknown, PontusXAccountsMetadata, string[]>,
 ): AccountMetadataInfo => {
   const { isLoading, isError, error, data: allData } = usePontusXAccountsMetadata(queryOptions)
@@ -57,7 +57,7 @@ export const usePontusXAccountMetadata = (
     console.log('Failed to load Pontus-X account names', error)
   }
   return {
-    metadata: allData?.map.get(address.toLowerCase()),
+    metadata: allData?.map.get(oasisAddress),
     isLoading,
     isError,
   }

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -18,7 +18,7 @@ import { useTokenInfo } from '../pages/TokenDashboardPage/hook'
 export const useAccountMetadata = (scope: SearchScope, address: string): AccountMetadataInfo => {
   // Look up metadata specified by us
   const isPontusX = scope.layer === Layer.pontusxtest || scope.layer === Layer.pontusxdev
-  const pontusXData = usePontusXAccountMetadata(address, {
+  const pontusXData = usePontusXAccountMetadata(getOasisAddress(address), {
     enabled: isPontusX,
     useErrorBoundary: false,
   })


### PR DESCRIPTION
- Unifies how we get account metadata for other layers
- Fixes recognizing unused named accounts opened by oasis1 address

These are the same account:
https://explorer.dev.oasis.io/testnet/pontusxtest/address/0x628677D9A9d93a913182fa04893Da0ce4E6570Ee
https://explorer.dev.oasis.io/testnet/pontusxtest/address/oasis1qz5ejnpmy46zt6f8tvfqmcspawg26mphfujj3gjk
but only hex one was recognized as "deltaDAO AG"

related to https://github.com/oasisprotocol/explorer/pull/1685
and https://github.com/oasisprotocol/explorer/pull/1398#discussion_r1604289575