### PR TITLE
Fix LinkableDiv getting covered by sticky header

### DIFF
--- a/.changelog/1953.bugfix.md
+++ b/.changelog/1953.bugfix.md
@@ -1,0 +1,1 @@
+Fix LinkableDiv getting covered by sticky header

--- a/src/app/components/PageLayout/LinkableDiv.tsx
+++ b/src/app/components/PageLayout/LinkableDiv.tsx
@@ -1,3 +1,4 @@
+import GlobalStyles from '@mui/material/GlobalStyles'
 import { FC, useEffect, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
@@ -25,5 +26,11 @@ export const LinkableDiv: FC<JSX.IntrinsicElements['div'] & { id: string }> = pr
     }
   }, [id, hash, element])
 
-  return <div {...props} ref={divRef} />
+  return (
+    <>
+      {/* Don't scroll the target underneath sticky Header */}
+      <GlobalStyles styles="html { scroll-padding-top: 180px; }" />
+      <div {...props} ref={divRef} />
+    </>
+  )
 }


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/explorer/issues/1950