### PR TITLE
Adaptive trimmer: don't react to window height change

### DIFF
--- a/.changelog/2000.bugfix.md
+++ b/.changelog/2000.bugfix.md
@@ -1,0 +1,1 @@
+Avoid twitching on window height changes


### PR DESCRIPTION
Also, separate the event handler from the reactive logic.

This solves #1535, based on a suggestion by @lukaw3d.