### PR TITLE
Fix regressions in address display

### DIFF
--- a/.changelog/1959.bugfix.md
+++ b/.changelog/1959.bugfix.md
@@ -1,0 +1,1 @@
+Fix regressions in address display

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -183,7 +183,16 @@ export const AccountLink: FC<Props> = ({
     <WithTypographyAndLink scope={scope} address={address} mobile labelOnly={labelOnly}>
       <>
         {showAccountName && (
-          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+          <Box
+            component="span"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 3,
+              maxWidth: '100%',
+              overflowX: 'hidden',
+            }}
+          >
             <AccountMetadataSourceIndicator source={accountMetadata.source} />
             <AdaptiveHighlightedText
               text={accountName}

--- a/src/app/components/HighlightingContext/WithHighlighting.tsx
+++ b/src/app/components/HighlightingContext/WithHighlighting.tsx
@@ -16,6 +16,8 @@ export const WithHighlighting: FC<{ children: ReactNode; address: string }> = ({
         alignItems: 'center',
         verticalAlign: 'middle',
         padding: '2px 4px 2px 4px',
+        maxWidth: '100%',
+        overflowX: 'hidden',
         ...(isHighlighted
           ? {
               background: COLORS.warningLight,

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -179,7 +179,15 @@ export const RuntimeTransactionDetailView: FC<{
                 }}
               >
                 {(transaction?.signers ?? []).map((signer, index) => (
-                  <Box key={`signer-${index}-link`} sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                  <Box
+                    key={`signer-${index}-link`}
+                    sx={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      maxWidth: '100%',
+                      overflowX: 'hidden',
+                    }}
+                  >
                     <AccountLink
                       scope={transaction}
                       address={(signer.address_eth ?? signer.address) as string}


### PR DESCRIPTION
The mechanism introduced in #1396 was partially broken
in #1773 and #1776.  

(Kudos to @lukaw3d for investigating the history if this.)

This change fixes the regression by adding the missing `max-width: 100%` to the divs wrapping the addresses, which are necessary for the sizing to work.

|Before | After |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/23b5da23-9a9f-4f35-a358-58ce4142a18b) | ![image](https://github.com/user-attachments/assets/c9408440-169d-460b-b961-1c26844e72e1) |
|  ![image](https://github.com/user-attachments/assets/bf8af0be-daf0-4b4d-81f4-f7a42b7b721e) | ![image](https://github.com/user-attachments/assets/9db67689-3eea-4dbf-aeb0-c85e5a131d4d) | 


 

Fixes #1943 and #1957
