### PR TITLE
Display token icons and origins from metadata

### DIFF
--- a/.changelog/1909.feature.md
+++ b/.changelog/1909.feature.md
@@ -1,0 +1,1 @@
+Display token icons and origins from metadata

--- a/src/app/components/Account/RuntimeAccountDetailsView.tsx
+++ b/src/app/components/Account/RuntimeAccountDetailsView.tsx
@@ -14,7 +14,7 @@ import { DashboardLink } from '../../pages/ParatimeDashboardPage/DashboardLink'
 import { AllTokenPrices } from '../../../coin-gecko/api'
 import { ContractCreatorInfo } from './ContractCreatorInfo'
 import { VerificationIcon } from '../ContractVerificationIcon'
-import { TokenLink } from '../Tokens/TokenLink'
+import { TokenLinkWithIcon } from '../Tokens/TokenLinkWithIcon'
 import { AccountAvatar } from '../AccountAvatar'
 import { RuntimeBalanceDisplay } from '../Balance/RuntimeBalanceDisplay'
 import { calculateFiatValue } from '../Balance/hooks'
@@ -89,7 +89,7 @@ export const RuntimeAccountDetailsView: FC<RuntimeAccountDetailsViewProps> = ({
         <>
           <dt>{t('common.token')}</dt>
           <dd>
-            <TokenLink
+            <TokenLinkWithIcon
               scope={account}
               address={token.eth_contract_addr || token.contract_addr}
               name={token.name}

--- a/src/app/components/AccountAvatar/InitialsAvatar.tsx
+++ b/src/app/components/AccountAvatar/InitialsAvatar.tsx
@@ -1,0 +1,24 @@
+import { COLORS } from '../../../styles/theme/colors'
+
+function extractTwoChars(strRaw: string) {
+  const str = strRaw.trim().replace(/[^A-Za-z0-9 ]/g, '')
+  if (str.length < 2) return str || '  '
+  const first = str[0]
+  const rest = str.slice(1)
+  const lastDigitInSequence = rest.match(/\d+/)?.[0].at(-1)
+  const firstCharAfterSpace = rest.match(/\s+./)?.[0].at(-1)
+  const firstCapitalized = rest.match(/[A-Z]/)?.[0]
+  const second = lastDigitInSequence || firstCharAfterSpace || firstCapitalized || rest[0]
+  return first + second
+}
+
+export const InitialsAvatar = ({ name, size }: { name: string; size: number }) => {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100">
+      <rect width="100" height="100" rx="50" fill={COLORS.brandDark} />
+      <text fontSize="40" x="50" y="50" dominantBaseline="central" textAnchor="middle" fill={COLORS.white}>
+        {extractTwoChars(name)}
+      </text>
+    </svg>
+  )
+}

--- a/src/app/components/Tokens/TokenDetails.tsx
+++ b/src/app/components/Tokens/TokenDetails.tsx
@@ -4,7 +4,7 @@ import { TextSkeleton } from '../Skeleton'
 import { StyledDescriptionList } from '../StyledDescriptionList'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { useTranslation } from 'react-i18next'
-import { TokenLink } from './TokenLink'
+import { TokenLinkWithIcon } from './TokenLinkWithIcon'
 import { CopyToClipboard } from '../CopyToClipboard'
 import { AccountLink } from '../Account/AccountLink'
 import { DashboardLink } from '../../pages/ParatimeDashboardPage/DashboardLink'
@@ -40,7 +40,7 @@ export const TokenDetails: FC<{
       )}
       <dt>{t('common.name')}</dt>
       <dd>
-        <TokenLink
+        <TokenLinkWithIcon
           scope={token}
           address={token.eth_contract_addr ?? token.contract_addr}
           name={token.name}

--- a/src/app/components/Tokens/TokenLinkWithIcon.tsx
+++ b/src/app/components/Tokens/TokenLinkWithIcon.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+
+import { SearchScope } from '../../../types/searchScope'
+import { TokenLink } from './TokenLink'
+import { useAccountMetadata } from '../../hooks/useAccountMetadata'
+import Box from '@mui/material/Box'
+import { COLORS } from '../../../styles/theme/colors'
+
+export const TokenLinkWithIcon: FC<{
+  scope: SearchScope
+  address: string
+  name: string | undefined
+  highlightedPart?: string | undefined
+}> = ({ scope, address, name, highlightedPart }) => {
+  const { metadata } = useAccountMetadata(scope, address)
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      {metadata?.icon && <img src={metadata.icon} alt="" width={28} />}
+
+      <span>
+        <TokenLink
+          scope={scope}
+          address={address}
+          name={metadata?.name || name}
+          highlightedPart={highlightedPart}
+        />
+        <Box component="span" sx={{ color: COLORS.grayMedium }}>
+          {metadata?.origin && ` (${metadata.origin})`}
+        </Box>
+      </span>
+    </Box>
+  )
+}

