### PR TITLE
Restrict hover-based address highlighting to desktop

### DIFF
--- a/.changelog/1961.trivial.md
+++ b/.changelog/1961.trivial.md
@@ -1,0 +1,1 @@
+Restrict hover-based address highlighting to desktop

--- a/src/app/components/HighlightingContext/WithHighlighting.tsx
+++ b/src/app/components/HighlightingContext/WithHighlighting.tsx
@@ -2,11 +2,16 @@ import { FC, ReactNode, useEffect } from 'react'
 import { useAddressHighlighting } from './index'
 import { COLORS } from '../../../styles/theme/colors'
 import Box from '@mui/material/Box'
+import { useScreenSize } from '../../hooks/useScreensize'
 
 export const WithHighlighting: FC<{ children: ReactNode; address: string }> = ({ children, address }) => {
   const { highlightedAddress, highlightAddress, releaseAddress } = useAddressHighlighting()
   useEffect(() => () => releaseAddress(address)) // Release address on umount
-  const isHighlighted = !!highlightedAddress && highlightedAddress.toLowerCase() === address.toLowerCase()
+  const { isTablet } = useScreenSize()
+  // We have decided that we only want this feature on desktop,
+  // so we are on tablet (or mobile), just return the wrapped contnt directly.
+  const isHighlighted =
+    !isTablet && !!highlightedAddress && highlightedAddress.toLowerCase() === address.toLowerCase()
   return (
     <Box
       onMouseEnter={() => highlightAddress(address)}


### PR DESCRIPTION
@donouwens has confirmed that the feature when we highlight all matching addresses on mouse hover should be restricted to desktop.

Currently this decision is not consistently applied.

This change makes sure that this feature is always deactivated on tablet or mobile.

| Before | After |
| ---- | --- |
| ![image](https://github.com/user-attachments/assets/4fbae73a-1cf7-4ba0-9a10-e020f9b2304c) |  ![image](https://github.com/user-attachments/assets/2c659720-98e6-4d68-b1a6-34efa451407b) |

