### PR TITLE
Add support for filtering Rofl app list by name

### DIFF
--- a/.changelog/1987.feature.md
+++ b/.changelog/1987.feature.md
@@ -1,0 +1,1 @@
+Add support for filtering Rofl app list by name

--- a/src/app/components/Rofl/RoflAppsList.tsx
+++ b/src/app/components/Rofl/RoflAppsList.tsx
@@ -14,9 +14,16 @@ type RoflAppsListProps = {
   isLoading: boolean
   limit: number
   pagination: TablePaginationProps | false
+  highlightedPartOfName?: string
 }
 
-export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, pagination, apps }) => {
+export const RoflAppsList: FC<RoflAppsListProps> = ({
+  isLoading,
+  limit,
+  pagination,
+  apps,
+  highlightedPartOfName,
+}) => {
   const { t } = useTranslation()
   const { isTablet } = useScreenSize()
 
@@ -50,7 +57,12 @@ export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, paginati
         },
         {
           content: app?.metadata['net.oasis.rofl.name'] ? (
-            <RoflAppLink id={app.id} name={app?.metadata['net.oasis.rofl.name']} network={app.network} />
+            <RoflAppLink
+              id={app.id}
+              name={app?.metadata['net.oasis.rofl.name']}
+              network={app.network}
+              highlightedPartOfName={highlightedPartOfName}
+            />
           ) : (
             t('rofl.nameNotProvided')
           ),

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -14,12 +14,31 @@ import Button from '@mui/material/Button'
 import { CardEmptyState } from '../CardEmptyState'
 import { inputBaseClasses } from '@mui/material/InputBase'
 
+type SearchBarSize = 'small' | 'medium' | 'large'
+
 export interface TableSearchBarProps {
   placeholder: string
   warning?: string
   value: string
   fullWidth?: boolean
   onChange: (value: string) => void
+  size?: SearchBarSize
+}
+
+type SizingInfo = {
+  font: number | string
+}
+
+const sizeMapping: Record<SearchBarSize, SizingInfo> = {
+  small: {
+    font: '1em',
+  },
+  medium: {
+    font: '1.25em',
+  },
+  large: {
+    font: '1.5em',
+  },
 }
 
 export const TableSearchBar: FC<TableSearchBarProps> = ({
@@ -28,6 +47,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   placeholder,
   warning,
   fullWidth,
+  size = 'medium',
 }) => {
   const { isTablet } = useScreenSize()
 
@@ -117,6 +137,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
             p: 0,
             width: fullWidth ? '100%' : isTablet ? 110 : 300,
             margin: 2,
+            fontSize: sizeMapping[size].font,
           },
         },
         startAdornment,

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, KeyboardEventHandler, useCallback, useEffect, useState } from 'react'
 import TextField from '@mui/material/TextField'
 import SearchIcon from '@mui/icons-material/Search'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
@@ -22,6 +22,7 @@ export interface TableSearchBarProps {
   value: string
   fullWidth?: boolean
   onChange: (value: string) => void
+  onEnter?: () => void
   size?: SearchBarSize
   autoFocus?: boolean
 }
@@ -50,6 +51,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   fullWidth,
   size = 'medium',
   autoFocus,
+  onEnter,
 }) => {
   const { isTablet } = useScreenSize()
 
@@ -65,6 +67,15 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
       setIsWarningFresh(true)
     }
   }, [warning])