--- a/src/app/components/Tokens/TokenLinkWithIcon.tsx
+++ b/src/app/components/Tokens/TokenLinkWithIcon.tsx
@@ -5,6 +5,7 @@ import { TokenLink } from './TokenLink'
 import { useAccountMetadata } from '../../hooks/useAccountMetadata'
 import Box from '@mui/material/Box'
 import { COLORS } from '../../../styles/theme/colors'
+import { InitialsAvatar } from '../AccountAvatar/InitialsAvatar'
 
 export const TokenLinkWithIcon: FC<{
   scope: SearchScope
@@ -15,7 +16,11 @@ export const TokenLinkWithIcon: FC<{
   const { metadata } = useAccountMetadata(scope, address)
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-      {metadata?.icon && <img src={metadata.icon} alt="" width={28} />}
+      {metadata?.icon ? (
+        <img src={metadata.icon} alt="" width={28} />
+      ) : (
+        <InitialsAvatar name={metadata?.name || name || address.slice(2, 4)} size={28} />
+      )}
 
       <span>
         <TokenLink

--- a/src/app/components/Tokens/TokenList.tsx
+++ b/src/app/components/Tokens/TokenList.tsx
@@ -3,7 +3,7 @@ import { EvmToken, EvmTokenType } from '../../../oasis-nexus/api'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { AccountLink } from '../Account/AccountLink'
-import { TokenLink } from './TokenLink'
+import { TokenLinkWithIcon } from './TokenLinkWithIcon'
 import { CopyToClipboard } from '../CopyToClipboard'
 import { VerificationIcon, verificationIconBoxHeight } from '../ContractVerificationIcon'
 import Box from '@mui/material/Box'
@@ -88,7 +88,7 @@ export const TokenList = (props: TokensProps) => {
         },
         {
           content: (
-            <TokenLink
+            <TokenLinkWithIcon
               scope={token}
               address={token.eth_contract_addr ?? token.contract_addr}
               name={token.name}

--- a/src/app/data/named-accounts.ts
+++ b/src/app/data/named-accounts.ts
@@ -7,7 +7,9 @@ export type AccountMetadata = {
   address: Address
   name?: string
   description?: string
-  source: AccountMetadataSource
+  icon?: string // Sanitized URL
+  origin?: string // Origin of this token/account
+  source: AccountMetadataSource // Origin of metadata. TODO: rename to e.g. metadata_source
 }
 
 export type AccountMetadataInfo = {

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -19,6 +19,7 @@ import {
 import { hasTextMatch } from '../components/HighlightedText/text-matching'
 import * as externalLinks from '../utils/externalLinks'
 import { getOasisAddress } from '../utils/helpers'
+import { hasValidProtocol } from '../utils/url'
 
 const dataSources: Record<Network, Partial<Record<Layer, string>>> = {
   [Network.mainnet]: {
@@ -55,6 +56,8 @@ const getOasisAccountsMetadata = async (network: Network, layer: Layer): Promise
       address: getOasisAddress(entry.Address),
       name: entry.Name,
       description: entry.Description,
+      origin: entry.Origin,
+      icon: entry.Icon && hasValidProtocol(entry.Icon) ? entry.Icon : undefined,
     }
     // Register the metadata in its native form
     list.push(metadata)

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -11,7 +11,7 @@ import { VerificationIcon } from '../../components/ContractVerificationIcon'
 import CardContent from '@mui/material/CardContent'
 import { TokenTypeTag } from '../../components/Tokens/TokenList'
 import { SearchScope } from '../../../types/searchScope'
-import { TokenLink } from '../../components/Tokens/TokenLink'
+import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 import { EvmNft } from 'oasis-nexus/api'
 import Box from '@mui/material/Box'
 
@@ -66,7 +66,7 @@ export const InstanceDetailsCard: FC<InstanceDetailsCardProps> = ({
             <dd>{nft.id}</dd>
             <dt>{t('common.collection')} </dt>
             <dd>
-              <TokenLink scope={scope} address={contractAddress} name={token?.name} />
+              <TokenLinkWithIcon scope={scope} address={contractAddress} name={token?.name} />
             </dd>
             <dt>{t('common.type')} </dt>
             <dd>

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTokensCard.tsx
@@ -11,7 +11,7 @@ import { EvmTokenType, Layer } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
-import { TokenLink } from '../../components/Tokens/TokenLink'
+import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 import { AccountLink } from '../../components/Account/AccountLink'
 import {
   getTokenTypePluralDescription,
@@ -69,7 +69,7 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, account, 
     data: [
       {
         content: (
-          <TokenLink
+          <TokenLinkWithIcon
             scope={scope}
             address={item.token_contract_addr_eth ?? item.token_contract_addr}
             name={item.token_name || t('common.missing')}

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -106,6 +106,14 @@ export const SearchResultsList: FC<{
         />
 
         <ResultsGroupByType
+          title={t('search.results.tokens.title')}
+          results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
+          resultComponent={item => <TokenDetails token={item} highlightedPartOfName={searchTerm} showLayer />}
+          link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
+          linkLabel={t('search.results.tokens.viewLink')}
+        />
+
+        <ResultsGroupByType
           title={t('search.results.accounts.title')}
           results={searchResults.filter((item): item is AccountResult => item.resultType === 'account')}
           resultComponent={item =>
@@ -157,14 +165,6 @@ export const SearchResultsList: FC<{
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}
-        />
-
-        <ResultsGroupByType
-          title={t('search.results.tokens.title')}
-          results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightedPartOfName={searchTerm} showLayer />}
-          link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
-          linkLabel={t('search.results.tokens.viewLink')}
         />
 
         <ResultsGroupByType

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -411,6 +411,7 @@ export const useSearch = (currentScope: SearchScope | undefined, q: SearchParams
     : [
         ...blocks.map((block): BlockResult => ({ ...block, resultType: 'block' })),
         ...transactions.map((tx): TransactionResult => ({ ...tx, resultType: 'transaction' })),
+        ...tokens.map((token): TokenResult => ({ ...token, resultType: 'token' })),
         ...accounts
           .filter(account => !(account as RuntimeAccount).evm_contract)
           .map((account): AccountResult => ({ ...account, resultType: 'account' })),
@@ -419,7 +420,6 @@ export const useSearch = (currentScope: SearchScope | undefined, q: SearchParams
           .filter(account => account.evm_contract)
           .map((account): ContractResult => ({ ...account, resultType: 'contract' })),
         ...roflApps.map((roflApp): RoflAppResult => ({ ...roflApp, resultType: 'roflApp' })),
-        ...tokens.map((token): TokenResult => ({ ...token, resultType: 'token' })),
         ...proposals.map((proposal): ProposalResult => ({ ...proposal, resultType: 'proposal' })),
       ]
   return {

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -17,12 +17,12 @@ import { TokenTypeTag } from '../../components/Tokens/TokenList'
 import { SearchScope } from '../../../types/searchScope'
 import { RouteUtils } from '../../utils/route-utils'
 import { RoundedBalance } from 'app/components/RoundedBalance'
-import { HighlightedText } from '../../components/HighlightedText'
 import { RuntimeBalanceDisplay } from '../../components/Balance/RuntimeBalanceDisplay'
 import { extractMinimalProxyERC1167 } from '../../components/ContractVerificationIcon/extractMinimalProxyERC1167'
 import { AbiPlaygroundLink } from '../../components/ContractVerificationIcon/AbiPlaygroundLink'
 import Box from '@mui/material/Box'
 import { holdersContainerId, tokenTransfersContainerId } from '../../utils/tabAnchors'
+import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 
 export const TokenDetailsCard: FC<{ scope: SearchScope; address: string; searchTerm: string }> = ({
   scope,
@@ -44,7 +44,12 @@ export const TokenDetailsCard: FC<{ scope: SearchScope; address: string; searchT
           <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
             <dt>{t('common.token')}</dt>
             <dd>
-              <HighlightedText text={token.name} pattern={searchTerm} />
+              <TokenLinkWithIcon
+                scope={account}
+                address={token.eth_contract_addr || token.contract_addr}
+                name={token.name}
+                highlightedPart={searchTerm}
+              />
             </dd>
 
             {isMobile && (


### PR DESCRIPTION
Part of https://github.com/oasisprotocol/explorer/issues/1769
Metadata added in https://github.com/oasisprotocol/nexus/pull/985
Icons added in https://github.com/oasisprotocol/assets/pull/7

Someone else should fill out metadata+icons for more tokens