### PR TITLE
Votes page: adjust filter positions on layout

### DIFF
--- a/.changelog/1994.trivial.md
+++ b/.changelog/1994.trivial.md
@@ -1,0 +1,1 @@
+Votes page: adjust filter positions

--- a/src/app/components/CardHeaderWithResponsiveActions/index.tsx
+++ b/src/app/components/CardHeaderWithResponsiveActions/index.tsx
@@ -2,6 +2,16 @@ import CardHeader, { cardHeaderClasses } from '@mui/material/CardHeader'
 import { styled } from '@mui/material/styles'
 
 export const CardHeaderWithResponsiveActions = styled(CardHeader)(({ theme }) => ({
+  [`.${cardHeaderClasses.content}`]: {
+    flex: 0,
+    textWrap: 'nowrap',
+  },
+  [`.${cardHeaderClasses.action}`]: {
+    marginLeft: theme.spacing(4),
+    flex: 1,
+    alignSelf: 'auto',
+    textAlign: 'end',
+  },
   [theme.breakpoints.down('md')]: {
     display: 'inline',
     alignItems: 'flex-start',

--- a/src/app/components/Proposals/VoteTypeFilter.tsx
+++ b/src/app/components/Proposals/VoteTypeFilter.tsx
@@ -6,6 +6,7 @@ import { FilterButtons } from '../FilterButtons'
 type VoteTypeFilterProps = {
   onSelect: (voteType: VoteType) => void
   value?: VoteType
+  fullWidth?: boolean
 }
 
 export const VoteTypeFilter: FC<VoteTypeFilterProps> = props => {

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -18,10 +18,29 @@ export interface TableSearchBarProps {
   placeholder: string
   warning?: string
   value: string
+  /**
+   * Should we go 100% width?
+   */
+  fullWidth?: boolean
+
+  /**
+   * Width of the whole component
+   *
+   * Note: fullWidth overrides this.
+   */
+  width?: string | number
+
   onChange: (value: string) => void
 }
 
-export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, placeholder, warning }) => {
+export const TableSearchBar: FC<TableSearchBarProps> = ({
+  value,
+  onChange,
+  placeholder,
+  warning,
+  fullWidth,
+  width = 250,
+}) => {
   const { isTablet } = useScreenSize()
 
   const [isWarningFresh, setIsWarningFresh] = useState(false)
@@ -72,7 +91,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
         verticalAlign: 'middle',
         mt: 3,
         mb: 4,
-        width: isTablet ? '160px' : undefined,
+        width: fullWidth ? '100%' : isTablet ? '160px' : undefined,
       }}
     >
       <WarningIcon sx={{ mr: 3 }} />
@@ -99,6 +118,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
             }
           : {}),
         zIndex: 10,
+        ...(fullWidth ? { width: '100%' } : {}),
       }}
       variant={'outlined'}
       value={value}
@@ -107,7 +127,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
         inputProps: {
           sx: {
             p: 0,
-            width: isTablet ? 110 : 300,
+            width: fullWidth ? '100%' : width,
             margin: 2,
           },
         },

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -84,8 +84,6 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
     <TextField
       sx={{
         backgroundColor: COLORS.white,
-        marginLeft: 4,
-        marginRight: helperText ? '25px' : '25px',
         '&:focus-within': {
           boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.125) !important',
         },

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -87,7 +87,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({ value, onChange, place
         marginLeft: 4,
         marginRight: helperText ? '25px' : '25px',
         '&:focus-within': {
-          boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.25) !important',
+          boxShadow: '3px 3px 3px 3px rgb(0, 0, 98, 0.125) !important',
         },
         [`.${inputBaseClasses.root}`]: {
           border: '1px solid',

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -122,7 +122,7 @@ export const ProposalVotesCard: FC = () => {
     <SubPageCard>
       <CardHeaderWithResponsiveActions
         action={
-          <>
+          <Box sx={{ display: 'inline-flex', gap: 5 }}>
             <TableSearchBar
               value={wantedNameInput}
               onChange={setWantedNameInput}
@@ -130,7 +130,7 @@ export const ProposalVotesCard: FC = () => {
               warning={nameError}
             />
             <VoteTypeFilter onSelect={setWantedType} value={wantedType} />
-          </>
+          </Box>
         }
         disableTypography
         component="h2"

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import Box from '@mui/material/Box'
 import { NoMatchingDataMaybeClearFilters, TableSearchBar } from '../../components/Search/TableSearchBar'
 import { CardEmptyState } from '../../components/CardEmptyState'
+import { useScreenSize } from '../../hooks/useScreensize'
 
 type ProposalVotesProps = {
   isLoading: boolean
@@ -115,6 +116,7 @@ export const ProposalVotesView: FC = () => {
 
 export const ProposalVotesCard: FC = () => {
   const { t } = useTranslation()
+  const { isMobile, isTablet } = useScreenSize()
 
   const { wantedType, setWantedType, wantedNameInput, setWantedNameInput, nameError } = useVoteFiltering()
 
@@ -122,14 +124,23 @@ export const ProposalVotesCard: FC = () => {
     <SubPageCard>
       <CardHeaderWithResponsiveActions
         action={
-          <Box sx={{ display: 'inline-flex', gap: 5 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              flexWrap: isTablet ? 'wrap' : 'nowrap',
+              gap: 4,
+              paddingRight: isMobile ? 4 : 0,
+            }}
+          >
+            <VoteTypeFilter onSelect={setWantedType} value={wantedType} />
             <TableSearchBar
               value={wantedNameInput}
               onChange={setWantedNameInput}
               placeholder={t('networkProposal.searchForVoter')}
               warning={nameError}
+              fullWidth={isTablet}
             />
-            <VoteTypeFilter onSelect={setWantedType} value={wantedType} />
           </Box>
         }
         disableTypography


### PR DESCRIPTION
@donouwens has requested some adjustments on the network proposal votes page.

Changes made:
 - ~Add missing checkmark from the selected pill~ - moving to separate PR
 - Change the order of the pills and the search bar
 - Make it so that the components are further apart, the pills right next to the title
 - Adjust the drop shadow around the search bar


| Before | After |
|---------|----------|
| ![image](https://github.com/user-attachments/assets/6a58c35d-53e7-4a1a-8671-963f98885631) | ![image](https://github.com/user-attachments/assets/c3864321-a04c-41cc-ba3a-4078607e4c59)   |
|![image](https://github.com/user-attachments/assets/b9cdc232-d683-40c7-b9b8-8a9f01f27292) | ![image](https://github.com/user-attachments/assets/2592cfce-b785-47e7-a1cd-b515111fb8cb)  |