### PR TITLE
ROFL app details page fixes

### DIFF
--- a/.changelog/1960.trivial.md
+++ b/.changelog/1960.trivial.md
@@ -1,0 +1,1 @@
+Small tweaks on ROFL add detail pages

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -1,10 +1,10 @@
-import { FC } from 'react'
+import { FC, PropsWithChildren } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
 import MuiLink from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
-import { trimLongString } from '../..//utils/trimLongString'
+import { trimLongString } from '../../utils/trimLongString'
 import { HighlightedText } from '../HighlightedText'
 import Box from '@mui/material/Box'
 import { AccountMetadataSourceIndicator } from '../Account/AccountMetadataSourceIndicator'
@@ -19,6 +19,7 @@ type LinkProps = {
   highlightedPartOfName?: string
   to: string
   withSourceIndicator?: boolean
+  labelOnly?: boolean
 }
 
 export const Link: FC<LinkProps> = ({
@@ -28,6 +29,7 @@ export const Link: FC<LinkProps> = ({
   highlightedPartOfName,
   to,
   withSourceIndicator = true,
+  labelOnly,
 }) => {
   const { isTablet } = useScreenSize()
   const hasName = name?.toLowerCase() !== address.toLowerCase()
@@ -50,9 +52,19 @@ export const Link: FC<LinkProps> = ({
     <MaybeWithTooltip title={tooltipTitle}>
       <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
         {hasName && withSourceIndicator && <AccountMetadataSourceIndicator source={'SelfProfessed'} />}
-        <Typography variant="mono" component="span" sx={{ color: COLORS.brandDark, fontWeight: 700 }}>
+        <Typography
+          variant="mono"
+          component="span"
+          sx={{ color: labelOnly ? COLORS.brandExtraDark : COLORS.brandDark, fontWeight: 700 }}
+        >
           {isTablet ? (
-            <TabletLink address={address} name={name} to={to} highlightedPart={highlightedPartOfName} />
+            <TabletLink
+              address={address}
+              name={name}
+              to={to}
+              highlightedPart={highlightedPartOfName}
+              labelOnly={labelOnly}
+            />
           ) : (
             <DesktopLink
               address={address}
@@ -60,6 +72,7 @@ export const Link: FC<LinkProps> = ({
               name={name}
               to={to}
               highlightedPart={highlightedPartOfName}
+              labelOnly={labelOnly}
             />
           )}
         </Typography>
@@ -72,12 +85,27 @@ type CustomTrimEndLinkLabelProps = {
   name: string
   to: string
   highlightedPart?: string
+  labelOnly?: boolean
 }
 
-const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({ name, to, highlightedPart }) => {
-  return (
+const LinkLabel: FC<PropsWithChildren> = ({ children }) => (
+  <Typography component={'span'} fontSize={'inherit'} fontWeight={'inherit'} lineHeight={'inherit'}>
+    <span>{children}</span>
+  </Typography>
+)
+
+const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({
+  name,
+  to,
+  highlightedPart,
+  labelOnly,
+}) => {
+  const label = <HighlightedTrimmedText text={name} pattern={highlightedPart} fragmentLength={14} />
+  return labelOnly ? (
+    <LinkLabel>{label}</LinkLabel>
+  ) : (
     <MuiLink component={RouterLink} to={to}>
-      <HighlightedTrimmedText text={name} pattern={highlightedPart} fragmentLength={14} />
+      {label}
     </MuiLink>
   )
 }
@@ -87,13 +115,19 @@ type TabletLinkProps = {
   name?: string
   to: string
   highlightedPart?: string
+  labelOnly?: boolean
 }
 
-const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart }) => {
+const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart, labelOnly }) => {
   if (name) {
-    return <CustomTrimEndLinkLabel name={name} to={to} highlightedPart={highlightedPart} />
+    return (
+      <CustomTrimEndLinkLabel name={name} to={to} highlightedPart={highlightedPart} labelOnly={labelOnly} />
+    )
   }
-  return (
+
+  return labelOnly ? (
+    <LinkLabel>{trimLongString(address)}</LinkLabel>
+  ) : (
     <MuiLink component={RouterLink} to={to}>
       {trimLongString(address)}
     </MuiLink>
@@ -102,14 +136,22 @@ const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart })
 
 type DesktopLinkProps = TabletLinkProps & {
   alwaysTrim?: boolean
+  labelOnly?: boolean
 }
 
-const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, highlightedPart }) => {
+const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, highlightedPart, labelOnly }) => {
   if (alwaysTrim) {
     return (
       <WithHighlighting address={address}>
         {name ? (
-          <CustomTrimEndLinkLabel name={name} to={to} highlightedPart={highlightedPart} />
+          <CustomTrimEndLinkLabel
+            name={name}
+            to={to}
+            highlightedPart={highlightedPart}
+            labelOnly={labelOnly}
+          />
+        ) : labelOnly ? (
+          <LinkLabel>{trimLongString(address)}</LinkLabel>
         ) : (
           <MuiLink component={RouterLink} to={to}>
             {trimLongString(address)}
@@ -118,11 +160,16 @@ const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, high
       </WithHighlighting>
     )
   }
+  const label = name ? <HighlightedText text={name} pattern={highlightedPart} /> : address
   return (
     <WithHighlighting address={address}>
-      <MuiLink component={RouterLink} to={to}>
-        {name ? <HighlightedText text={name} pattern={highlightedPart} /> : address}
-      </MuiLink>
+      {labelOnly ? (
+        <LinkLabel>{label}</LinkLabel>
+      ) : (
+        <MuiLink component={RouterLink} to={to}>
+          {label}
+        </MuiLink>
+      )}
     </WithHighlighting>
   )
 }

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -10,12 +10,17 @@ import Box from '@mui/material/Box'
 import { AccountMetadataSourceIndicator } from '../Account/AccountMetadataSourceIndicator'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import { WithHighlighting } from '../HighlightingContext/WithHighlighting'
+import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
+import { AdaptiveHighlightedText } from '../HighlightedText/AdaptiveHighlightedText'
 import { HighlightedTrimmedText } from '../HighlightedText/HighlightedTrimmedText'
+
+export type TrimMode = 'fixes' | 'adaptive'
 
 type LinkProps = {
   address: string
   name?: string
   alwaysTrim?: boolean
+  trimMode?: TrimMode
   highlightedPartOfName?: string
   to: string
   withSourceIndicator?: boolean
@@ -26,6 +31,7 @@ export const Link: FC<LinkProps> = ({
   address,
   name,
   alwaysTrim,
+  trimMode,
   highlightedPartOfName,
   to,
   withSourceIndicator = true,
@@ -70,6 +76,7 @@ export const Link: FC<LinkProps> = ({
               to={to}
               highlightedPart={highlightedPartOfName}
               labelOnly={labelOnly}
+              trimMode={trimMode}
             />
           ) : (
             <DesktopLink
@@ -79,6 +86,7 @@ export const Link: FC<LinkProps> = ({
               to={to}
               highlightedPart={highlightedPartOfName}
               labelOnly={labelOnly}
+              trimMode={trimMode}
             />
           )}
         </Typography>
@@ -92,6 +100,7 @@ type CustomTrimEndLinkLabelProps = {
   to: string
   highlightedPart?: string
   labelOnly?: boolean
+  trimMode?: TrimMode
 }
 
 const LinkLabel: FC<PropsWithChildren> = ({ children }) => (
@@ -105,8 +114,14 @@ const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({
   to,
   highlightedPart,
   labelOnly,
+  trimMode,
 }) => {
-  const label = <HighlightedTrimmedText text={name} pattern={highlightedPart} fragmentLength={14} />
+  const label =
+    trimMode === 'adaptive' ? (
+      <AdaptiveHighlightedText text={name} pattern={highlightedPart} minLength={14} debugMode={true} />
+    ) : (
+      <HighlightedTrimmedText text={name} pattern={highlightedPart} fragmentLength={14} />
+    )
   return labelOnly ? (
     <LinkLabel>{label}</LinkLabel>
   ) : (
@@ -122,20 +137,33 @@ type TabletLinkProps = {
   to: string
   highlightedPart?: string
   labelOnly?: boolean
+  trimMode?: TrimMode
 }
 
-const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart, labelOnly }) => {
+const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart, labelOnly, trimMode }) => {
   if (name) {
     return (
-      <CustomTrimEndLinkLabel name={name} to={to} highlightedPart={highlightedPart} labelOnly={labelOnly} />
+      <CustomTrimEndLinkLabel
+        name={name}
+        to={to}
+        highlightedPart={highlightedPart}
+        labelOnly={labelOnly}
+        trimMode={trimMode}
+      />
     )
   }
 
+  const label =
+    trimMode === 'adaptive' ? (
+      <AdaptiveTrimmer text={address} strategy={'middle'} minLength={13} />
+    ) : (
+      trimLongString(address)
+    )
   return labelOnly ? (
-    <LinkLabel>{trimLongString(address)}</LinkLabel>
+    <LinkLabel>{label}</LinkLabel>
   ) : (
     <MuiLink component={RouterLink} to={to}>
-      {trimLongString(address)}
+      {label}
     </MuiLink>
   )
 }
@@ -145,7 +173,15 @@ type DesktopLinkProps = TabletLinkProps & {
   labelOnly?: boolean
 }
 
-const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, highlightedPart, labelOnly }) => {
+const DesktopLink: FC<DesktopLinkProps> = ({
+  address,
+  name,
+  to,
+  alwaysTrim,
+  trimMode,
+  highlightedPart,
+  labelOnly,
+}) => {
   if (alwaysTrim) {
     return (
       <WithHighlighting address={address}>
@@ -155,6 +191,7 @@ const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, high
             to={to}
             highlightedPart={highlightedPart}
             labelOnly={labelOnly}
+            trimMode={trimMode}
           />
         ) : labelOnly ? (
           <LinkLabel>{trimLongString(address)}</LinkLabel>

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -35,17 +35,23 @@ export const Link: FC<LinkProps> = ({
   const hasName = name?.toLowerCase() !== address.toLowerCase()
 
   const tooltipTitle =
-    hasName && withSourceIndicator ? (
+    hasName && (withSourceIndicator || isTablet) ? (
       <div>
         {name && (
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
             <Box sx={{ fontWeight: 'bold' }}>{name}</Box>
-            <span>-</span>
-            <AccountMetadataSourceIndicator source={'SelfProfessed'} withText />
+            {withSourceIndicator && (
+              <>
+                <span>-</span>
+                <AccountMetadataSourceIndicator source={'SelfProfessed'} withText />
+              </>
+            )}
           </Box>
         )}
         <Box sx={{ fontWeight: 'normal' }}>{address}</Box>
       </div>
+    ) : isTablet ? (
+      address
     ) : undefined
 
   return (

--- a/src/app/components/Rofl/RoflAppLink.tsx
+++ b/src/app/components/Rofl/RoflAppLink.tsx
@@ -1,15 +1,17 @@
 import { FC } from 'react'
 import { RouteUtils } from '../../utils/route-utils'
 import { Network } from '../../../types/network'
-import { Link } from '../Link'
+import { Link, TrimMode } from '../Link'
 
 type RoflAppLinkProps = {
   id: string
   name?: string
   network: Network
   alwaysTrim?: boolean
+  trimMode?: TrimMode
   highlightedPartOfName?: string
   withSourceIndicator?: boolean
+  labelOnly?: boolean
 }
 
 export const RoflAppLink: FC<RoflAppLinkProps> = ({
@@ -17,8 +19,10 @@ export const RoflAppLink: FC<RoflAppLinkProps> = ({
   name,
   network,
   alwaysTrim,
+  trimMode,
   highlightedPartOfName,
   withSourceIndicator,
+  labelOnly,
 }) => {
   const to = RouteUtils.getRoflAppRoute(network, id)
 
@@ -28,8 +32,10 @@ export const RoflAppLink: FC<RoflAppLinkProps> = ({
       name={name}
       to={to}
       alwaysTrim={alwaysTrim}
+      trimMode={trimMode}
       highlightedPartOfName={highlightedPartOfName}
       withSourceIndicator={withSourceIndicator}
+      labelOnly={labelOnly}
     />
   )
 }

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -43,6 +43,7 @@ import { LastActivity } from './LastActivity'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { SearchScope } from 'types/searchScope'
 import { Ticker } from 'types/ticker'
+import { WithHighlighting } from '../../components/HighlightingContext/WithHighlighting'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -137,9 +138,11 @@ export const RoflAppDetailsView: FC<{
       <VersionRow version={app.metadata['net.oasis.rofl.version']} />
       <TeeRow policy={app.policy} />
       <DetailsRow title={t('rofl.appId')}>
-        <Typography variant="mono" component="span">
-          {app.id}
-        </Typography>
+        <WithHighlighting address={app.id}>
+          <Typography variant="mono" component="span">
+            {app.id}
+          </Typography>
+        </WithHighlighting>
         <CopyToClipboard value={app.id} />
       </DetailsRow>
       <DetailsRow title={t('rofl.enclaveId')}>

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -67,7 +67,20 @@ export const RoflAppDetailsPage: FC = () => {
       <SubPageCard
         featured
         title={
-          isLoading ? <Skeleton variant="text" /> : roflApp?.metadata['net.oasis.rofl.name'] || roflApp?.id
+          isLoading ? (
+            <Skeleton variant="text" />
+          ) : (
+            roflApp && (
+              <RoflAppLink
+                id={roflApp.id}
+                network={scope.network}
+                name={roflApp.metadata['net.oasis.rofl.name']}
+                labelOnly
+                trimMode={'adaptive'}
+                withSourceIndicator={false}
+              />
+            )
+          )
         }
       >
         <RoflAppDetailsView isLoading={isLoading} app={roflApp} />


### PR DESCRIPTION
**Tweak 1**: implement page title shortening in table and mobile mode

| Before | After | Comment |
| ----- | ---- | --- |
|  ![image](https://github.com/user-attachments/assets/ad0ce6bf-4ea3-488d-a100-9568aa8cca2e) | ![image](https://github.com/user-attachments/assets/08b37a83-f10b-440c-82b7-b8943cb4ce31)  | No change in desktop size |
| ![image](https://github.com/user-attachments/assets/71c5db93-4b77-4286-8912-4d35292714e5) |![image](https://github.com/user-attachments/assets/823aaaa3-03cd-482f-a1f1-033240b33f6a) | Automatic shortening of title at tablet and mobile sizes  |

**Tweak 2**: Enable highlighting matching ROFL addresses on mouse hover

(Currently this is only enabled on desktop.)

![image](https://github.com/user-attachments/assets/e9f3627c-173b-41b9-b001-9fadbca0fafb)

**Tweak 3**:

Enable tool-tip on shortened app ids:

![image](https://github.com/user-attachments/assets/9403e0b1-68b8-46c3-a7b0-12ca9ec84dba)

