### PR TITLE
Layer handling code cleanup

### DIFF
--- a/.changelog/2002.internal.md
+++ b/.changelog/2002.internal.md
@@ -1,0 +1,1 @@
+Layer handling cleanup

--- a/src/app/components/Account/ContractCreatorInfo.tsx
+++ b/src/app/components/Account/ContractCreatorInfo.tsx
@@ -1,27 +1,22 @@
 import { FC } from 'react'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { useTranslation } from 'react-i18next'
 import { TransactionLink } from '../Transactions/TransactionLink'
 import {
-  Layer,
   Runtime,
   useGetRuntimeAccountsAddress,
   useGetRuntimeTransactionsTxHash,
 } from '../../../oasis-nexus/api'
-import { AppErrors } from '../../../types/errors'
 import { AccountLink } from './AccountLink'
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 
-const TxSender: FC<{ scope: SearchScope; txHash: string; alwaysTrim?: boolean }> = ({
+const TxSender: FC<{ scope: RuntimeScope; txHash: string; alwaysTrim?: boolean }> = ({
   scope,
   txHash,
   alwaysTrim,
 }) => {
   const { t } = useTranslation()
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
   const query = useGetRuntimeTransactionsTxHash(scope.network, scope.layer, txHash)
   const tx = query.data?.data.transactions[0]
   const senderAddress = tx?.signers[0].address_eth ?? tx?.signers[0].address
@@ -41,7 +36,7 @@ const TxSender: FC<{ scope: SearchScope; txHash: string; alwaysTrim?: boolean }>
 }
 
 export const ContractCreatorInfo: FC<{
-  scope: SearchScope
+  scope: RuntimeScope
   isLoading?: boolean
   creationTxHash: string | undefined
   alwaysTrim?: boolean
@@ -62,7 +57,7 @@ export const ContractCreatorInfo: FC<{
 }
 
 export const DelayedContractCreatorInfo: FC<{
-  scope: SearchScope
+  scope: RuntimeScope
   contractOasisAddress: string | undefined
   alwaysTrim?: boolean
 }> = ({ scope, contractOasisAddress, alwaysTrim }) => {

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import PaginationItem from '@mui/material/PaginationItem'
 import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope, RuntimeScope, SearchScope } from '../../../types/searchScope'
 import { COLORS } from '../../../styles/theme/colors'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
 import { RouteUtils } from '../../utils/route-utils'
@@ -58,12 +58,15 @@ const NextBlockButton: FC<{ disabled: boolean; scope: SearchScope; currentRound:
   )
 }
 
-type NextBlockButtonProps = {
-  scope: SearchScope
+type NextBlockButtonProps<Scope = SearchScope> = {
+  scope: Scope
   currentRound: number
 }
 
-export const ConsensusNextBlockButton: FC<NextBlockButtonProps> = ({ currentRound, scope }) => {
+export const ConsensusNextBlockButton: FC<NextBlockButtonProps<ConsensusScope>> = ({
+  currentRound,
+  scope,
+}) => {
   const { latestBlock } = useConsensusFreshness(scope.network)
   const disabled = !!latestBlock && currentRound >= latestBlock
   useConsensusFreshness(scope.network, { polling: disabled })
@@ -71,7 +74,7 @@ export const ConsensusNextBlockButton: FC<NextBlockButtonProps> = ({ currentRoun
   return <NextBlockButton currentRound={currentRound} disabled={disabled} scope={scope} />
 }
 
-export const RuntimeNextBlockButton: FC<NextBlockButtonProps> = ({ currentRound, scope }) => {
+export const RuntimeNextBlockButton: FC<NextBlockButtonProps<RuntimeScope>> = ({ currentRound, scope }) => {
   const { latestBlock } = useRuntimeFreshness(scope)
   const disabled = !!latestBlock && currentRound >= latestBlock
   useRuntimeFreshness(scope, { polling: disabled })

--- a/src/app/components/LayerPicker/LayerDetails.tsx
+++ b/src/app/components/LayerPicker/LayerDetails.tsx
@@ -16,7 +16,7 @@ import { Link as RouterLink } from 'react-router-dom'
 import { docs } from '../../utils/externalLinks'
 import { TextList, TextListItem } from '../TextList'
 import { getLayerLabels, getNetworkIcons } from '../../utils/content'
-import { getNameForScope, SearchScope } from '../../../types/searchScope'
+import { ConsensusScope, getNameForScope, RuntimeScope, SearchScope } from '../../../types/searchScope'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
 import { LayerStatus } from '../LayerStatus'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -114,23 +114,26 @@ export const StyledButton = styled(Button)(({ theme }) => ({
   },
 }))
 
-type LayerDetailsProps = {
+type LayerDetailsProps<Scope = SearchScope> = {
   handleConfirm: () => void
-  selectedScope: SearchScope
+  selectedScope: Scope
   isOutOfDate: boolean | undefined
 }
 
 // Prevent modal height from changing height when switching between layers
 const contentMinHeight = '270px'
 
-export const LayerDetails: FC<LayerDetailsProps> = (props: LayerDetailsProps) =>
-  props.selectedScope.layer === Layer.consensus ? (
-    <ConsensusDetails {...props} />
+export const LayerDetails: FC<LayerDetailsProps> = ({
+  selectedScope: { network, layer },
+  ...rest
+}: LayerDetailsProps) =>
+  layer === Layer.consensus ? (
+    <ConsensusDetails selectedScope={{ network, layer }} {...rest} />
   ) : (
-    <RuntimeDetails {...props} />
+    <RuntimeDetails selectedScope={{ network, layer }} {...rest} />
   )
 
-const ConsensusDetails: FC<LayerDetailsProps> = props => {
+const ConsensusDetails: FC<LayerDetailsProps<ConsensusScope>> = props => {
   const { t } = useTranslation()
   const { handleConfirm, selectedScope } = props
   const isOutOfDate = useConsensusFreshness(selectedScope.network).outOfDate
@@ -150,7 +153,7 @@ const ConsensusDetails: FC<LayerDetailsProps> = props => {
   )
 }
 
-const RuntimeDetails: FC<LayerDetailsProps> = props => {
+const RuntimeDetails: FC<LayerDetailsProps<RuntimeScope>> = props => {
   const { t } = useTranslation()
   const { handleConfirm, selectedScope } = props
   const isOutOfDate = useRuntimeFreshness(selectedScope).outOfDate

--- a/src/app/components/OfflineBanner/hook.ts
+++ b/src/app/components/OfflineBanner/hook.ts
@@ -1,13 +1,6 @@
-import {
-  Layer,
-  getStatus,
-  GetRuntimeStatus,
-  useGetRuntimeStatus,
-  useGetStatus,
-} from '../../../oasis-nexus/api'
+import { getStatus, GetRuntimeStatus, useGetRuntimeStatus, useGetStatus } from '../../../oasis-nexus/api'
 import { Network } from '../../../types/network'
-import { SearchScope } from '../../../types/searchScope'
-import { AppError, AppErrors } from '../../../types/errors'
+import { RuntimeScope } from '../../../types/searchScope'
 import { useFormattedTimestampStringWithDistance } from '../../hooks/useFormattedTimestamp'
 import { outOfDateThreshold } from '../../../config'
 import { UseQueryResult } from '@tanstack/react-query'
@@ -110,13 +103,9 @@ export const useConsensusFreshness = (
 }
 
 export const useRuntimeFreshness = (
-  scope: SearchScope,
+  scope: RuntimeScope,
   queryParams: { polling?: boolean } = {},
 ): FreshnessInfo => {
-  if (scope.layer === Layer.consensus) {
-    throw new AppError(AppErrors.UnsupportedLayer)
-  }
-
   const query = useGetRuntimeStatus(scope.network, scope.layer, {
     query: { refetchInterval: queryParams.polling ? 8000 : undefined, useErrorBoundary: false },
   })

--- a/src/app/components/OfflineBanner/index.tsx
+++ b/src/app/components/OfflineBanner/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useRequiredScopeParam, useScopeParam } from '../../hooks/useScopeParam'
+import { useRequiredScopeParam, useRuntimeScope, useScopeParam } from '../../hooks/useScopeParam'
 import { getNetworkNames, Network } from '../../../types/network'
 import { FreshnessInfo, useConsensusFreshness, useIsApiReachable, useRuntimeFreshness } from './hook'
 import { SearchScope, getNameForScope } from '../../../types/searchScope'
@@ -70,7 +70,7 @@ export const ConsensusOfflineBanner: FC = () => {
 }
 
 export const RuntimeOfflineBanner: FC = () => {
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const layerStatus = useRuntimeFreshness(scope)
 
   return <OfflineBanner layerStatus={layerStatus} scope={scope} />

--- a/src/app/components/PageLayout/NetworkSelector.tsx
+++ b/src/app/components/PageLayout/NetworkSelector.tsx
@@ -12,7 +12,7 @@ import { Layer } from '../../../oasis-nexus/api'
 import { LayerPicker } from './../LayerPicker'
 import { fixedLayer, fixedNetwork, RouteUtils } from '../../utils/route-utils'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope, SearchScope } from '../../../types/searchScope'
 import { useLocalSettings } from '../../hooks/useLocalSettings'
 
 export const StyledBox = styled(Box)(({ theme }) => ({
@@ -33,11 +33,11 @@ type NetworkSelectorProps = {
   network: Network
 }
 
-export const NetworkSelector: FC<NetworkSelectorProps> = props => {
-  return props.layer === Layer.consensus ? (
-    <ConsensusNetworkSelector {...props} />
+export const NetworkSelector: FC<NetworkSelectorProps> = ({ network, layer }) => {
+  return layer === Layer.consensus ? (
+    <ConsensusNetworkSelector network={network} layer={layer} />
   ) : (
-    <RuntimeNetworkSelector {...props} />
+    <RuntimeNetworkSelector network={network} layer={layer} />
   )
 }
 
@@ -47,7 +47,7 @@ const ConsensusNetworkSelector: FC<NetworkSelectorProps> = ({ layer, network }) 
   return <NetworkSelectorView layer={layer} network={network} isOutOfDate={outOfDate} />
 }
 
-const RuntimeNetworkSelector: FC<NetworkSelectorProps> = ({ layer, network }) => {
+const RuntimeNetworkSelector: FC<RuntimeScope> = ({ layer, network }) => {
   const { outOfDate } = useRuntimeFreshness({ network, layer })
 
   return <NetworkSelectorView layer={layer} network={network} isOutOfDate={outOfDate} />

--- a/src/app/components/Search/SearchSuggestionsButtons.tsx
+++ b/src/app/components/Search/SearchSuggestionsButtons.tsx
@@ -12,6 +12,7 @@ import { searchSuggestionTerms } from './search-utils'
 import { OptionalBreak } from '../OptionalBreak'
 import { SearchScope } from '../../../types/searchScope'
 import { Layer } from '../../../oasis-nexus/api'
+import { Network } from '../../../types/network'
 
 const StyledPlainTextButton = styled(Button)({
   fontSize: 'inherit',
@@ -39,7 +40,7 @@ export const SearchSuggestionsButtons: FC<Props> = ({ scope, onClickSuggestion }
   const { t } = useTranslation()
   const { suggestedBlock, suggestedTransaction, suggestedAccount, suggestedTokenFragment } =
     (scope?.network && scope?.layer && searchSuggestionTerms[scope.network][scope.layer]) ??
-    searchSuggestionTerms['mainnet']['sapphire']!
+    searchSuggestionTerms[Network.mainnet][Layer.sapphire]!
   const defaultComponents = {
     OptionalBreak: <OptionalBreak />,
     BlockIcon: <WidgetsIcon sx={{ fontSize: '18px' }} />,

--- a/src/app/components/Search/SearchSuggestionsLinksForNoResults.tsx
+++ b/src/app/components/Search/SearchSuggestionsLinksForNoResults.tsx
@@ -13,6 +13,7 @@ import { SearchScope } from '../../../types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { SxProps } from '@mui/material/styles'
 import { Layer } from '../../../oasis-nexus/api'
+import { Network } from '../../../types/network'
 
 interface Props {
   scope: SearchScope | undefined
@@ -31,7 +32,7 @@ export const SearchSuggestionsLinksForNoResults: FC<Props> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { suggestedBlock, suggestedTransaction, suggestedAccount, suggestedTokenFragment } =
     (scope?.network && scope?.layer && searchSuggestionTerms[scope.network][scope.layer]) ??
-    searchSuggestionTerms['mainnet']['sapphire']!
+    searchSuggestionTerms[Network.mainnet][Layer.sapphire]!
   const defaultComponents = {
     OptionalBreak: <OptionalBreak />,
     BlockIcon: isMobile ? empty : <WidgetsIcon sx={iconSxProps} />,

--- a/src/app/components/Transactions/RuntimeTransactionEvents.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionEvents.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Layer, RuntimeTransaction, useGetRuntimeEvents } from '../../../oasis-nexus/api'
+import { RuntimeTransaction, useGetRuntimeEvents } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { useSearchParamsPagination } from '../Table/useSearchParamsPagination'
 import { AppErrors } from '../../../types/errors'
@@ -11,9 +11,6 @@ export const RuntimeTransactionEvents: FC<{
   const { network, layer } = transaction
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
   const eventsQuery = useGetRuntimeEvents(network, layer, {
     tx_hash: transaction.hash,
     limit,

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -1,4 +1,4 @@
-import { SearchScope } from '../../types/searchScope'
+import { RuntimeScope, SearchScope } from '../../types/searchScope'
 import { Layer } from '../../oasis-nexus/api'
 import { usePontusXAccountMetadata, useSearchForPontusXAccountsByName } from '../data/pontusx-account-names'
 import { AccountMetadataInfo, AccountNameSearchResults } from '../data/named-accounts'
@@ -33,7 +33,8 @@ export const useAccountMetadata = (scope: SearchScope, address: string): Account
     token,
     isLoading: isTokenLoading,
     isError: isTokenError,
-  } = useTokenInfo(scope, address, {
+  } = useTokenInfo(scope as RuntimeScope, address, {
+    // The type cast is OK because whenever we are on consensus, we will set enabled to false
     enabled: !registryData?.metadata && scope.layer !== Layer.consensus,
     useCaching: true,
   })

--- a/src/app/hooks/useListBeforeDate.ts
+++ b/src/app/hooks/useListBeforeDate.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Layer, useGetRuntimeStatus, useGetStatus } from '../../oasis-nexus/api'
-import { AppError, AppErrors } from 'types/errors'
-import { SearchScope } from 'types/searchScope'
+import { useGetRuntimeStatus, useGetStatus } from '../../oasis-nexus/api'
+import { ConsensusScope, RuntimeScope } from 'types/searchScope'
 
 // Workaround around "before" filter exclusive maximum transaction time
 function addOneSecond(timestamp: string | undefined) {
@@ -39,12 +38,8 @@ const useListBeforeDate = (
   return { beforeDate, setBeforeDateFromCollection }
 }
 
-export const useRuntimeListBeforeDate = (scope: SearchScope, offset: number) => {
+export const useRuntimeListBeforeDate = (scope: RuntimeScope, offset: number) => {
   const [offsetAssociatedWithDate, setOffsetAssociatedWithDate] = useState<number | undefined>(offset)
-
-  if (scope.layer === Layer.consensus) {
-    throw new AppError(AppErrors.UnsupportedLayer)
-  }
 
   const { data } = useGetRuntimeStatus(scope.network, scope.layer, {
     query: {
@@ -55,7 +50,7 @@ export const useRuntimeListBeforeDate = (scope: SearchScope, offset: number) => 
   return useListBeforeDate(data?.data.latest_block_time, offset, setOffsetAssociatedWithDate)
 }
 
-export const useConsensusListBeforeDate = (scope: SearchScope, offset: number) => {
+export const useConsensusListBeforeDate = (scope: ConsensusScope, offset: number) => {
   const [offsetAssociatedWithDate, setOffsetAssociatedWithDate] = useState<number | undefined>(offset)
   const { data } = useGetStatus(scope.network, {
     query: {

--- a/src/app/hooks/useScopeParam.ts
+++ b/src/app/hooks/useScopeParam.ts
@@ -1,7 +1,8 @@
 import { useRouteLoaderData, useParams } from 'react-router-dom'
 import { Network } from '../../types/network'
 import { AppError, AppErrors } from '../../types/errors'
-import { SearchScope } from '../../types/searchScope'
+import { ConsensusScope, RuntimeScope, SearchScope } from '../../types/searchScope'
+import { Layer } from '../../oasis-nexus/api'
 
 export const useNetworkParam = (): Network | undefined => {
   const { network } = useParams()
@@ -26,4 +27,26 @@ export const useRequiredScopeParam = (): SearchScope => {
   if (!scope) throw new AppError(AppErrors.UnsupportedNetwork)
 
   return scope
+}
+
+/**
+ * Use this in situations where we require to have a runtime scope
+ */
+export const useRuntimeScope = (): RuntimeScope => {
+  const { network, layer } = useRequiredScopeParam()
+
+  if (layer === Layer.consensus) throw new AppError(AppErrors.UnsupportedLayer)
+
+  return { network, layer }
+}
+
+/**
+ * Use this in situations where we require to have a consensus scope
+ */
+export const useConsensusScope = (): ConsensusScope => {
+  const { network, layer } = useRequiredScopeParam()
+
+  if (layer !== Layer.consensus) throw new AppError(AppErrors.UnsupportedLayer)
+
+  return { network, layer }
 }

--- a/src/app/pages/ConsensusBlockDetailPage/index.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/index.tsx
@@ -4,10 +4,10 @@ import { useHref, useOutletContext, useParams } from 'react-router-dom'
 import Typography from '@mui/material/Typography'
 import { AppErrors } from '../../../types/errors'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { Block, EntityMetadata, Layer, useGetConsensusBlockByHeight } from '../../../oasis-nexus/api'
-import { SearchScope } from '../../../types/searchScope'
+import { Block, EntityMetadata, useGetConsensusBlockByHeight } from '../../../oasis-nexus/api'
+import { ConsensusScope } from '../../../types/searchScope'
 import { useFormattedTimestampStringWithDistance } from '../../hooks/useFormattedTimestamp'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useConsensusScope } from '../../hooks/useScopeParam'
 import { RouterTabs } from '../..//components/RouterTabs'
 import { StyledDescriptionList } from '../../components/StyledDescriptionList'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
@@ -26,7 +26,7 @@ export type BlockDetailConsensusBlock = Block & {
 }
 
 export type ConsensusBlockDetailsContext = {
-  scope: SearchScope
+  scope: ConsensusScope
   blockHeight?: number
 }
 
@@ -34,12 +34,9 @@ export const useConsensusBlockDetailsProps = () => useOutletContext<ConsensusBlo
 
 export const ConsensusBlockDetailPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
+  const scope = useConsensusScope()
   const txLink = useHref('')
   const eventsLink = useHref(`events#${eventsContainerId}`)
-  if (scope.layer !== Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
   const blockHeight = parseInt(useParams().blockHeight!, 10)
   const { isLoading, data } = useGetConsensusBlockByHeight(scope.network, blockHeight)
   if (!data && !isLoading) {

--- a/src/app/pages/ConsensusBlocksPage/index.tsx
+++ b/src/app/pages/ConsensusBlocksPage/index.tsx
@@ -15,7 +15,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { LoadMoreButton } from '../../components/LoadMoreButton'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useConsensusScope } from '../../hooks/useScopeParam'
 import { ConsensusBlocks, TableConsensusBlockList } from '../../components/Blocks/ConsensusBlocks'
 import { useConsensusListBeforeDate } from '../../hooks/useListBeforeDate'
 
@@ -34,7 +34,7 @@ export const ConsensusBlocksPage: FC = () => {
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * PAGE_SIZE
-  const scope = useRequiredScopeParam()
+  const scope = useConsensusScope()
   const enablePolling = offset === 0
   const { beforeDate, setBeforeDateFromCollection } = useConsensusListBeforeDate(scope, offset)
 

--- a/src/app/pages/ConsensusTransactionsPage/index.tsx
+++ b/src/app/pages/ConsensusTransactionsPage/index.tsx
@@ -12,7 +12,7 @@ import { AxiosResponse } from 'axios'
 import { AppErrors } from '../../../types/errors'
 import { LoadMoreButton } from '../../components/LoadMoreButton'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useConsensusScope } from '../../hooks/useScopeParam'
 import { VerticalList } from '../../components/VerticalList'
 import { ConsensusTransactionDetailView } from '../ConsensusTransactionDetailPage'
 import { useConsensusListBeforeDate } from '../../hooks/useListBeforeDate'
@@ -28,7 +28,7 @@ export const ConsensusTransactionsPage: FC = () => {
   const pagination = useSearchParamsPagination('page')
   const { method, setMethod } = useConsensusTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
-  const scope = useRequiredScopeParam()
+  const scope = useConsensusScope()
   const enablePolling = offset === 0
   const { beforeDate, setBeforeDateFromCollection } = useConsensusListBeforeDate(scope, offset)
 

--- a/src/app/pages/HomePage/Graph/Graph/index.tsx
+++ b/src/app/pages/HomePage/Graph/Graph/index.tsx
@@ -19,7 +19,7 @@ import { COLORS } from '../../../../../styles/theme/testnet/colors'
 import { COLORS as LOCALNET_COLORS } from '../../../../../styles/theme/localnet/colors'
 import { useTranslation } from 'react-i18next'
 import { useConsensusFreshness, useRuntimeFreshness } from '../../../../components/OfflineBanner/hook'
-import { SearchScope } from '../../../../../types/searchScope'
+import { RuntimeScope, SearchScope } from '../../../../../types/searchScope'
 import { SelectorArea, UniverseArea } from '../ParaTimeSelector'
 
 interface GraphBaseProps {
@@ -248,7 +248,7 @@ const ConsensusStatus: FC<{ network: Network; statusChange: (outOfDate?: boolean
   return null
 }
 
-const RuntimeStatus: FC<{ scope: SearchScope; statusChange: (outOfDate?: boolean) => void }> = ({
+const RuntimeStatus: FC<{ scope: RuntimeScope; statusChange: (outOfDate?: boolean) => void }> = ({
   scope,
   statusChange,
 }) => {
@@ -265,13 +265,13 @@ const RuntimeStatus: FC<{ scope: SearchScope; statusChange: (outOfDate?: boolean
 }
 
 const LayerStatus: FC<{ scope: SearchScope; statusChange: (outOfDate?: boolean) => void }> = ({
-  scope,
+  scope: { network, layer },
   statusChange,
 }) =>
-  scope.layer === Layer.consensus ? (
-    <ConsensusStatus network={scope.network} statusChange={statusChange} />
+  layer === Layer.consensus ? (
+    <ConsensusStatus network={network} statusChange={statusChange} />
   ) : (
-    <RuntimeStatus scope={scope} statusChange={statusChange} />
+    <RuntimeStatus scope={{ network, layer }} statusChange={statusChange} />
   )
 
 const GraphCmp: ForwardRefRenderFunction<SVGSVGElement, GraphProps> = (

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceDetailsCard.tsx
@@ -10,7 +10,7 @@ import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { VerificationIcon } from '../../components/ContractVerificationIcon'
 import CardContent from '@mui/material/CardContent'
 import { TokenTypeTag } from '../../components/Tokens/TokenList'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 import { EvmNft } from 'oasis-nexus/api'
 import Box from '@mui/material/Box'
@@ -19,7 +19,7 @@ type InstanceDetailsCardProps = {
   nft: EvmNft | undefined
   isFetched: boolean
   isLoading: boolean
-  scope: SearchScope
+  scope: RuntimeScope
   contractAddress: string
 }
 

--- a/src/app/pages/NFTInstanceDashboardPage/index.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/index.tsx
@@ -1,19 +1,19 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHref, useParams, useOutletContext } from 'react-router-dom'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { PageLayout } from '../../components/PageLayout'
 import { InstanceTitleCard } from './InstanceTitleCard'
 import { InstanceDetailsCard } from './InstanceDetailsCard'
 import { InstanceImageCard } from './InstanceImageCard'
 import { AppErrors } from '../../../types/errors'
 import { RouterTabs } from 'app/components/RouterTabs'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { useNFTInstance } from '../TokenDashboardPage/hook'
 import { metadataContainerId } from '../../utils/tabAnchors'
 
 export type NftDashboardContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   address: string
   instanceId: string
 }
@@ -22,7 +22,7 @@ export const useNftDetailsProps = () => useOutletContext<NftDashboardContext>()
 
 export const NFTInstanceDashboardPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const { address, instanceId } = useParams()
   if (!address || !instanceId) {
     throw AppErrors.InvalidUrl

--- a/src/app/pages/ParatimeDashboardPage/LatestRoflApps.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRoflApps.tsx
@@ -5,20 +5,18 @@ import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import Link from '@mui/material/Link'
-import { Layer, useGetRuntimeRoflApps } from '../../../oasis-nexus/api'
-import { SearchScope } from '../../../types/searchScope'
-import { NUMBER_OF_ITEMS_ON_DASHBOARD as limit } from '../../../config'
+import { useGetRuntimeRoflApps } from '../../../oasis-nexus/api'
+import { RuntimeScope } from '../../../types/searchScope'
+import { NUMBER_OF_ITEMS_ON_DASHBOARD as limit, paraTimesConfig } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
 import { RouteUtils } from '../../utils/route-utils'
 import { RoflAppsList } from '../../components/Rofl/RoflAppsList'
 
-export const LatestRoflApps: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const LatestRoflApps: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network, layer } = scope
-  if (layer !== Layer.sapphire) {
-    throw AppErrors.UnsupportedLayer
-  }
+  if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
   const roflAppsQuery = useGetRuntimeRoflApps(network, layer, { limit })
   const { isLoading, data } = roflAppsQuery
   const roflApps = data?.data.rofl_apps

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
@@ -5,26 +5,20 @@ import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import Link from '@mui/material/Link'
-import { Layer, useGetRuntimeBlocks } from '../../../oasis-nexus/api'
+import { useGetRuntimeBlocks } from '../../../oasis-nexus/api'
 import { RuntimeBlocks, BlocksTableType } from '../../components/Blocks'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { AppErrors } from '../../../types/errors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const LatestRuntimeBlocks: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const { network, layer } = scope
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus blocks is not yet implemented.
-    // We should use useGetConsensusBlocks()
-  }
   const blocksQuery = useGetRuntimeBlocks(
     network,
     layer,

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
@@ -5,14 +5,13 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
-import { Layer, useGetRuntimeTransactions } from '../../../oasis-nexus/api'
+import { useGetRuntimeTransactions } from '../../../oasis-nexus/api'
 import { RuntimeTransactions } from '../../components/Transactions'
 import { FILTERING_ON_DASHBOARD, NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { AppErrors } from '../../../types/errors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
 import Box from '@mui/material/Box'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
@@ -21,18 +20,13 @@ const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 const shouldFilter = FILTERING_ON_DASHBOARD
 
 export const LatestRuntimeTransactions: FC<{
-  scope: SearchScope
+  scope: RuntimeScope
   method: string
   setMethod: (value: string) => void
 }> = ({ scope, method, setMethod }) => {
   const { isMobile, isTablet } = useScreenSize()
   const { t } = useTranslation()
   const { network, layer } = scope
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus transactions is not yet supported.
-    // We should use useGetConsensusTransactions()
-  }
 
   const transactionsQuery = useGetRuntimeTransactions(
     network,

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -7,10 +7,9 @@ import { Layer } from '../../../oasis-nexus/api'
 import { getLayerLabels } from '../../utils/content'
 import { Network } from '../../../types/network'
 import { SpecifiedPerEnabledRuntime } from '../../utils/route-utils'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { LearningMaterialsCard } from 'app/components/LearningMaterialsCard'
 import { LearningSection } from '../../components/LearningMaterialsCard/LearningSection'
-import { AppErrors } from 'types/errors'
 
 type Content = {
   description: string
@@ -39,7 +38,7 @@ const getContent = (t: TFunction) => {
           url: docs.token,
         },
         tertiary: {
-          description: t('learningMaterials.transfer.description', { layer: labels['emerald'] }),
+          description: t('learningMaterials.transfer.description', { layer: labels[Layer.emerald] }),
           header: t('learningMaterials.transfer.header'),
           url: docs.paraTimeTransfer,
         },
@@ -56,7 +55,7 @@ const getContent = (t: TFunction) => {
           url: docs.token,
         },
         tertiary: {
-          description: t('learningMaterials.transfer.description', { layer: labels['sapphire'] }),
+          description: t('learningMaterials.transfer.description', { layer: labels[Layer.sapphire] }),
           header: t('learningMaterials.transfer.header'),
           url: docs.paraTimeTransfer,
         },
@@ -96,7 +95,7 @@ const getContent = (t: TFunction) => {
         },
         tertiary: {
           description: t('learningMaterials.hardhat.description'),
-          header: t('learningMaterials.hardhat.header', { layer: labels['sapphire'] }),
+          header: t('learningMaterials.hardhat.header', { layer: labels[Layer.sapphire] }),
           url: docs.sapphireTestnetHardhat,
         },
       },
@@ -167,7 +166,7 @@ const getContent = (t: TFunction) => {
         },
         tertiary: {
           description: t('learningMaterials.tools.description'),
-          header: t('learningMaterials.tools.header', { layer: labels['sapphire'] }),
+          header: t('learningMaterials.tools.header', { layer: labels[Layer.sapphire] }),
           url: docs.tools,
         },
       },
@@ -178,12 +177,9 @@ const getContent = (t: TFunction) => {
   } satisfies SpecifiedPerEnabledRuntime<LayerContent>
 }
 
-export const LearningMaterials: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const LearningMaterials: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { layer, network } = scope
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
   const content = getContent(t)[network][layer]
 
   if (!content) {

--- a/src/app/pages/ParatimeDashboardPage/Nodes.tsx
+++ b/src/app/pages/ParatimeDashboardPage/Nodes.tsx
@@ -6,17 +6,13 @@ import OfflineBoltIcon from '@mui/icons-material/OfflineBolt'
 import InfoIcon from '@mui/icons-material/Info'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
-import { Layer, useGetRuntimeStatus } from '../../../oasis-nexus/api'
-import { AppErrors } from '../../../types/errors'
+import { useGetRuntimeStatus } from '../../../oasis-nexus/api'
 import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
-export const Nodes: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const Nodes: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
   const { data, isFetched } = useGetRuntimeStatus(scope.network, scope.layer)
   const activeNodes = data?.data.active_nodes
   const title = (

--- a/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
@@ -10,11 +10,11 @@ import { useConstant } from '../../hooks/useConstant'
 import { getTokensForScope, showFiatValues } from '../../../config'
 import { getLayerLabels } from '../../utils/content'
 import { TestnetFaucet } from './TestnetFaucet'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { Snapshot, StyledGrid } from 'app/components/Snapshots/Snapshot'
 import { getFaucetLink } from '../../utils/faucet-links'
 
-export const ParaTimeSnapshot: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const ParaTimeSnapshot: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const defaultChartDurationValue = useConstant<ChartDuration>(() => ChartDuration.TODAY)
   const [chartDuration, setChartDuration] = useState<ChartDuration>(defaultChartDurationValue)

--- a/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
@@ -5,24 +5,18 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
-import { Layer, useGetRuntimeEvmTokens } from '../../../oasis-nexus/api'
+import { useGetRuntimeEvmTokens } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { AppErrors } from '../../../types/errors'
 import { RouteUtils } from '../../utils/route-utils'
 import { TokenList } from '../../components/Tokens/TokenList'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const TopTokens: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const TopTokens: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network, layer } = scope
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus transactions is not yet supported.
-    // We should use useGetConsensusTransactions()
-  }
   const tokensQuery = useGetRuntimeEvmTokens(network, layer, { limit })
 
   return (

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -12,13 +12,14 @@ import { TotalTransactions } from '../../components/TotalTransactions'
 import { PageLayout } from '../../components/PageLayout'
 import { ParaTimeSnapshot } from './ParaTimeSnapshot'
 import { TopTokens } from './TopTokens'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { LatestRoflApps } from './LatestRoflApps'
+import { paraTimesConfig } from '../../../config'
 
 export const ParatimeDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const isLocal = isLocalnet(scope.network)
   const { method, setMethod } = useRuntimeTxMethodParam()
 
@@ -36,7 +37,7 @@ export const ParatimeDashboardPage: FC = () => {
         </Grid>
         <Grid item xs={12}>
           <TopTokens scope={scope} />
-          {scope.layer === 'sapphire' && <LatestRoflApps scope={scope} />}
+          {paraTimesConfig[scope.layer]?.offerRoflTxTypes && <LatestRoflApps scope={scope} />}
         </Grid>
       </Grid>
       {!isLocal && (

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -4,8 +4,8 @@ import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import InfoIcon from '@mui/icons-material/Info'
 import CancelIcon from '@mui/icons-material/Cancel'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
-import { Layer, Proposal, useGetConsensusProposalsProposalId } from '../../../oasis-nexus/api'
+import { useConsensusScope } from '../../hooks/useScopeParam'
+import { Proposal, useGetConsensusProposalsProposalId } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
 import { useLoaderData } from 'react-router-dom'
 import { PageLayout } from '../../components/PageLayout'
@@ -27,10 +27,7 @@ import { getTypeNameForProposal } from '../../../types/proposalType'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
-  if (scope.layer !== Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-  }
+  const scope = useConsensusScope()
   const { proposalId, searchTerm } = useLoaderData() as ProposalIdLoaderData
 
   const {

--- a/src/app/pages/RoflAppDetailsPage/InstancesCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/InstancesCard.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Layer, useGetConsensusEpochs, useGetRuntimeRoflAppsIdInstances } from '../../../oasis-nexus/api'
+import { useGetConsensusEpochs, useGetRuntimeRoflAppsIdInstances } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { instancesContainerId } from '../../utils/tabAnchors'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
@@ -19,7 +19,7 @@ const InstancesView: FC<RoflAppDetailsContext> = ({ scope, id }) => {
   const { network } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  const instancesQuery = useGetRuntimeRoflAppsIdInstances(network, Layer.sapphire, id, {
+  const instancesQuery = useGetRuntimeRoflAppsIdInstances(network, scope.layer, id, {
     limit,
     offset,
   })

--- a/src/app/pages/RoflAppDetailsPage/PolicyCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/PolicyCard.tsx
@@ -5,7 +5,7 @@ import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
-import { Layer, RoflAppPolicy, useGetRuntimeRoflAppsIdTransactions } from '../../../oasis-nexus/api'
+import { RoflAppPolicy, Runtime, useGetRuntimeRoflAppsIdTransactions } from '../../../oasis-nexus/api'
 import { Network } from '../../../types/network'
 import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { EmptyStateCard } from './EmptyStateCard'
@@ -15,6 +15,7 @@ type PolicyCardProps = {
   id: string
   isFetched: boolean
   network: Network
+  layer: Runtime
   policy: RoflAppPolicy | undefined
 }
 
@@ -24,9 +25,9 @@ type PolicyCardProps = {
 // feePolicy can be 1 for InstancePays and 2 for EndorsingNodePays
 // https://github.com/oasisprotocol/oasis-sdk/blob/41480106d585debd33391cb0dfcad32d2f3cdc9d/runtime-sdk/src/modules/rofl/policy.rs#L48
 
-export const PolicyCard: FC<PolicyCardProps> = ({ id, isFetched, network, policy }) => {
+export const PolicyCard: FC<PolicyCardProps> = ({ id, isFetched, network, layer, policy }) => {
   const { t } = useTranslation()
-  const { data } = useGetRuntimeRoflAppsIdTransactions(network, Layer.sapphire, id, {
+  const { data } = useGetRuntimeRoflAppsIdTransactions(network, layer, id, {
     limit: 1,
     method: 'rofl.Update',
   })

--- a/src/app/pages/RoflAppDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppDetailsPage/hooks.tsx
@@ -1,17 +1,16 @@
 import { useOutletContext } from 'react-router-dom'
 import {
   useGetRuntimeRoflAppsIdTransactions,
-  Layer,
   useGetRuntimeRoflAppsIdInstanceTransactions,
 } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
-import { SearchScope } from '../../../types/searchScope'
-import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
+import { RuntimeScope } from '../../../types/searchScope'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit, paraTimesConfig } from '../../../config'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
-import { useSearchParamsPagination } from '../..//components/Table/useSearchParamsPagination'
+import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 
 export type RoflAppDetailsContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   id: string
   method: string
   setMethod: (value: string) => void
@@ -19,15 +18,13 @@ export type RoflAppDetailsContext = {
 
 export const useRoflAppDetailsProps = () => useOutletContext<RoflAppDetailsContext>()
 
-export const useRoflAppUpdates = (scope: SearchScope, id: string, method: string) => {
+export const useRoflAppUpdates = (scope: RuntimeScope, id: string, method: string) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer !== Layer.sapphire) {
-    throw AppErrors.UnsupportedLayer
-  }
+  if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
-  const query = useGetRuntimeRoflAppsIdTransactions(network, Layer.sapphire, id, {
+  const query = useGetRuntimeRoflAppsIdTransactions(network, layer, id, {
     limit,
     offset: offset,
     rel: id,
@@ -53,15 +50,13 @@ export const useRoflAppUpdates = (scope: SearchScope, id: string, method: string
   }
 }
 
-export const useRoflAppInstanceTransactions = (scope: SearchScope, id: string, method: string) => {
+export const useRoflAppInstanceTransactions = (scope: RuntimeScope, id: string, method: string) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer !== Layer.sapphire) {
-    throw AppErrors.UnsupportedLayer
-  }
+  if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
-  const query = useGetRuntimeRoflAppsIdInstanceTransactions(network, Layer.sapphire, id, {
+  const query = useGetRuntimeRoflAppsIdInstanceTransactions(network, layer, id, {
     limit,
     offset: offset,
     ...getRuntimeTransactionMethodFilteringParam(method),

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -8,16 +8,10 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import InfoIcon from '@mui/icons-material/Info'
 import { styled } from '@mui/material/styles'
-import {
-  Layer,
-  RoflApp,
-  RoflAppPolicy,
-  RuntimeTransaction,
-  useGetRuntimeRoflAppsId,
-} from '../../../oasis-nexus/api'
+import { RoflApp, RoflAppPolicy, RuntimeTransaction, useGetRuntimeRoflAppsId } from '../../../oasis-nexus/api'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { AppErrors } from '../../../types/errors'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 import { COLORS } from '../../../styles/theme/colors'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -49,7 +43,7 @@ import { RoflAppLoaderData } from '../../utils/route-utils'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const { id, searchTerm } = useLoaderData() as RoflAppLoaderData
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
@@ -58,7 +52,7 @@ export const RoflAppDetailsPage: FC = () => {
     deleteParams: ['page'],
   })
   const context: RoflAppDetailsContext = { scope, id, method, setMethod }
-  const { isFetched, isLoading, data } = useGetRuntimeRoflAppsId(scope.network, Layer.sapphire, id)
+  const { isFetched, isLoading, data } = useGetRuntimeRoflAppsId(scope.network, scope.layer, id)
   const roflApp = data?.data
 
   if (!roflApp && isFetched) {
@@ -98,6 +92,7 @@ export const RoflAppDetailsPage: FC = () => {
             <PolicyCard
               id={roflApp?.id}
               network={roflApp?.network}
+              layer={roflApp?.layer}
               isFetched={isFetched}
               policy={roflApp?.policy}
             />

--- a/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
@@ -1,13 +1,13 @@
 import { useOutletContext } from 'react-router-dom'
-import { Layer, useGetRuntimeRoflAppsIdInstancesRakTransactions } from '../../../oasis-nexus/api'
+import { useGetRuntimeRoflAppsIdInstancesRakTransactions } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
-import { SearchScope } from '../../../types/searchScope'
-import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
+import { RuntimeScope } from '../../../types/searchScope'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit, paraTimesConfig } from '../../../config'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import { useSearchParamsPagination } from '../..//components/Table/useSearchParamsPagination'
 
 export type RoflAppInstanceDetailsContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   id: string
   rak: string
   method: string
@@ -17,7 +17,7 @@ export type RoflAppInstanceDetailsContext = {
 export const useRoflAppInstanceDetailsProps = () => useOutletContext<RoflAppInstanceDetailsContext>()
 
 export const useRoflAppInstanceRakTransactions = (
-  scope: SearchScope,
+  scope: RuntimeScope,
   id: string,
   rak: string,
   method: string,
@@ -25,11 +25,9 @@ export const useRoflAppInstanceRakTransactions = (
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer !== Layer.sapphire) {
-    throw AppErrors.UnsupportedLayer
-  }
+  if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
-  const query = useGetRuntimeRoflAppsIdInstancesRakTransactions(network, Layer.sapphire, id, rak, {
+  const query = useGetRuntimeRoflAppsIdInstancesRakTransactions(network, layer, id, rak, {
     limit,
     offset: offset,
     ...getRuntimeTransactionMethodFilteringParam(method),

--- a/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
@@ -2,11 +2,11 @@ import { FC } from 'react'
 import { useHref, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import Typography from '@mui/material/Typography'
-import { Layer, RoflInstance, useGetRuntimeRoflAppsIdInstancesRak } from '../../../oasis-nexus/api'
+import { RoflInstance, useGetRuntimeRoflAppsIdInstancesRak } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { AppErrors } from '../../../types/errors'
 import { RoflAppInstanceDetailsContext } from './hooks'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { getOasisAddressFromBase64PublicKey } from '../../utils/helpers'
 import { PageLayout } from '../../components/PageLayout'
@@ -21,7 +21,7 @@ import { AccountLink } from '../../components/Account/AccountLink'
 
 export const RoflAppInstanceDetailsPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const id = useParams().id!
   const rak = useParams().rak!
   const txLink = useHref('')
@@ -29,7 +29,7 @@ export const RoflAppInstanceDetailsPage: FC = () => {
     deleteParams: ['page'],
   })
   const context: RoflAppInstanceDetailsContext = { scope, id, rak, method, setMethod }
-  const instancesQuery = useGetRuntimeRoflAppsIdInstancesRak(scope.network, Layer.sapphire, id, rak)
+  const instancesQuery = useGetRuntimeRoflAppsIdInstancesRak(scope.network, scope.layer, id, rak)
   const { isLoading, isFetched, data } = instancesQuery
   const instance = data?.data
 

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -1,11 +1,11 @@
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@mui/material/Divider'
-import { Layer, useGetRuntimeRoflApps } from '../../../oasis-nexus/api'
+import { useGetRuntimeRoflApps } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
-import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, paraTimesConfig } from '../../../config'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { RoflAppsList } from '../../components/Rofl/RoflAppsList'
@@ -23,11 +23,9 @@ export const RoflAppsPage: FC = () => {
   const { isMobile } = useScreenSize()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
 
-  if (scope.layer !== Layer.sapphire) {
-    throw AppErrors.UnsupportedLayer
-  }
+  if (!paraTimesConfig[scope.layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
   useEffect(() => {
     if (!isMobile) {

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTokensCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTokensCard.tsx
@@ -7,8 +7,7 @@ import { CardEmptyState } from '../../components/CardEmptyState'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
-import { EvmTokenType, Layer } from '../../../oasis-nexus/api'
-import { AppErrors } from '../../../types/errors'
+import { EvmTokenType } from '../../../oasis-nexus/api'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
@@ -59,11 +58,6 @@ export const AccountTokensCard: FC<AccountTokensCardProps> = ({ scope, account, 
         ]
       : []),
   ]
-  const { layer } = scope
-  if (layer === Layer.consensus) {
-    // There can be no ERC-20 or ERC-721 tokens on consensus
-    throw AppErrors.UnsupportedLayer
-  }
   const tableRows = (account?.tokenBalances[type] || []).map(item => ({
     key: item.token_contract_addr,
     data: [

--- a/src/app/pages/RuntimeAccountDetailsPage/hook.ts
+++ b/src/app/pages/RuntimeAccountDetailsPage/hook.ts
@@ -1,5 +1,4 @@
 import {
-  Layer,
   useGetRuntimeAccountsAddress,
   useGetRuntimeEvents,
   useGetRuntimeTransactions,
@@ -7,15 +6,11 @@ import {
 import { AppErrors } from '../../../types/errors'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 
-export const useAccount = (scope: SearchScope, address: string) => {
+export const useAccount = (scope: RuntimeScope, address: string) => {
   const { network, layer } = scope
-  if (layer === Layer.consensus) {
-    // There can be no ERC-20 or ERC-721 tokens on consensus
-    throw AppErrors.UnsupportedLayer
-  }
   const query = useGetRuntimeAccountsAddress(network, layer, address)
   const account = query.data?.data
 
@@ -24,16 +19,10 @@ export const useAccount = (scope: SearchScope, address: string) => {
   return { account, isLoading, isError, isFetched }
 }
 
-export const useAccountTransactions = (scope: SearchScope, address: string, method: string) => {
+export const useAccountTransactions = (scope: RuntimeScope, address: string, method: string) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Loading transactions on the consensus layer is not supported yet.
-    // We should use useGetConsensusTransactions()
-  }
-
   const query = useGetRuntimeTransactions(
     network,
     layer, // This is OK since consensus has been handled separately
@@ -64,16 +53,10 @@ export const useAccountTransactions = (scope: SearchScope, address: string, meth
   }
 }
 
-export const useAccountEvents = (scope: SearchScope, address: string) => {
+export const useAccountEvents = (scope: RuntimeScope, address: string) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Loading events on the consensus layer is not supported yet.
-    // We should use useGetConsensusEvents()
-  }
-
   const query = useGetRuntimeEvents(network, layer, {
     limit,
     offset: offset,

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -6,10 +6,10 @@ import { RouterTabs } from '../../components/RouterTabs'
 import { useAllTokenPrices } from '../../../coin-gecko/api'
 import { EvmTokenType, RuntimeAccount } from '../../../oasis-nexus/api'
 import { useAccount } from './hook'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useTokenInfo } from '../TokenDashboardPage/hook'
 import { getTokenTypePluralName } from '../../../types/tokens'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { RuntimeAccountDetailsCard } from './RuntimeAccountDetailsCard'
 import { DappBanner } from '../../components/DappBanner'
 import { AddressLoaderData } from '../../utils/route-utils'
@@ -23,7 +23,7 @@ import {
 } from '../../utils/tabAnchors'
 
 export type RuntimeAccountDetailsContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   address: string
   account?: RuntimeAccount
   method: string
@@ -35,7 +35,7 @@ export const useRuntimeAccountDetailsProps = () => useOutletContext<RuntimeAccou
 export const RuntimeAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
 
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -1,10 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Layer, useGetRuntimeEvents } from '../../../oasis-nexus/api'
+import { useGetRuntimeEvents } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
-import { AppErrors } from '../../../types/errors'
 import { RuntimeEventsDetailedList } from '../../components/RuntimeEvents/RuntimeEventsDetailedList'
 import { EmptyState } from '../../components/EmptyState'
 import { RuntimeBlockDetailsContext } from '.'
@@ -14,11 +13,6 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
-  if (scope.layer === Layer.consensus) {
-    // Loading events for consensus blocks is not yet supported.
-    // Should use useGetConsensusEvents()
-    throw AppErrors.UnsupportedLayer
-  }
   const eventsQuery = useGetRuntimeEvents(scope.network, scope.layer, {
     block: blockHeight,
     // TODO: search for tx_hash = null

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
-import { Layer, useGetRuntimeTransactions } from '../../../oasis-nexus/api'
+import { useGetRuntimeTransactions } from '../../../oasis-nexus/api'
 import { RuntimeTransactions } from '../../components/Transactions'
 import { AppErrors } from '../../../types/errors'
 import { RuntimeBlockDetailsContext } from '.'
@@ -15,11 +15,7 @@ import { transactionsContainerId } from '../../utils/tabAnchors'
 const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, method }) => {
   const txsPagination = useSearchParamsPagination('page')
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
-  if (scope.layer === Layer.consensus) {
-    // Loading transactions for consensus blocks is not yet supported.
-    // Should use useGetConsensusTransactions()
-    throw AppErrors.UnsupportedLayer
-  }
+
   const transactionsQuery = useGetRuntimeTransactions(scope.network, scope.layer, {
     block: blockHeight,
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useHref, useOutletContext, useParams } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
 import Link from '@mui/material/Link'
-import { Layer, RuntimeBlock, useGetRuntimeBlockByHeight } from '../../../oasis-nexus/api'
+import { RuntimeBlock, useGetRuntimeBlockByHeight } from '../../../oasis-nexus/api'
 import { RouterTabs } from '../../components/RouterTabs'
 import { StyledDescriptionList } from '../../components/StyledDescriptionList'
 import { PageLayout } from '../../components/PageLayout'
@@ -15,15 +15,15 @@ import { AppErrors } from '../../../types/errors'
 import { paraTimesConfig } from '../../../config'
 import { BlockLink, BlockHashLink } from '../../components/Blocks/BlockLink'
 import { RouteUtils } from '../../utils/route-utils'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { RuntimeNextBlockButton, RuntimePrevBlockButton } from '../../components/BlockNavigationButtons'
-import { SearchScope } from 'types/searchScope'
+import { RuntimeScope } from 'types/searchScope'
 import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId, transactionsContainerId } from '../../utils/tabAnchors'
 
 export type RuntimeBlockDetailsContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   blockHeight?: number
   method: string
   setMethod: (method: string) => void
@@ -33,13 +33,9 @@ export const useRuntimeBlockDetailsProps = () => useOutletContext<RuntimeBlockDe
 
 export const RuntimeBlockDetailPage: FC = () => {
   const { t } = useTranslation()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const txLink = useHref('')
   const eventsLink = useHref(`events#${eventsContainerId}`)
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // We should use useGetConsensusBlocksHeight()
-  }
   const blockHeight = parseInt(useParams().blockHeight!, 10)
   const { isLoading, data } = useGetRuntimeBlockByHeight(
     scope.network,

--- a/src/app/pages/RuntimeBlocksPage/index.tsx
+++ b/src/app/pages/RuntimeBlocksPage/index.tsx
@@ -5,7 +5,7 @@ import Divider from '@mui/material/Divider'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
-import { Layer, useGetRuntimeBlocks } from '../../../oasis-nexus/api'
+import { useGetRuntimeBlocks } from '../../../oasis-nexus/api'
 import { RuntimeBlocks, BlocksTableType, TableRuntimeBlockList } from '../../components/Blocks'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, REFETCH_INTERVAL } from '../../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
@@ -13,7 +13,7 @@ import { RuntimeBlockDetailView } from '../RuntimeBlockDetailPage'
 import { AppErrors } from '../../../types/errors'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { LoadMoreButton } from '../../components/LoadMoreButton'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { VerticalList } from '../../components/VerticalList'
 import { useRuntimeListBeforeDate } from '../../hooks/useListBeforeDate'
 
@@ -25,15 +25,9 @@ export const RuntimeBlocksPage: FC = () => {
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * PAGE_SIZE
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const enablePolling = offset === 0
   const { beforeDate, setBeforeDateFromCollection } = useRuntimeListBeforeDate(scope, offset)
-  // Consensus is not yet enabled in ENABLED_LAYERS, just some preparation
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus blocks is not yet implemented.
-    // we should call useGetConsensusBlocks()
-  }
 
   useEffect(() => {
     if (!isMobile) {
@@ -43,7 +37,7 @@ export const RuntimeBlocksPage: FC = () => {
 
   const blocksQuery = useGetRuntimeBlocks<AxiosResponse<TableRuntimeBlockList>>(
     scope.network,
-    scope.layer, // This is OK, since consensus is already handled separately
+    scope.layer,
     {
       limit: tableView === TableLayout.Vertical ? offset + PAGE_SIZE : PAGE_SIZE,
       offset: tableView === TableLayout.Vertical ? 0 : offset,

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Layer, RuntimeTransaction, useGetRuntimeTransactionsTxHash } from '../../../oasis-nexus/api'
+import { RuntimeTransaction, useGetRuntimeTransactionsTxHash } from '../../../oasis-nexus/api'
 import { StyledDescriptionList } from '../../components/StyledDescriptionList'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
@@ -16,7 +16,7 @@ import { TextSkeleton } from '../../components/Skeleton'
 import { BlockLink } from '../../components/Blocks/BlockLink'
 import { TransactionLink } from '../../components/Transactions/TransactionLink'
 import { RuntimeTransactionEvents } from '../../components/Transactions/RuntimeTransactionEvents'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { AllTokenPrices, useAllTokenPrices } from '../../../coin-gecko/api'
 import { CurrentFiatValue } from '../../components/CurrentFiatValue'
@@ -46,14 +46,7 @@ import { RouteUtils } from '../../utils/route-utils'
 export const RuntimeTransactionDetailPage: FC = () => {
   const { t } = useTranslation()
 
-  const scope = useRequiredScopeParam()
-  // Consensus is not yet enabled in ENABLED_LAYERS, just some preparation
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Displaying consensus transactions is not yet implemented.
-    // we should call useGetConsensusTransactionsTxHash()
-  }
-
+  const scope = useRuntimeScope()
   const hash = useParams().hash!
 
   const { isLoading, data } = useGetRuntimeTransactionsTxHash(

--- a/src/app/pages/RuntimeTransactionsPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionsPage/index.tsx
@@ -5,7 +5,7 @@ import { useScreenSize } from '../../hooks/useScreensize'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
 import { TableRuntimeTransactionList, RuntimeTransactions } from '../../components/Transactions'
-import { Layer, useGetRuntimeTransactions } from '../../../oasis-nexus/api'
+import { useGetRuntimeTransactions } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE, REFETCH_INTERVAL } from '../../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { AxiosResponse } from 'axios'
@@ -13,7 +13,7 @@ import { AppErrors } from '../../../types/errors'
 import { LoadMoreButton } from '../../components/LoadMoreButton'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { RuntimeTransactionDetailView } from '../RuntimeTransactionDetailPage'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useAllTokenPrices } from '../../../coin-gecko/api'
 import { VerticalList } from '../../components/VerticalList'
 import { getFiatCurrencyForScope } from '../../../config'
@@ -32,15 +32,9 @@ export const RuntimeTransactionsPage: FC = () => {
   const pagination = useSearchParamsPagination('page')
   const { method, setMethod } = useRuntimeTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const enablePolling = offset === 0
   const { beforeDate, setBeforeDateFromCollection } = useRuntimeListBeforeDate(scope, offset)
-  // Consensus is not yet enabled in ENABLED_LAYERS, just some preparation
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus transactions is not yet implemented.
-    // we should call useGetConsensusTransactions()
-  }
 
   const tokenPrices = useAllTokenPrices(getFiatCurrencyForScope(scope))
 

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -351,6 +351,7 @@ export function useNamedValidatorConditionally(nameFragment: string | undefined)
 }
 
 export function useRoflAppIdConditionally(id: string | undefined): ConditionalResults<RoflApp> {
+  // TODO: also search on other layers that support Rofl
   const queries = RouteUtils.getEnabledNetworksForLayer(Layer.sapphire).map(network =>
     // See explanation above
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -368,6 +369,7 @@ export function useRoflAppIdConditionally(id: string | undefined): ConditionalRe
 }
 
 export function useRoflAppNameConditionally(nameFragment: string | undefined): ConditionalResults<RoflApp> {
+  // TODO: also search on other layers that support Rofl
   const queries = RouteUtils.getEnabledNetworksForLayer(Layer.sapphire).map(network =>
     // See explanation above
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -14,7 +14,7 @@ import { VerificationIcon } from '../../components/ContractVerificationIcon'
 import { DelayedContractCreatorInfo } from '../../components/Account/ContractCreatorInfo'
 import CardContent from '@mui/material/CardContent'
 import { TokenTypeTag } from '../../components/Tokens/TokenList'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { RouteUtils } from '../../utils/route-utils'
 import { RoundedBalance } from 'app/components/RoundedBalance'
 import { RuntimeBalanceDisplay } from '../../components/Balance/RuntimeBalanceDisplay'
@@ -24,7 +24,7 @@ import Box from '@mui/material/Box'
 import { holdersContainerId, tokenTransfersContainerId } from '../../utils/tabAnchors'
 import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 
-export const TokenDetailsCard: FC<{ scope: SearchScope; address: string; searchTerm: string }> = ({
+export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; searchTerm: string }> = ({
   scope,
   address,
   searchTerm,

--- a/src/app/pages/TokenDashboardPage/TokenGasUsedCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenGasUsedCard.tsx
@@ -5,9 +5,9 @@ import Typography from '@mui/material/Typography'
 import { SnapshotCard } from '../../components/Snapshots/SnapshotCard'
 import { COLORS } from '../../../styles/theme/colors'
 import { useAccount } from '../RuntimeAccountDetailsPage/hook'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
-export const TokenGasUsedCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenGasUsedCard: FC<{ scope: RuntimeScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const { account, isFetched } = useAccount(scope, address)

--- a/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenHoldersCountCard.tsx
@@ -2,10 +2,10 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import Skeleton from '@mui/material/Skeleton'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { useTokenInfo } from './hook'
 
-export const TokenHoldersCountCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenHoldersCountCard: FC<{ scope: RuntimeScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)

--- a/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSnapshot.tsx
@@ -10,10 +10,10 @@ import { TokenSupplyCard } from './TokenSupplyCard'
 import { TokenHoldersCountCard } from './TokenHoldersCountCard'
 import { TokenTypeCard } from './TokenTypeCard'
 import { TokenTotalTransactionsCard } from './TokenTotalTransactionsCard'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { StyledGrid } from '../../components/Snapshots/Snapshot'
 
-export const TokenSnapshot: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenSnapshot: FC<{ scope: RuntimeScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const theme = useTheme()

--- a/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenSupplyCard.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 import { useTokenInfo } from './hook'
 import Skeleton from '@mui/material/Skeleton'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { RoundedBalance } from '../../components/RoundedBalance'
 
-export const TokenSupplyCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenSupplyCard: FC<{ scope: RuntimeScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)
 

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -6,11 +6,11 @@ import { VerificationIcon } from '../../components/ContractVerificationIcon'
 import { AccountLink } from '../../components/Account/AccountLink'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useTranslation } from 'react-i18next'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { HighlightedText } from '../../components/HighlightedText'
 import { TitleCard } from '../../components/PageLayout/TitleCard'
 
-export const TokenTitleCard: FC<{ scope: SearchScope; address: string; searchTerm: string }> = ({
+export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; searchTerm: string }> = ({
   scope,
   address,
   searchTerm,

--- a/src/app/pages/TokenDashboardPage/TokenTotalTransactionsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTotalTransactionsCard.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next'
 import Skeleton from '@mui/material/Skeleton'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 import { useTokenInfo } from './hook'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
-export const TokenTotalTransactionsCard: FC<{ scope: SearchScope; address: string }> = ({
+export const TokenTotalTransactionsCard: FC<{ scope: RuntimeScope; address: string }> = ({
   scope,
   address,
 }) => {

--- a/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTypeCard.tsx
@@ -7,9 +7,9 @@ import { COLORS } from '../../../styles/theme/colors'
 import { useTokenInfo } from './hook'
 import Skeleton from '@mui/material/Skeleton'
 import { getTokenTypeDescription, getTokenTypeStrictName } from '../../../types/tokens'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 
-export const TokenTypeCard: FC<{ scope: SearchScope; address: string }> = ({ scope, address }) => {
+export const TokenTypeCard: FC<{ scope: RuntimeScope; address: string }> = ({ scope, address }) => {
   const { t } = useTranslation()
 
   const { isLoading, token, isFetched } = useTokenInfo(scope, address)

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -5,19 +5,19 @@ import Divider from '@mui/material/Divider'
 import { TokenTitleCard } from './TokenTitleCard'
 import { TokenSnapshot } from './TokenSnapshot'
 import { TokenDetailsCard } from './TokenDetailsCard'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { useHref, useLoaderData, useOutletContext } from 'react-router-dom'
 import { useTokenInfo } from './hook'
 import { AppErrors } from '../../../types/errors'
 import { RouterTabs } from '../../components/RouterTabs'
 import { useTranslation } from 'react-i18next'
-import { SearchScope } from '../../../types/searchScope'
+import { RuntimeScope } from '../../../types/searchScope'
 import { DappBanner } from '../../components/DappBanner'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { codeContainerId, holdersContainerId, inventoryContainerId } from '../../utils/tabAnchors'
 
 export type TokenDashboardContext = {
-  scope: SearchScope
+  scope: RuntimeScope
   address: string
 }
 
@@ -26,7 +26,7 @@ export const useTokenDashboardProps = () => useOutletContext<TokenDashboardConte
 export const TokenDashboardPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
-  const scope = useRequiredScopeParam()
+  const scope = useRuntimeScope()
   const { address, searchTerm } = useLoaderData() as AddressLoaderData
 
   const { isError } = useTokenInfo(scope, address)

--- a/src/app/pages/TokensOverviewPage/index.tsx
+++ b/src/app/pages/TokensOverviewPage/index.tsx
@@ -5,13 +5,13 @@ import Divider from '@mui/material/Divider'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { PageLayout } from '../../components/PageLayout'
 import { SubPageCard } from '../../components/SubPageCard'
-import { EvmTokenType, Layer, useGetRuntimeEvmTokens } from '../../../oasis-nexus/api'
+import { EvmTokenType, useGetRuntimeEvmTokens } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { AppErrors } from '../../../types/errors'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { LoadMoreButton } from '../../components/LoadMoreButton'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { TokenList } from '../../components/Tokens/TokenList'
 import { TokenDetails } from '../../components/Tokens/TokenDetails'
 import { VerticalList } from '../../components/VerticalList'
@@ -29,13 +29,7 @@ export const TokensPage: FC = () => {
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * PAGE_SIZE
-  const scope = useRequiredScopeParam()
-  // Consensus is not yet enabled in ENABLED_LAYERS, just some preparation
-  if (scope.layer === Layer.consensus) {
-    throw AppErrors.UnsupportedLayer
-    // Listing the latest consensus blocks is not yet implemented.
-    // we should call useGetConsensusBlocks()
-  }
+  const scope = useRuntimeScope()
 
   useEffect(() => {
     if (!isMobile) {

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -13,6 +13,7 @@ import {
   useGetConsensusValidatorsAddress,
   Account,
   useGetConsensusAccountsAddress,
+  Layer,
 } from '../../../oasis-nexus/api'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { useFormattedTimestampStringWithDistance } from '../../hooks/useFormattedTimestamp'
@@ -172,7 +173,7 @@ export const ValidatorDetailsView: FC<{
           <dd>{validator.rank}</dd>
           <dt>{t('common.address')}</dt>
           <dd>
-            <AccountLink scope={{ network, layer: 'consensus' }} address={validator.entity_address} />
+            <AccountLink scope={{ network, layer: Layer.consensus }} address={validator.entity_address} />
           </dd>
           <dt>
             <strong>{t('account.totalBalance')}</strong>
@@ -261,7 +262,7 @@ export const ValidatorDetailsView: FC<{
               <dd>
                 <AccountLink
                   alwaysTrimOnTablet
-                  scope={{ network, layer: 'consensus' }}
+                  scope={{ network, layer: Layer.consensus }}
                   address={getOasisAddressFromBase64PublicKey(validator.node_id)}
                 />
               </dd>

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -54,28 +54,28 @@ declare module './generated/api' {
     amount: string | undefined
     to: string | undefined
     network: Network
-    layer: Layer
+    layer: typeof Layer.consensus
     ticker: Ticker
   }
 
   export interface RuntimeTransaction {
     network: Network
-    layer: Layer
+    layer: Runtime
   }
 
   export interface Block {
     network: Network
-    layer: Layer
+    layer: typeof Layer.consensus
   }
 
   export interface RuntimeBlock {
     network: Network
-    layer: Layer
+    layer: Runtime
   }
 
   export interface Account {
     network: Network
-    layer: Layer
+    layer: typeof Layer.consensus
     ticker: Ticker
     size: string
     total: string
@@ -83,14 +83,14 @@ declare module './generated/api' {
 
   export interface RuntimeAccount {
     network: Network
-    layer: Layer
+    layer: Runtime
     address_eth?: string
     tokenBalances: Partial<Record<EvmTokenType, generated.RuntimeEvmBalance[]>>
   }
 
   export interface RuntimeEvent {
     network: Network
-    layer: Layer
+    layer: Runtime
   }
 
   export interface EvmAbiParam {
@@ -105,12 +105,12 @@ declare module './generated/api' {
 
   export interface EvmToken {
     network: Network
-    layer: Layer
+    layer: Runtime
   }
 
   export interface BareTokenHolder {
     network: Network
-    layer: Layer
+    layer: Runtime
     rank: number
   }
 
@@ -150,7 +150,7 @@ declare module './generated/api' {
   }
 
   export interface RoflApp {
-    layer: typeof Layer.sapphire
+    layer: Runtime
     network: Network
     ticker: Ticker
   }
@@ -1495,7 +1495,7 @@ export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (
   params?,
   options?,
 ) => {
-  const ticker = getTokensForScope({ network, layer: Layer.sapphire })[0].ticker
+  const ticker = getTokensForScope({ network, layer })[0].ticker
   return generated.useGetRuntimeRoflApps(network, layer, params, {
     ...options,
     request: {
@@ -1511,7 +1511,7 @@ export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (
                 ...app,
                 stake: app.stake ? fromBaseUnits(app.stake, paraTimesConfig.sapphire.decimals) : undefined,
                 network,
-                layer: Layer.sapphire,
+                layer,
                 ticker,
               }
             }),
@@ -1529,7 +1529,7 @@ export const useGetRuntimeRoflAppsId: typeof generated.useGetRuntimeRoflAppsId =
   id,
   options?,
 ) => {
-  const ticker = getTokensForScope({ network, layer: Layer.sapphire })[0].ticker
+  const ticker = getTokensForScope({ network, layer })[0].ticker
   return generated.useGetRuntimeRoflAppsId(network, layer, id, {
     ...options,
     request: {
@@ -1542,7 +1542,7 @@ export const useGetRuntimeRoflAppsId: typeof generated.useGetRuntimeRoflAppsId =
             ...data,
             stake: data.stake ? fromBaseUnits(data.stake, paraTimesConfig.sapphire.decimals) : undefined,
             network,
-            layer: Layer.sapphire,
+            layer,
             ticker,
           }
         },

--- a/src/types/searchScope.ts
+++ b/src/types/searchScope.ts
@@ -1,12 +1,24 @@
 import { getNetworkNames, Network } from './network'
 import { getLayerLabels } from '../app/utils/content'
-import { HasScope, Layer } from '../oasis-nexus/api'
+import { HasScope, Layer, Runtime } from '../oasis-nexus/api'
 import { TFunction } from 'i18next'
 import { specialScopeNames } from '../config'
 
 export interface SearchScope {
   network: Network
   layer: Layer
+}
+
+// This is just like SearchScope, but we know that it's not consensus
+export interface RuntimeScope {
+  network: Network
+  layer: Runtime
+}
+
+// This is just like SearchScope, but we know it's consensus
+export interface ConsensusScope {
+  network: Network
+  layer: typeof Layer.consensus
 }
 
 export const MainnetEmerald: SearchScope = {


### PR DESCRIPTION
- Replace string literals with proper constants
- Introduce ConsensusScope and RuntimeScope
  for situations when we expect a specific type of scope.
- Introduce useRuntimeScope() and useConsensusScope()
  hooks which verify that we have the right kind of scope.
  (This makes checking in the individual components unnecessary.)
- Remove hard-wiring "sapphire" for all rofl-related pages
  (We already have feature flags for runtimes to enable/disable rofl)