### PR TITLE
Make adaptive trimmer more resilient

### DIFF
--- a/.changelog/1963.trivial.md
+++ b/.changelog/1963.trivial.md
@@ -1,0 +1,1 @@
+Make adaptive trimmer more resilient

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -22,22 +22,11 @@ const WithTypographyAndLink: FC<{
   mobile?: boolean
   children: ReactNode
   labelOnly?: boolean
-}> = ({ scope, address, children, mobile, labelOnly }) => {
+}> = ({ scope, address, children, labelOnly }) => {
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
     <WithHighlighting address={address}>
-      <Typography
-        variant="mono"
-        component="span"
-        sx={{
-          ...(mobile
-            ? {
-                maxWidth: '100%',
-                overflow: 'hidden',
-              }
-            : {}),
-        }}
-      >
+      <Typography variant="mono" component="span">
         {labelOnly ? (
           children
         ) : (
@@ -186,13 +175,21 @@ export const AccountLink: FC<Props> = ({
           <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
             <AccountMetadataSourceIndicator source={accountMetadata.source} />
             <AdaptiveHighlightedText
+              idPrefix="account-name"
               text={accountName}
               pattern={highlightedPartOfName}
               extraTooltip={tooltipTitle}
+              minLength={5}
             />
           </Box>
         )}
-        <AdaptiveTrimmer text={address} strategy="middle" tooltipOverride={tooltipTitle} />
+        <AdaptiveTrimmer
+          idPrefix="account-address"
+          text={address}
+          strategy="middle"
+          tooltipOverride={tooltipTitle}
+          minLength={13}
+        />
       </>
     </WithTypographyAndLink>
   )

--- a/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
+++ b/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
@@ -1,14 +1,34 @@
-import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { FC, ReactNode, useMemo } from 'react'
 import Box from '@mui/material/Box'
 import InfoIcon from '@mui/icons-material/Info'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
+import { getAdaptiveId, ShorteningResult, useAdaptiveSizing } from './hooks'
 
 type AdaptiveDynamicTrimmerProps = {
+  /**
+   * The ID (prefix) used for debugging
+   */
+  idPrefix: string
+
+  /**
+   * A function to return the full content
+   */
   getFullContent: () => {
     content: ReactNode
     length: number
   }
-  getShortenedContent: (wantedLength: number) => ReactNode
+
+  /**
+   * A function to return shortened content
+   */
+  getShortenedContent: (wantedLength: number) => ShorteningResult
+
+  /**
+   * The minimum length we ever want to shorten to.
+   *
+   * Default is 2
+   */
+  minLength?: number
 
   /**
    * Normally, the tooltip will be the full content. Do you want to add something?
@@ -19,6 +39,11 @@ type AdaptiveDynamicTrimmerProps = {
    * Normally, the tooltip will be the full content. Do you want to replace it with something else?
    */
   tooltipOverride?: ReactNode
+
+  /**
+   * Do we want to see debug output about the adaptive trimming process?
+   */
+  debugMode?: boolean
 }
 
 /**
@@ -31,132 +56,44 @@ type AdaptiveDynamicTrimmerProps = {
  * expects a function to provide a shortened version of the components.
  */
 export const AdaptiveDynamicTrimmer: FC<AdaptiveDynamicTrimmerProps> = ({
+  idPrefix,
   getFullContent,
   getShortenedContent,
   extraTooltip,
   tooltipOverride,
+  debugMode = false,
+  minLength = 2,
 }) => {
-  // Initial setup
-  const textRef = useRef<HTMLDivElement | null>(null)
-  const { content: fullContent, length: fullLength } = getFullContent()
+  const id = useMemo(() => getAdaptiveId(idPrefix), [idPrefix])
 
-  // Data about the currently rendered version
-  const [currentContent, setCurrentContent] = useState<ReactNode>()
-  const [currentLength, setCurrentLength] = useState(0)
-
-  // Known good - this fits
-  const [largestKnownGood, setLargestKnownGood] = useState(0)
-
-  // Known bad - this doesn't fit
-  const [smallestKnownBad, setSmallestKnownBad] = useState(fullLength + 1)
-
-  // Are we exploring our possibilities now?
-  const [inDiscovery, setInDiscovery] = useState(false)
-
-  const attemptContent = useCallback((content: ReactNode, length: number) => {
-    setCurrentContent(content)
-    setCurrentLength(length)
-  }, [])
-
-  const attemptShortenedContent = useCallback(
-    (length: number) => {
-      const content = getShortenedContent(length)
-
-      attemptContent(content, length)
-    },
-    [attemptContent, getShortenedContent],
+  const { currentContent, fullContent, textRef, isTruncated, isFinal } = useAdaptiveSizing(
+    id,
+    getFullContent,
+    getShortenedContent,
+    debugMode,
+    minLength,
   )
 
-  const initDiscovery = useCallback(() => {
-    setLargestKnownGood(0)
-    setSmallestKnownBad(fullLength + 1)
-    attemptContent(fullContent, fullLength)
-    setInDiscovery(true)
-  }, [fullContent, fullLength, attemptContent])
-
-  useEffect(() => {
-    initDiscovery()
-    const handleResize = () => {
-      initDiscovery()
-    }
-
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [initDiscovery])
-
-  useEffect(() => {
-    if (inDiscovery) {
-      if (!textRef.current) {
-        return
-      }
-      const isOverflow = textRef.current.scrollWidth > textRef.current.clientWidth
-
-      if (isOverflow) {
-        // This is too much
-
-        // Update known bad length
-        const newSmallestKnownBad = Math.min(currentLength, smallestKnownBad)
-        setSmallestKnownBad(newSmallestKnownBad)
-
-        // We should try something smaller
-        attemptShortenedContent(Math.floor((largestKnownGood + newSmallestKnownBad) / 2))
-      } else {
-        // This is OK
-
-        // Update known good length
-        const newLargestKnownGood = Math.max(currentLength, largestKnownGood)
-        setLargestKnownGood(currentLength)
-
-        if (currentLength === fullLength) {
-          // The whole thing fits, so we are good.
-          setInDiscovery(false)
-        } else {
-          if (currentLength + 1 === smallestKnownBad) {
-            // This the best we can do, for now
-            setInDiscovery(false)
-          } else {
-            // So far, so good, but we should try something longer
-            attemptShortenedContent(Math.floor((newLargestKnownGood + smallestKnownBad) / 2))
-          }
-        }
-      }
-    }
-  }, [
-    attemptShortenedContent,
-    currentLength,
-    fullContent,
-    fullLength,
-    inDiscovery,
-    initDiscovery,
-    largestKnownGood,
-    smallestKnownBad,
-  ])
-
-  const title =
-    currentLength !== fullLength ? (
-      <Box>
-        <Box>{tooltipOverride ?? fullContent}</Box>
-        {extraTooltip && (
-          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-            <InfoIcon />
-            {extraTooltip}
-          </Box>
-        )}
-      </Box>
-    ) : (
-      extraTooltip
-    )
+  const title = isTruncated ? (
+    <Box>
+      <Box>{tooltipOverride ?? fullContent}</Box>
+      {extraTooltip && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+          <InfoIcon />
+          {extraTooltip}
+        </Box>
+      )}
+    </Box>
+  ) : (
+    extraTooltip
+  )
 
   return (
-    <Box
-      ref={textRef}
-      sx={{
-        overflow: 'hidden',
-        maxWidth: '100%',
-        textWrap: 'nowrap',
-      }}
-    >
-      <MaybeWithTooltip title={title} spanSx={{ whiteSpace: 'nowrap' }}>
+    <Box component={'span'} ref={textRef} sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
+      <MaybeWithTooltip
+        title={title}
+        spanSx={{ textWrap: 'nowrap', whiteSpace: 'nowrap', opacity: isFinal ? 1 : 0 }}
+      >
         {currentContent}
       </MaybeWithTooltip>
     </Box>

--- a/src/app/components/AdaptiveTrimmer/hooks.ts
+++ b/src/app/components/AdaptiveTrimmer/hooks.ts
@@ -1,0 +1,295 @@
+import {
+  MutableRefObject,
+  ReactNode,
+  useCallback,
+  // using useLayoutEffect would be nicer (it eliminated the flickers), but sometimes we run unto the limit of maximum updates during render.
+  // until this is resolved, we need to stick to useEffect instead
+  // useLayoutEffect,
+  useEffect as useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import { useAdaptiveTrimmerContext } from '../AdaptiveTrimmerContext'
+
+const emptyTestContent = '.^.'
+
+export type ShorteningResult = {
+  content: ReactNode
+  length: number
+}
+
+interface AdaptiveSizingControls {
+  fullContent: ReactNode
+  currentContent: ReactNode
+  textRef: MutableRefObject<HTMLDivElement | null>
+  isTruncated: boolean
+  isFinal: boolean
+}
+
+let idCounter = 0
+
+export const getAdaptiveId = (prefix: string) => `${prefix}-${++idCounter}`
+
+// Hook for implementing the adaptive sizing behavior
+export const useAdaptiveSizing = (
+  id: string,
+  getFullContent: () => ShorteningResult,
+  getShortenedContent: (wantedLength: number) => ShorteningResult,
+  debugMode = false,
+  minLength = 2,
+): AdaptiveSizingControls => {
+  const { useController } = useAdaptiveTrimmerContext()
+
+  const { shouldMinimize, shouldAdjust, reportProcessFinish, onMount, onUnmount } = useController(id)
+
+  // Register and de-register this instance (the controller needs to know who is here)
+  useLayoutEffect(
+    () => {
+      onMount()
+      return () => onUnmount()
+    },
+    // We only want to run this on mounting and unmounting, so we deliberately ignore any dep changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+
+  const debugLog = useCallback(
+    (message: any, ...args: any[]) => {
+      if (debugMode) console.log(`[${id}]`, message, ...args)
+    },
+    [debugMode, id],
+  )
+
+  const { content: fullContent, length: fullLength } = getFullContent()
+
+  // Are we currently minimizing out content?
+  const [isMinimizing, setIsMinimizing] = useState(false)
+
+  // Where are we in the adjustment process?
+  const [adjustmentStep, setAdjustmentStep] = useState<
+    'idle' | 'checkBaseline' | 'checkFull' | 'findBest' | 'done'
+  >('idle')
+
+  const [currentContent, setCurrentContent] = useState<ReactNode>()
+  const [currentLength, setCurrentLength] = useState(0)
+
+  // Known good - this fits
+  const [largestKnownGood, setLargestKnownGood] = useState(0)
+
+  // Known bad - this doesn't fit
+  const [smallestKnownBad, setSmallestKnownBad] = useState(fullLength + 1)
+
+  // Ref to attach to DOM element
+  const textRef = useRef<HTMLDivElement | null>(null)
+
+  // The first element where we are supposed to fine overflow anyway
+  const [overflowRoot, setOverflowRoot] = useState<HTMLElement | null>()
+
+  type OverflowStatus = {
+    isOverflow: boolean
+    element: HTMLElement | null
+    steps: number
+  }
+
+  // A function to find the first overflow in our ancestors
+  const checkOverflow = useCallback((): OverflowStatus => {
+    let element: HTMLElement | null = textRef.current
+    let steps = 0
+    let isOverflow = false
+
+    while (element && !isOverflow) {
+      if (element.scrollWidth > element.offsetWidth) {
+        isOverflow = true
+      } else {
+        element = element.parentElement
+        steps++
+      }
+    }
+    return { isOverflow, element, steps }
+  }, [textRef])
+
+  const checkIfOverflow = useCallback((): boolean => {
+    const {
+      isOverflow,
+      element,
+      // steps
+    } = checkOverflow()
+    // No overflow whatsoever, clear case
+    if (!isOverflow) return false
+
+    // We should not be having an overflow, so this is bad
+    if (!overflowRoot) return true
+
+    // We need to check if this is the same as baseline
+    return element !== overflowRoot
+  }, [checkOverflow, overflowRoot])
+
+  // Function to update context and wait for the results
+  const attemptContent = useCallback(
+    (content: ReactNode, length: number) => {
+      setCurrentContent(content)
+      setCurrentLength(length)
+    },
+    [setCurrentContent, setCurrentLength],
+  )
+
+  // Use a shortened form for content
+  const attemptShortenedContent = useCallback(
+    (wantedLength: number) => {
+      const { content, length } = getShortenedContent(wantedLength)
+      if (length !== wantedLength) {
+        debugLog(`Wanted to shorten content to ${wantedLength}, received ${length}.`)
+      }
+      attemptContent(content, length)
+    },
+    [attemptContent, getShortenedContent, debugLog],
+  )
+
+  // Start to minimise on signal from controller
+  useLayoutEffect(() => {
+    if (shouldMinimize && !isMinimizing) setIsMinimizing(true)
+  }, [id, shouldMinimize, isMinimizing])
+
+  // Execute actual minimization
+  useLayoutEffect(() => {
+    if (isMinimizing) {
+      if (currentContent !== emptyTestContent) {
+        // phase 1: set content
+        attemptContent(emptyTestContent, emptyTestContent.length)
+      } else {
+        // phase 2: proceed to next step
+        debugLog(`I wonder if layout has updated yet. scrollWidth is now ${textRef.current?.scrollWidth}`)
+        setIsMinimizing(false)
+        reportProcessFinish('minimize')
+      }
+    }
+  }, [isMinimizing, attemptContent, currentContent, debugLog, id, reportProcessFinish])
+
+  // Execute the next phase of adjustment
+  useLayoutEffect(() => {
+    if (!shouldAdjust) return
+    debugLog('Doing step', adjustmentStep)
+    let overflowStatus: OverflowStatus
+    let isOverflow: boolean
+    switch (adjustmentStep) {
+      case 'idle':
+        // We are just starting
+        setAdjustmentStep('checkBaseline')
+        break
+      case 'checkBaseline':
+        // We need to record the baseline
+        overflowStatus = checkOverflow()
+
+        if (overflowStatus.isOverflow) {
+          debugLog(
+            'At baseline test, found overflow at step',
+            overflowStatus.steps,
+            ':',
+            overflowStatus.element,
+            overflowStatus.element!.scrollWidth,
+            overflowStatus.element!.clientWidth,
+          )
+          setOverflowRoot(overflowStatus.element)
+        } else {
+          debugLog('At baseline test, found no overflow', textRef.current)
+          setOverflowRoot(undefined)
+        }
+        setAdjustmentStep('checkFull')
+        break
+      case 'checkFull':
+        // Check if we can fit in the whole content
+        if (currentLength !== fullLength) {
+          // phase 1: set full content
+          attemptContent(fullContent, fullLength)
+        } else {
+          // phase 2: evaluate
+          isOverflow = checkIfOverflow()
+          if (isOverflow) {
+            debugLog("Full content doesn't fit, we need to try to find something smaller")
+            setLargestKnownGood(0)
+            setSmallestKnownBad(fullLength + 1)
+            setAdjustmentStep('findBest')
+          } else {
+            debugLog('Full content fits')
+            setAdjustmentStep('done')
+          }
+        }
+        break
+      case 'findBest':
+        // Iterate until we find the best
+        isOverflow = checkIfOverflow()
+        if (isOverflow) {
+          // This is too much
+
+          // Update known bad length
+          const newSmallestKnownBad = Math.min(currentLength, smallestKnownBad)
+          setSmallestKnownBad(newSmallestKnownBad)
+
+          // Have we hit the minimum?
+          if (currentLength === minLength) {
+            // If we can not even fit the minimum number, there is nothing we can do here.
+            debugLog('Sticking to the minimum of', minLength)
+            setAdjustmentStep('done')
+          } else if (currentLength === largestKnownGood + 1) {
+            // This the best we can do, for now
+            debugLog(largestKnownGood, 'is as long as we can grow.')
+            attemptShortenedContent(largestKnownGood)
+            setAdjustmentStep('done')
+          } else {
+            // We should try something smaller
+            debugLog(`${largestKnownGood} <= ? < ${newSmallestKnownBad}, going DOWN from ${currentLength}`)
+            attemptShortenedContent(
+              Math.max(minLength, Math.floor((largestKnownGood + newSmallestKnownBad) / 2)),
+            )
+          }
+        } else {
+          // This is OK
+
+          // Update known good length
+          const newLargestKnownGood = Math.max(currentLength, largestKnownGood)
+          setLargestKnownGood(currentLength)
+
+          if (currentLength + 1 === smallestKnownBad) {
+            // This the best we can do, for now
+            debugLog(currentLength, 'is as long as we can grow.')
+            setAdjustmentStep('done')
+          } else {
+            // So far, so good, but we should try something longer
+            debugLog(`${newLargestKnownGood} <= ? < ${smallestKnownBad}, going UP from ${currentLength}`)
+            attemptShortenedContent(Math.floor((newLargestKnownGood + smallestKnownBad) / 2))
+          }
+        }
+        break
+      case 'done':
+        debugLog('We are done, going back to idle state')
+        reportProcessFinish('adjusting')
+        setAdjustmentStep('idle')
+        break
+      default:
+        console.warn('Unknown process step', adjustmentStep)
+    }
+  }, [
+    shouldAdjust,
+    adjustmentStep,
+    checkOverflow,
+    debugLog,
+    attemptContent,
+    attemptShortenedContent,
+    checkIfOverflow,
+    currentLength,
+    fullLength,
+    fullContent,
+    largestKnownGood,
+    smallestKnownBad,
+    minLength,
+    reportProcessFinish,
+  ])
+
+  return {
+    fullContent,
+    currentContent,
+    textRef,
+    isTruncated: currentLength !== fullLength,
+    isFinal: currentContent !== emptyTestContent && !shouldAdjust,
+  }
+}

--- a/src/app/components/AdaptiveTrimmerContext/AdaptiveTrimmerProvider.tsx
+++ b/src/app/components/AdaptiveTrimmerContext/AdaptiveTrimmerProvider.tsx
@@ -1,0 +1,141 @@
+import { FC, PropsWithChildren, useCallback, useLayoutEffect, useState } from 'react'
+import {
+  AdaptiveTrimmerContext,
+  AdaptiveTrimmerContextData,
+  AdjustmentProcess,
+  ControlSignals,
+} from './index'
+
+const controllerDebugMode = false
+
+const debugLog = (message: any, ...args: any[]) => {
+  if (controllerDebugMode) console.log(`[controller]`, message, ...args)
+}
+
+/**
+ * This object provides control over the adaptive trimming process between all the components using it.
+ * Should be injected into the context.
+ */
+export const AdaptiveTrimmerContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [instances, setInstances] = useState<string[]>([])
+
+  const [shouldMinimize, setShouldMinimize] = useState(false)
+  const [shouldAdjust, setShouldAdjust] = useState(false)
+  const [adjustIndex, setAdjustIndex] = useState(0)
+  const [minimizedList, setMinimizedList] = useState<string[]>([])
+  const [hasMissedAction, setHasMissedAction] = useState(false)
+
+  // If there are no instances around, forget that we should minimize or adjust
+  useLayoutEffect(() => {
+    if (shouldMinimize && !instances.length) {
+      setShouldMinimize(false)
+    }
+    if (shouldAdjust && !instances.length) {
+      setShouldAdjust(false)
+    }
+  }, [shouldMinimize, shouldAdjust, instances.length])
+
+  // Start the adjustment process
+  const startProcess = useCallback(() => {
+    setMinimizedList([])
+    setShouldMinimize(true)
+  }, [])
+
+  // Add a window resize handler
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      if (!instances.length || shouldMinimize) return
+      if (shouldAdjust) {
+        // We are inside an adjustment cycle, so we need to wait
+        setHasMissedAction(true)
+      } else {
+        startProcess()
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [shouldMinimize, shouldAdjust, instances.length, startProcess])
+
+  useLayoutEffect(() => {
+    if (!shouldMinimize && !shouldAdjust && hasMissedAction) {
+      // If we have missed out on some action, now is the time to make up for it
+      setHasMissedAction(false)
+      startProcess()
+    }
+  }, [shouldMinimize, shouldAdjust, hasMissedAction, startProcess])
+
+  const reportProcessFinish = useCallback(
+    (id: string, process: AdjustmentProcess) => {
+      // debugLog(id, 'has finished to', process)
+      switch (process) {
+        case 'minimize':
+          setMinimizedList(list => (list.includes(id) ? list : [...list, id]))
+          break
+        case 'adjusting':
+          if (adjustIndex + 1 === minimizedList.length) {
+            debugLog('This was last one, we are all good')
+            setShouldAdjust(false)
+            setMinimizedList([])
+          } else {
+            debugLog('Now we will adjust', minimizedList[adjustIndex + 1])
+            setAdjustIndex(index => index + 1)
+          }
+          break
+        default:
+          console.warn("Don't know how to handle this.")
+      }
+    },
+    [minimizedList, adjustIndex],
+  )
+
+  // When we ara done minimizing, start the size discovery process
+  useLayoutEffect(() => {
+    if (shouldMinimize && minimizedList.length === instances.length) {
+      setShouldMinimize(false)
+      if (instances.length) {
+        debugLog(
+          'Everyone has minimized, we will do the adjustments now on',
+          minimizedList.length,
+          'instances:',
+          minimizedList,
+        )
+        setAdjustIndex(0)
+        setShouldAdjust(true)
+      } else {
+        debugLog('Finished minimizing, but there is nothing to adjust, so we are good')
+      }
+    }
+  }, [shouldMinimize, minimizedList, instances])
+
+  const onMount = useCallback((id: string) => {
+    setInstances(instances => (instances.includes(id) ? instances : [...instances, id]))
+    setHasMissedAction(true)
+  }, [])
+
+  const onUnmount = useCallback((id: string) => {
+    setInstances(instances => instances.filter(instance => instance !== id))
+    setMinimizedList(instances => instances.filter(instance => instance !== id))
+  }, [])
+
+  const useController = useCallback(
+    (id: string): ControlSignals => {
+      return {
+        onMount: () => onMount(id),
+        onUnmount: () => onUnmount(id),
+        shouldMinimize: shouldMinimize && !minimizedList.includes(id),
+        shouldAdjust: shouldAdjust && minimizedList[adjustIndex] === id,
+        reportProcessFinish: process => reportProcessFinish(id, process),
+      }
+    },
+    [onMount, onUnmount, minimizedList, reportProcessFinish, shouldMinimize, adjustIndex, shouldAdjust],
+  )
+
+  const adaptiveState: AdaptiveTrimmerContextData = {
+    useController,
+  }
+
+  return <AdaptiveTrimmerContext.Provider value={adaptiveState}>{children}</AdaptiveTrimmerContext.Provider>
+}

--- a/src/app/components/AdaptiveTrimmerContext/index.ts
+++ b/src/app/components/AdaptiveTrimmerContext/index.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react'
+
+export type AdjustmentProcess = 'minimize' | 'adjusting'
+
+export interface ControlSignals {
+  onMount: () => void
+  onUnmount: () => void
+  shouldMinimize: boolean
+  shouldAdjust: boolean
+  reportProcessFinish(process: AdjustmentProcess): void
+}
+
+export interface AdaptiveTrimmerContextData {
+  useController(id: string): ControlSignals
+}
+
+export const AdaptiveTrimmerContext = createContext<AdaptiveTrimmerContextData>(
+  {} as AdaptiveTrimmerContextData,
+)
+
+export const useAdaptiveTrimmerContext = () => {
+  const value = useContext(AdaptiveTrimmerContext)
+  if (Object.keys(value).length === 0) {
+    throw new Error('[useAdaptiveTrimmerContext] Component not wrapped within a Provider')
+  }
+
+  return value
+}

--- a/src/app/components/Blocks/BlockLink.tsx
+++ b/src/app/components/Blocks/BlockLink.tsx
@@ -54,7 +54,7 @@ export const BlockHashLink: FC<{
   return (
     <Typography variant="mono" sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
       <Link component={RouterLink} to={to}>
-        <AdaptiveTrimmer text={hash} strategy="middle" />
+        <AdaptiveTrimmer text={hash} strategy="middle" minLength={13} />
       </Link>
     </Typography>
   )

--- a/src/app/components/HighlightedText/AdaptiveHighlightedText.tsx
+++ b/src/app/components/HighlightedText/AdaptiveHighlightedText.tsx
@@ -5,6 +5,8 @@ import { AdaptiveDynamicTrimmer } from '../AdaptiveTrimmer/AdaptiveDynamicTrimme
 import { HighlightedTrimmedText } from './HighlightedTrimmedText'
 
 type AdaptiveHighlightedTextProps = {
+  idPrefix?: string
+
   /**
    * The text to display
    */
@@ -26,33 +28,53 @@ type AdaptiveHighlightedTextProps = {
    * Extra content to put into the tooltip
    */
   extraTooltip?: ReactNode
+
+  /**
+   * The minimum length we never want to go under
+   */
+  minLength?: number
+
+  /**
+   * Do we want to see debug output about the adaptive trimming process?
+   */
+  debugMode?: boolean
 }
 
 /**
  * Display a text with a part highlighted, adaptively trimmed to the maximum length around the highlight
  */
 export const AdaptiveHighlightedText: FC<AdaptiveHighlightedTextProps> = ({
+  idPrefix = 'adaptive-highlighted-text',
   text,
   pattern,
   options,
   extraTooltip,
+  minLength,
+  debugMode,
 }) => {
   const fullContent = <HighlightedText text={text} pattern={pattern} options={options} />
 
   return text ? (
     <AdaptiveDynamicTrimmer
+      idPrefix={idPrefix}
       getFullContent={() => ({
         content: fullContent,
         length: text.length,
       })}
-      getShortenedContent={wantedLength => (
-        <HighlightedTrimmedText
-          fragmentLength={wantedLength}
-          text={text}
-          pattern={pattern}
-          options={options}
-        />
-      )}
+      getShortenedContent={wantedLength => {
+        const content = (
+          <HighlightedTrimmedText
+            fragmentLength={wantedLength}
+            text={text}
+            pattern={pattern}
+            options={options}
+          />
+        )
+        return {
+          content,
+          length: wantedLength,
+        }
+      }}
       extraTooltip={
         extraTooltip ? (
           <>
@@ -61,6 +83,8 @@ export const AdaptiveHighlightedText: FC<AdaptiveHighlightedTextProps> = ({
           </>
         ) : undefined
       }
+      debugMode={debugMode}
+      minLength={minLength}
     />
   ) : undefined
 }

--- a/src/app/components/HighlightedText/index.tsx
+++ b/src/app/components/HighlightedText/index.tsx
@@ -84,7 +84,7 @@ export const HighlightedText: FC<HighlightedTextProps> = ({
   const end = text.substring(task.endPos)
 
   return (
-    <span>
+    <span style={{ textWrap: 'nowrap' }}>
       {beginning}
       <Box component="mark" sx={sx}>
         {focus}

--- a/src/app/components/Tokens/TokenDetails.tsx
+++ b/src/app/components/Tokens/TokenDetails.tsx
@@ -58,7 +58,7 @@ export const TokenDetails: FC<{
 
       <dt>{t(isMobile ? 'common.smartContract_short' : 'common.smartContract')}</dt>
       <dd>
-        <span>
+        <span style={{ textWrap: 'nowrap' }}>
           <AccountLink
             showOnlyAddress
             scope={token}

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -74,7 +74,7 @@ export const TransactionLink: FC<{
   // Mobile mode
   return (
     <WithTypographyAndLink mobile to={to}>
-      <AdaptiveTrimmer text={hash} strategy="middle" extraTooltip={extraTooltip} />
+      <AdaptiveTrimmer text={hash} strategy="middle" extraTooltip={extraTooltip} minLength={13} />
     </WithTypographyAndLink>
   )
 }

--- a/src/app/pages/ConsensusBlockDetailPage/index.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/index.tsx
@@ -123,7 +123,7 @@ export const ConsensusBlockDetailView: FC<{
           <dd>
             {isTablet ? (
               <Typography variant="mono" sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
-                <AdaptiveTrimmer text={block.state_root} strategy="middle" />
+                <AdaptiveTrimmer text={block.state_root} strategy="middle" minLength={13} />
               </Typography>
             ) : (
               <Typography variant="mono">{block.state_root}</Typography>

--- a/src/app/utils/__tests__/renderWithProviders.test.tsx
+++ b/src/app/utils/__tests__/renderWithProviders.test.tsx
@@ -4,6 +4,7 @@ import { withDefaultTheme } from '../../components/ThemeByScope'
 import React from 'react'
 import { useIsApiReachable, useRuntimeFreshness } from '../../components/OfflineBanner/hook'
 import { LocalSettingsContextProvider } from '../../providers/LocalSettingsProvider'
+import { AdaptiveTrimmerContextProvider } from '../../components/AdaptiveTrimmerContext/AdaptiveTrimmerProvider'
 
 jest.mock('../../components/OfflineBanner/hook')
 
@@ -17,7 +18,9 @@ export function renderWithProviders(component: React.ReactElement) {
     wrapper: ({ children }) =>
       withDefaultTheme(
         <LocalSettingsContextProvider>
-          <MemoryRouter>{children}</MemoryRouter>
+          <AdaptiveTrimmerContextProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </AdaptiveTrimmerContextProvider>
         </LocalSettingsContextProvider>,
       ),
   })

--- a/src/app/utils/trimLongString.ts
+++ b/src/app/utils/trimLongString.ts
@@ -1,11 +1,19 @@
+/**
+ * Get a shortened version of a string
+ *
+ * @param value The original string
+ * @param trimStart How many characters to use at the beginning? (Minimum: 1)
+ * @param trimEnd How many characters to use at the end? (Minimum: 0)
+ * @param ellipsis What string should we use to indicate the shortening?
+ */
 export function trimLongString(value: string, trimStart = 6, trimEnd = 6, ellipsis = '…') {
-  if (!value) {
-    return
-  }
-  const trimmedLength = trimStart + ellipsis.length + trimEnd
-  if (trimmedLength > value.length) {
-    return value
-  }
+  if (!value) return
+  // We always want to show at least one character at the beginning and at the end
+  const wantedStart = Math.max(trimStart, 1)
+  // We might not want to show anything from the end of the string, but the number should not be negative
+  const wantedEnd = Math.max(trimEnd, 0)
+  const trimmedLength = wantedStart + ellipsis.length + wantedEnd
+  if (trimmedLength > value.length) return value
 
-  return `${value.slice(0, trimStart)}${ellipsis}${trimEnd ? value.slice(-trimEnd) : ''}`
+  return `${value.slice(0, wantedStart)}${ellipsis}${trimEnd ? value.slice(-wantedEnd) : ''}`
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import './styles/index.css'
 // Initialize languages
 import './locales/i18n'
 import { LocalSettingsContextProvider } from './app/providers/LocalSettingsProvider'
+import { AdaptiveTrimmerContextProvider } from './app/components/AdaptiveTrimmerContext/AdaptiveTrimmerProvider'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -41,8 +42,10 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <LocalSettingsContextProvider>
-        <RouterProvider router={router} />
-        <ReactQueryDevtools initialIsOpen={false} />
+        <AdaptiveTrimmerContextProvider>
+          <RouterProvider router={router} />
+          <ReactQueryDevtools initialIsOpen={false} />
+        </AdaptiveTrimmerContextProvider>
       </LocalSettingsContextProvider>
     </QueryClientProvider>
   </React.StrictMode>,


### PR DESCRIPTION
Up to now, the adaptive trimmer needed to be inserted in a DOM element
with a fixed width, and overflow-X set to hidden.
(This was required so that it can find the best size to fill it, detecting
overflow.)

This was fragile, because it relied on all parent components being configured
in a particular way.

This changes makes it so that we can detect overflow recursively
on any of the parent elements, which means that there are no
restrictions on parent configuration.

As a side effect, this fixes fixes #1943 and #1957, both regressions on the address
display, caused by changes in CSS configurations on parent nodes, which earlier
confused the adaptive display.


|Before | After |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/23b5da23-9a9f-4f35-a358-58ce4142a18b) | ![image](https://github.com/user-attachments/assets/c9408440-169d-460b-b961-1c26844e72e1) |
|  ![image](https://github.com/user-attachments/assets/bf8af0be-daf0-4b4d-81f4-f7a42b7b721e) | ![image](https://github.com/user-attachments/assets/9db67689-3eea-4dbf-aeb0-c85e5a131d4d) | 

But besides fixing these regressions, the more important change is that
the adaptive trigger is a lot more resilient now, and no more relies on CSS settings
of parent nodes in the tree, the the probability of future regressions is greatly reduced.