### PR TITLE
Show seconds in formatted timestamp

### DIFF
--- a/.changelog/1972.trivial.md
+++ b/.changelog/1972.trivial.md
@@ -1,0 +1,1 @@
+ Show seconds in formatted timestamp

--- a/src/app/hooks/useFormattedTimestamp.ts
+++ b/src/app/hooks/useFormattedTimestamp.ts
@@ -25,7 +25,7 @@ export const useFormattedTimestamp = (
   })
 }
 
-export const useFormattedTimestampWithDistance = (
+const useFormattedTimestampWithDistance = (
   timestamp: Date | undefined,
   dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
@@ -33,6 +33,7 @@ export const useFormattedTimestampWithDistance = (
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
+    second: 'numeric',
     timeZoneName: 'short',
   },
 ) => {

--- a/src/app/pages/RuntimeBlockDetailPage/__tests__/RuntimeBlockDetailView.test.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/__tests__/RuntimeBlockDetailView.test.tsx
@@ -19,7 +19,7 @@ describe('RuntimeBlockDetailView', () => {
       <RuntimeBlockDetailView isLoading={false} block={suggestedParsedBlock as RuntimeBlock} />,
     )
     expect(screen.getByText('1,396,255')).toBeInTheDocument()
-    expect(screen.getByText('May 13, 2022 at 6:39 AM UTC (8 months ago)')).toBeInTheDocument()
+    expect(screen.getByText('May 13, 2022 at 6:39:03 AM UTC (8 months ago)')).toBeInTheDocument()
     expect(screen.getByText('4,214 bytes')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Slack req. Change affects block,tx,account,validator details and offline banner. 