### PR TITLE
Fix HighlightedText gaps in search results (parent style `gap: 3`)

### DIFF
--- a/.changelog/1908.bugfix.md
+++ b/.changelog/1908.bugfix.md
@@ -1,0 +1,1 @@
+Fix HighlightedText gaps in search results (parent style `gap: 3`)

--- a/src/app/components/HighlightedText/index.tsx
+++ b/src/app/components/HighlightedText/index.tsx
@@ -77,19 +77,19 @@ export const HighlightedText: FC<HighlightedTextProps> = ({
   const task = part ?? findTextMatch(text, [pattern], findOptions)
 
   if (text === undefined) return undefined // Nothing to display
-  if (task === NO_MATCH) return text // We don't have to highlight anything
+  if (task === NO_MATCH) return <span>{text}</span> // We don't have to highlight anything
 
   const beginning = text.substring(0, task.startPos)
   const focus = text.substring(task.startPos, task.endPos)
   const end = text.substring(task.endPos)
 
   return (
-    <>
+    <span>
       {beginning}
       <Box component="mark" sx={sx}>
         {focus}
       </Box>
       {end}
-    </>
+    </span>
   )
 }


### PR DESCRIPTION
https://explorer.dev.oasis.io/mainnet/sapphire/search?q=ose
Before, After
![Screenshot from 2025-04-19 01-44-35](https://github.com/user-attachments/assets/20da45d7-2590-4f48-a8d8-595aa134cb3a)
