### PR TITLE
Speedup CI: use playwright container instead of installing system deps

### DIFF
--- a/.changelog/1956.internal.md
+++ b/.changelog/1956.internal.md
@@ -1,0 +1,1 @@
+Speedup CI: use playwright container instead of installing system deps

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -16,6 +16,9 @@ jobs:
     # NOTE: This name appears in GitHub's Checks API.
     name: playwright
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.51.0-noble
+      options: --user 1001
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,9 +33,6 @@ jobs:
         run: yarn start &
       - name: Install playwright
         run: yarn install --frozen-lockfile
-        working-directory: playwright
-      - name: Install playwright dependencies
-        run: yarn playwright install --with-deps
         working-directory: playwright
       - name: Run playwright tests
         run: yarn test

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -29,11 +29,9 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Run dev server
-        run: yarn start &
       - name: Install playwright
         run: yarn install --frozen-lockfile
         working-directory: playwright
-      - name: Run playwright tests
+      - name: Run playwright tests (auto-starts dev server)
         run: yarn test
         working-directory: playwright

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  webServer: {
+    url: 'http://localhost:1234',
+    command: 'yarn --cwd ../ run start',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+})


### PR DESCRIPTION
Same as https://github.com/oasisprotocol/wallet/pull/2166/commits/eb3bb1d55ee313af4ece199170a9cad3b47488b0

Before:
 2m 21s
 2m 31s
 2m 34s
 4m 0s
 3m 19s

After:
 2m 51s
 2m 7s
 3m 13s
 2m 1s