+
+  const handleKeyPress: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    event => {
+      if (event.key === 'Enter') {
+        if (onEnter) onEnter()
+      }
+    },
+    [onEnter],
+  )
 
   const startAdornment = (
     <InputAdornment
@@ -133,6 +144,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
       variant={'outlined'}
       value={value}
       onChange={e => onChange(e.target.value)}
+      onKeyDown={handleKeyPress}
       InputProps={{
         inputProps: {
           sx: {

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -23,6 +23,7 @@ export interface TableSearchBarProps {
   fullWidth?: boolean
   onChange: (value: string) => void
   size?: SearchBarSize
+  autoFocus?: boolean
 }
 
 type SizingInfo = {
@@ -48,6 +49,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   warning,
   fullWidth,
   size = 'medium',
+  autoFocus,
 }) => {
   const { isTablet } = useScreenSize()
 
@@ -139,6 +141,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
             margin: 2,
             fontSize: sizeMapping[size].font,
           },
+          autoFocus,
         },
         startAdornment,
         endAdornment,

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -85,7 +85,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
       sx={{
         backgroundColor: COLORS.white,
         '&:focus-within': {
-          boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.25) !important',
+          boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.125) !important',
         },
         [`.${inputBaseClasses.root}`]: {
           border: '1px solid',

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -18,10 +18,17 @@ export interface TableSearchBarProps {
   placeholder: string
   warning?: string
   value: string
+  fullWidth?: boolean
   onChange: (value: string) => void
 }
 
-export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, placeholder, warning }) => {
+export const TableSearchBar: FC<TableSearchBarProps> = ({
+  value,
+  onChange,
+  placeholder,
+  warning,
+  fullWidth,
+}) => {
   const { isTablet } = useScreenSize()
 
   const [isWarningFresh, setIsWarningFresh] = useState(false)
@@ -72,7 +79,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
         verticalAlign: 'middle',
         mt: 3,
         mb: 4,
-        width: isTablet ? '160px' : undefined,
+        width: fullWidth ? '100%' : isTablet ? '160px' : undefined,
       }}
     >
       <WarningIcon sx={{ mr: 3 }} />
@@ -99,6 +106,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
             }
           : {}),
         zIndex: 10,
+        ...(fullWidth ? { width: '100%' } : {}),
       }}
       variant={'outlined'}
       value={value}
