### PR TITLE
Fix a regression in adaptive trimming

### DIFF
--- a/.changelog/1970.bugfix.md
+++ b/.changelog/1970.bugfix.md
@@ -1,0 +1,1 @@
+Fix a regression in adaptive trimming

--- a/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
+++ b/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
@@ -8,7 +8,7 @@ type AdaptiveDynamicTrimmerProps = {
   /**
    * The ID (prefix) used for debugging
    */
-  idPrefix: string
+  idPrefix?: string
 
   /**
    * A function to return the full content
@@ -56,7 +56,7 @@ type AdaptiveDynamicTrimmerProps = {
  * expects a function to provide a shortened version of the components.
  */
 export const AdaptiveDynamicTrimmer: FC<AdaptiveDynamicTrimmerProps> = ({
-  idPrefix,
+  idPrefix = 'adaptive-dynamic-trimmer',
   getFullContent,
   getShortenedContent,
   extraTooltip,

--- a/src/app/components/AdaptiveTrimmer/hooks.ts
+++ b/src/app/components/AdaptiveTrimmer/hooks.ts
@@ -153,7 +153,7 @@ export const useAdaptiveSizing = (
         attemptContent(emptyTestContent, emptyTestContent.length)
       } else {
         // phase 2: proceed to next step
-        debugLog(`I wonder if layout has updated yet. scrollWidth is now ${textRef.current?.scrollWidth}`)
+        // debugLog(`I wonder if layout has updated yet. scrollWidth is now ${textRef.current?.scrollWidth}`)
         setIsMinimizing(false)
         reportProcessFinish('minimize')
       }
@@ -163,7 +163,7 @@ export const useAdaptiveSizing = (
   // Execute the next phase of adjustment
   useLayoutEffect(() => {
     if (!shouldAdjust) return
-    debugLog('Doing step', adjustmentStep)
+    debugLog(`Step "${adjustmentStep}"`)
     let overflowStatus: OverflowStatus
     let isOverflow: boolean
     switch (adjustmentStep) {
@@ -186,7 +186,7 @@ export const useAdaptiveSizing = (
           )
           setOverflowRoot(overflowStatus.element)
         } else {
-          debugLog('At baseline test, found no overflow', textRef.current)
+          debugLog('At baseline test, found no overflow around', textRef.current)
           setOverflowRoot(undefined)
         }
         setAdjustmentStep('checkFull')
@@ -256,7 +256,6 @@ export const useAdaptiveSizing = (
         }
         break
       case 'done':
-        debugLog('We are done, going back to idle state')
         reportProcessFinish('adjusting')
         setAdjustmentStep('idle')
         break

--- a/src/app/components/AdaptiveTrimmer/hooks.ts
+++ b/src/app/components/AdaptiveTrimmer/hooks.ts
@@ -43,15 +43,10 @@ export const useAdaptiveSizing = (
   const { shouldMinimize, shouldAdjust, reportProcessFinish, onMount, onUnmount } = useController(id)
 
   // Register and de-register this instance (the controller needs to know who is here)
-  useLayoutEffect(
-    () => {
-      onMount()
-      return () => onUnmount()
-    },
-    // We only want to run this on mounting and unmounting, so we deliberately ignore any dep changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  )
+  useLayoutEffect(() => {
+    onMount(id)
+    return () => onUnmount(id)
+  }, [id, onMount, onUnmount])
 
   const debugLog = useCallback(
     (message: any, ...args: any[]) => {

--- a/src/app/components/AdaptiveTrimmerContext/index.ts
+++ b/src/app/components/AdaptiveTrimmerContext/index.ts
@@ -3,8 +3,8 @@ import { createContext, useContext } from 'react'
 export type AdjustmentProcess = 'minimize' | 'adjusting'
 
 export interface ControlSignals {
-  onMount: () => void
-  onUnmount: () => void
+  onMount: (id: string) => void
+  onUnmount: (id: string) => void
   shouldMinimize: boolean
   shouldAdjust: boolean
   reportProcessFinish(process: AdjustmentProcess): void


### PR DESCRIPTION
This is a follow-up to #1963.

(I found a corner case to break it after merging.)

This change add more resilience to the adaptive trimming process in situations when
React components are mounting and unmounting while the process is ongoing.

(Earlier, in some rare circumstances, the process could get stuck.)

## Explanation

This is how the adaptive trimming method has evolved

### The original method

In the original implementation of the adaptive trimmer, the idea was that we find out the largest fitting length of text by  watching for overflow happening on the element directly containing the content to shorten. This requires all the elements further up in the DOM to have exactly the right CSS settings, otherwise the overflow won't happen, or won't happen at the right place. This was a bit fragile, because changing something in the DOM at a higher level could break the adaptive trimming of the contained adaptive trimmers. (Like it happened in #1943)

### Relaxing the CSS requirements

To avoid this fragility, the behavior has been changed to look for overflow happening not only on the exact wrapping  element, but at any level above this node, that is, on all parents up to the root. (Sometimes there is already overflow even without our text being too long, so first we do a baseline measurement with a very short text, record which is the first level where we find overflow, and then compare the new situation to this saved baseline when experimenting with longer texts.)

This approach makes it unnecessary to add specific CSS configuration to all wrapping levels, therefore makes the system more robust. But there is a problem:

### Solving the interplay of multiple adaptive trimmers working at the same time

In the new approach, we let the components resize, and therefore change the layout of a larger sub-tree of the dom, until they hit an overflow. This works fine if there is only one adaptive trimmer doing this, but if multiple adaptive trimmers are doing this at the same time, then the results are unpredictable. (I.e. we won't know which adaptive trimmer has too long text, causing the overflow at an upper level.) The solution to this was adding a singleton controller object, which orchestrates  the whole process:
 - First, tell all adaptive trimmers to reduce to minimal content
 - Then tell them to do the adjustment one by one.

This way, there will be no confusion with the test results, because at each point in time, there is exactly one adaptive trimmer that is attempting to adapt (to the available size). This has been implemented as part of #1963, and solved several issues. But there is one more problem which was not handled...

### Solving the interplay of window resizing, component unmounting and ongoing adaptation

When the window is being resized, we get multiple resize events. Reacting to these events, we do a full round of adaptation. This is relatively fast, but not instantaneous. It's possible that we receive multiple events while still busy, but that is not a problem, we can handle that. The tricky situation is when as the result of enlarging the window size, we go over the limit to desktop territory, so we no longer want to do any trimming at all. This causes the adaptive trimmer to be removed from the DOM altogether. The problem happens if the component removed was the one that has the permission from the controller to do the resizing. This means that the resizing of that component never finishes (since it is removed from the DOM altogether), but the controller is still waiting it to finish, before giving the task to the next instance. This basically causes the adaptive process to freeze. This doesn't happen very often, but can triggered by resizing the window a lot. **This is the bug that is currently present in the master branch.** The solution to this issue is to make the code for selecting the current/next task more robust, and also add some reactive code to handle when the currently active adapting instance is removed. This PR does that.

   * * *
 
At this point, no further problems have been detected, and the current mechanism (with this fix) seems to work reliably, but more testing is always welcome.