@@ -107,7 +115,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
         inputProps: {
           sx: {
             p: 0,
-            width: isTablet ? 110 : 300,
+            width: fullWidth ? '100%' : isTablet ? 110 : 300,
             margin: 2,
           },
         },

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -84,8 +84,6 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
     <TextField
       sx={{
         backgroundColor: COLORS.white,
-        marginLeft: 4,
-        marginRight: helperText ? '25px' : '25px',
         '&:focus-within': {
           boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.25) !important',
         },

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -128,6 +128,7 @@ export const ProposalVotesCard: FC = () => {
               onChange={setWantedNameInput}
               placeholder={t('networkProposal.searchForVoter')}
               warning={nameError}
+              size={'small'}
             />
             <VoteTypeFilter onSelect={setWantedType} value={wantedType} />
           </Box>

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -122,7 +122,7 @@ export const ProposalVotesCard: FC = () => {
     <SubPageCard>
       <CardHeaderWithResponsiveActions
         action={
-          <>
+          <Box sx={{ display: 'inline-flex', gap: 5 }}>
             <TableSearchBar
               value={wantedNameInput}
               onChange={setWantedNameInput}
@@ -130,7 +130,7 @@ export const ProposalVotesCard: FC = () => {
               warning={nameError}
             />
             <VoteTypeFilter onSelect={setWantedType} value={wantedType} />
-          </>
+          </Box>
         }
         disableTypography
         component="h2"

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -227,7 +227,8 @@ export const RoflAppDetailsViewSearchResult: FC<{
 export const RoflAppDetailsVerticalListView: FC<{
   isLoading?: boolean
   app: RoflApp | undefined
-}> = ({ app, isLoading }) => {
+  highlightedPartOfName?: string
+}> = ({ app, isLoading, highlightedPartOfName }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -236,7 +237,7 @@ export const RoflAppDetailsVerticalListView: FC<{
 
   return (
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'} standalone>
-      <NameRow name={app.metadata['net.oasis.rofl.name']} />
+      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightedPartOfName={highlightedPartOfName} />
       <StatusBadgeRow hasActiveInstances={!!app.num_active_instances} removed={app.removed} />
       <DetailsRow title={t('rofl.appId')}>
         <RoflAppLink id={app.id} network={app.network} withSourceIndicator={false} />

--- a/src/app/pages/RoflAppsPage/hook.ts
+++ b/src/app/pages/RoflAppsPage/hook.ts
@@ -6,6 +6,8 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { TablePaginationProps } from '../../components/Table/TablePagination'
 import { Network } from '../../../types/network'
+import { useTranslation } from 'react-i18next'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 
 const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -22,11 +24,26 @@ export const useTableViewMode = () => {
   return { tableView, setTableView }
 }
 
+export const useROFLAppFiltering = () => {
+  const { t } = useTranslation()
+  const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('name', '', { deleteParams: ['page'] })
+  const wantedNamePattern = wantedNameInput.length < 3 ? undefined : wantedNameInput
+  const nameError = !!wantedNameInput && !wantedNamePattern ? t('tableSearch.error.tooShort') : undefined
+  return {
+    wantedNameInput,
+    setWantedNameInput,
+    nameError,
+    wantedNamePattern,
+  }
+}
+
 export const useRoflApps = (network: Network, layer: Runtime) => {
   const { tableView } = useTableViewMode()
   const pagination = useSearchParamsPagination('page')
+  const { wantedNamePattern } = useROFLAppFiltering()
   const offset = (pagination.selectedPage - 1) * limit
   const roflAppsQuery = useGetRuntimeRoflApps(network, layer, {
+    name: wantedNamePattern,
     limit: tableView === TableLayout.Vertical ? offset + limit : limit,
     offset: tableView === TableLayout.Vertical ? 0 : offset,
   })

--- a/src/app/pages/RoflAppsPage/hook.ts
+++ b/src/app/pages/RoflAppsPage/hook.ts
@@ -1,0 +1,54 @@
+import { Runtime, useGetRuntimeRoflApps } from 'oasis-nexus/api'
+import { TableLayout } from '../../components/TableLayoutButton'
+import { useEffect, useState } from 'react'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
+import { TablePaginationProps } from '../../components/Table/TablePagination'
+import { Network } from '../../../types/network'
+
+const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+
+export const useTableViewMode = () => {
+  const { isMobile } = useScreenSize()
+  const [tableView, setTableView] = useState<TableLayout>(TableLayout.Horizontal)
+
+  useEffect(() => {
+    if (!isMobile) {
+      setTableView(TableLayout.Horizontal)
+    }
+  }, [isMobile, setTableView])
+
+  return { tableView, setTableView }
+}
+
+export const useRoflApps = (network: Network, layer: Runtime) => {
+  const { tableView } = useTableViewMode()
+  const pagination = useSearchParamsPagination('page')
+  const offset = (pagination.selectedPage - 1) * limit
+  const roflAppsQuery = useGetRuntimeRoflApps(network, layer, {
+    limit: tableView === TableLayout.Vertical ? offset + limit : limit,
+    offset: tableView === TableLayout.Vertical ? 0 : offset,
+  })
+  const { isLoading, isFetched, data } = roflAppsQuery
+  const roflApps = data?.data.rofl_apps
+
+  const tablePagination: TablePaginationProps = {
+    selectedPage: pagination.selectedPage,
+    linkToPage: pagination.linkToPage,
+    totalCount: data?.data.total_count,
+    isTotalCountClipped: data?.data.is_total_count_clipped,
+    rowsPerPage: limit,
+  }
+
+  const hasNoResultsOnSelectedPage = isFetched && pagination.selectedPage > 1 && !roflApps?.length
+
+  return {
+    isLoading,
+    limit,
+    roflApps,
+    pagination,
+    tablePagination,
+    hasNoResultsOnSelectedPage,
+  }
+}

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -15,7 +15,7 @@ import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButt
 import { VerticalList } from '../../components/VerticalList'
 import { RoflAppDetailsVerticalListView } from '../RoflAppDetailsPage'
 import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
-import { TableSearchBar } from '../../components/Search/TableSearchBar'
+import { NoMatchingDataMaybeClearFilters, TableSearchBar } from '../../components/Search/TableSearchBar'
 import { Network } from '../../../types/network'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
@@ -24,15 +24,23 @@ const RoflAppsView: FC<{ network: Network; layer: Runtime; tableView: TableLayou
   layer,
   tableView,
 }) => {
-  const { wantedNamePattern } = useROFLAppFiltering()
+  const { wantedNamePattern, clearFilters } = useROFLAppFiltering()
 
-  const { tablePagination, isLoading, roflApps, limit, hasNoResultsOnSelectedPage } = useRoflApps(
-    network,
-    layer,
-  )
+  const {
+    tablePagination,
+    isLoading,
+    roflApps,
+    limit,
+    hasNoResultsOnSelectedPage,
+    hasNoResultsBecauseOfFilters,
+  } = useRoflApps(network, layer)
 
   if (hasNoResultsOnSelectedPage) {
     throw AppErrors.PageDoesNotExist
+  }
+
+  if (hasNoResultsBecauseOfFilters) {
+    return <NoMatchingDataMaybeClearFilters clearFilters={clearFilters} />
   }
 
   return (
@@ -77,7 +85,7 @@ export const RoflAppsPage: FC = () => {
 
   if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
-  const { pagination, isLoading } = useRoflApps(network, layer)
+  const { pagination, isLoading, hasNoResultsBecauseOfFilters } = useRoflApps(network, layer)
 
   const searchBar = (
     <TableSearchBar
@@ -93,7 +101,8 @@ export const RoflAppsPage: FC = () => {
   return (
     <PageLayout
       mobileFooterAction={
-        tableView === TableLayout.Vertical && <LoadMoreButton pagination={pagination} isLoading={isLoading} />
+        tableView === TableLayout.Vertical &&
+        !hasNoResultsBecauseOfFilters && <LoadMoreButton pagination={pagination} isLoading={isLoading} />
       }
     >
       {!isMobile && <Divider variant="layout" />}

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -85,8 +85,10 @@ export const RoflAppsPage: FC = () => {
 
   if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
-  const { pagination, isLoading, hasNoResultsBecauseOfFilters } = useRoflApps(network, layer)
-
+  const { pagination, isLoading, hasNoResultsBecauseOfFilters, jumpToSingleResult } = useRoflApps(
+    network,
+    layer,
+  )
   const searchBar = (
     <TableSearchBar
       value={wantedNameInput}
@@ -95,6 +97,7 @@ export const RoflAppsPage: FC = () => {
       warning={nameError}
       fullWidth={isMobile}
       autoFocus={!isMobile}
+      onEnter={jumpToSingleResult}
     />
   )
 

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -13,8 +13,8 @@ import { LoadMoreButton } from '../../components/LoadMoreButton'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { VerticalList } from '../../components/VerticalList'
 import { RoflAppDetailsVerticalListView } from '../RoflAppDetailsPage'
-
-import { useRoflApps, useTableViewMode } from './hook'
+import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
+import { TableSearchBar } from '../../components/Search/TableSearchBar'
 
 export const RoflAppsPage: FC = () => {
   const { tableView, setTableView } = useTableViewMode()
@@ -25,6 +25,7 @@ export const RoflAppsPage: FC = () => {
 
   if (!paraTimesConfig[scope.layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
+  const { wantedNameInput, setWantedNameInput, nameError, wantedNamePattern } = useROFLAppFiltering()
   const { pagination, tablePagination, isLoading, roflApps, limit, hasNoResultsOnSelectedPage } = useRoflApps(
     scope.network,
     scope.layer,
@@ -33,6 +34,17 @@ export const RoflAppsPage: FC = () => {
   if (hasNoResultsOnSelectedPage) {
     throw AppErrors.PageDoesNotExist
   }
+
+  const searchBar = (
+    <TableSearchBar
+      value={wantedNameInput}
+      onChange={setWantedNameInput}
+      placeholder={t('rofl.searchByNameOrKeyword')}
+      warning={nameError}
+      fullWidth={isMobile}
+      autoFocus={!isMobile}
+    />
+  )
 
   return (
     <PageLayout
@@ -43,12 +55,21 @@ export const RoflAppsPage: FC = () => {
       {!isMobile && <Divider variant="layout" />}
       <SubPageCard
         title={t('rofl.listTitle')}
-        action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
+        action={
+          isMobile ? <TableLayoutButton tableView={tableView} setTableView={setTableView} /> : searchBar
+        }
+        title2={isMobile && searchBar}
         noPadding={tableView === TableLayout.Vertical}
         mainTitle
       >
         {tableView === TableLayout.Horizontal && (
-          <RoflAppsList apps={roflApps} isLoading={isLoading} limit={limit} pagination={tablePagination} />
+          <RoflAppsList
+            apps={roflApps}
+            isLoading={isLoading}
+            limit={limit}
+            pagination={tablePagination}
+            highlightedPartOfName={wantedNamePattern}
+          />
         )}
 
         {tableView === TableLayout.Vertical && (
@@ -57,7 +78,14 @@ export const RoflAppsPage: FC = () => {
               [...Array(limit).keys()].map(key => (
                 <RoflAppDetailsVerticalListView key={key} isLoading={true} app={undefined} />
               ))}
-            {!isLoading && roflApps?.map(app => <RoflAppDetailsVerticalListView key={app.id} app={app} />)}
+            {!isLoading &&
+              roflApps?.map(app => (
+                <RoflAppDetailsVerticalListView
+                  key={app.id}
+                  app={app}
+                  highlightedPartOfName={wantedNamePattern}
+                />
+              ))}
           </VerticalList>
         )}
       </SubPageCard>

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -17,6 +17,7 @@ import { RoflAppDetailsVerticalListView } from '../RoflAppDetailsPage'
 import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
 import { TableSearchBar } from '../../components/Search/TableSearchBar'
 import { Network } from '../../../types/network'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const RoflAppsView: FC<{ network: Network; layer: Runtime; tableView: TableLayout }> = ({
   network,
@@ -105,7 +106,9 @@ export const RoflAppsPage: FC = () => {
         noPadding={tableView === TableLayout.Vertical}
         mainTitle
       >
-        <RoflAppsView network={network} layer={layer} tableView={tableView} />
+        <ErrorBoundary>
+          <RoflAppsView network={network} layer={layer} tableView={tableView} />
+        </ErrorBoundary>
       </SubPageCard>
     </PageLayout>
   )

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -174,8 +174,13 @@ export abstract class RouteUtils {
     return `/${encodeURIComponent(network)}/sapphire/rofl/app`
   }
 
-  static getRoflAppRoute = (network: Network, id: string) => {
-    return `/${encodeURIComponent(network)}/sapphire/rofl/app/${encodeURIComponent(id)}`
+  static getRoflAppRoute = (
+    network: Network,
+    id: string,
+    searchParams?: URLSearchParams,
+    preserveParams: string[] = [],
+  ) => {
+    return `/${encodeURIComponent(network)}/sapphire/rofl/app/${encodeURIComponent(id)}${formatPreservedParams(searchParams, preserveParams)}`
   }
 
   static getRoflAppInstanceRoute = (network: Network, id: string, rak: string) => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -728,6 +728,7 @@
     "roflName": "ROFL name",
     "roleCompute": "Role compute",
     "roleObserver": "Role observer",
+    "searchByNameOrKeyword":  "Search by name or keyword",
     "secretLength": "[{{value}} bytes]",
     "secrets": "Secrets",
     "secretsTooltip": "These secrets are end-to-end encrypted and can only be read by the ROFL app.",


### PR DESCRIPTION
The Nexus API has already added support for filtering the Rofl app list by name in https://github.com/oasisprotocol/nexus/pull/997.

In Explorer, currently this is only unitized in the global search since #1973/. (So that we can find Rofl apps from the global search field.)

This PR adds name/based filtering to the Rofl app list page itself.

I suggest reviewing commit by commit, because the different commits add different (small) features, and also there were some preparatory code refactorings, which would otherwise obscure the actual changes.

## Screenshots

Filtering the list on the desktop

![image](https://github.com/user-attachments/assets/938687bf-69de-4dd6-9bd9-e6d288d64e1d)

When no match:

![image](https://github.com/user-attachments/assets/496fe763-587c-4470-aa04-876763c588d0)

On mobile:

![image](https://github.com/user-attachments/assets/00614379-7c10-499f-99e6-a0f933ed6e45)

On mobile, vertical mode:

![image](https://github.com/user-attachments/assets/abd2f27d-347f-405b-be98-8aadb327b6a2)

No match on mobile:

![image](https://github.com/user-attachments/assets/6bee310b-2932-4b58-8083-0e1feb797d2d)

