### PR TITLE
Improve consensus dashboard resilience

### DIFF
--- a/.changelog/2004.feature.md
+++ b/.changelog/2004.feature.md
@@ -1,0 +1,1 @@
+Improve Consensus dashboard resilience

--- a/src/app/components/ErrorBoundary/index.tsx
+++ b/src/app/components/ErrorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import { Component, ReactNode } from 'react'
 import { ErrorDisplay } from '../ErrorDisplay'
 
 type HasChildren = {
@@ -7,6 +7,7 @@ type HasChildren = {
 
 type ErrorBoundaryProps = HasChildren & {
   light?: boolean
+  fallbackContent?: ReactNode
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boolean; error?: unknown }> {
@@ -21,7 +22,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boo
 
   render() {
     if (this.state.hasError) {
-      return <ErrorDisplay error={this.state.error} light={this.props.light} />
+      return this.props.fallbackContent ?? <ErrorDisplay error={this.state.error} light={this.props.light} />
     }
 
     return this.props.children

--- a/src/app/components/TransactionsStats/index.tsx
+++ b/src/app/components/TransactionsStats/index.tsx
@@ -14,11 +14,14 @@ import { CardHeaderWithResponsiveActions } from '../../components/CardHeaderWith
 import { ChartDuration } from '../../utils/chart-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { SearchScope } from '../../../types/searchScope'
+import { ErrorBoundary } from '../ErrorBoundary'
 
-export const TransactionsStats: FC<{ scope: SearchScope }> = ({ scope }) => {
+const TransactionsStatsContent: FC<{ scope: SearchScope; chartDuration: ChartDuration }> = ({
+  scope,
+  chartDuration,
+}) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
-  const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = durationToQueryParams[chartDuration]
 
   const dailyVolumeQuery = useGetLayerStatsTxVolume(scope.network, scope.layer, statsParams, {
@@ -41,6 +44,32 @@ export const TransactionsStats: FC<{ scope: SearchScope }> = ({ scope }) => {
     : undefined
 
   return (
+    windows && (
+      <BarChart
+        barSize={chartDuration === ChartDuration.WEEK ? 125 : undefined}
+        barRadius={chartDuration === ChartDuration.WEEK ? 20 : undefined}
+        cartesianGrid
+        data={windows.slice().reverse()}
+        dataKey="tx_volume"
+        formatters={{
+          data: (value: number) => t('transactionStats.perDay', { value: value.toLocaleString() }),
+          label: (value: string) =>
+            t('common.formattedDateTime', {
+              timestamp: new Date(value),
+              formatParams,
+            }),
+        }}
+        withLabels
+        margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
+      />
+    )
+  )
+}
+
+export const TransactionsStats: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { t } = useTranslation()
+  const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
+  return (
     <Card>
       <CardHeaderWithResponsiveActions
         action={<DurationPills handleChange={setChartDuration} value={chartDuration} />}
@@ -49,25 +78,9 @@ export const TransactionsStats: FC<{ scope: SearchScope }> = ({ scope }) => {
         title={t('transactionStats.header')}
       />
       <CardContent sx={{ height: 450 }}>
-        {windows && (
-          <BarChart
-            barSize={chartDuration === ChartDuration.WEEK ? 125 : undefined}
-            barRadius={chartDuration === ChartDuration.WEEK ? 20 : undefined}
-            cartesianGrid
-            data={windows.slice().reverse()}
-            dataKey="tx_volume"
-            formatters={{
-              data: (value: number) => t('transactionStats.perDay', { value: value.toLocaleString() }),
-              label: (value: string) =>
-                t('common.formattedDateTime', {
-                  timestamp: new Date(value),
-                  formatParams,
-                }),
-            }}
-            withLabels
-            margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
-          />
-        )}
+        <ErrorBoundary light={true}>
+          <TransactionsStatsContent scope={scope} chartDuration={chartDuration} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/AccountsCard.tsx
+++ b/src/app/pages/ConsensusDashboardPage/AccountsCard.tsx
@@ -11,15 +11,26 @@ import { COLORS } from '../../../styles/theme/colors'
 import { SearchScope } from '../../../types/searchScope'
 import { AccountList } from 'app/components/AccountList'
 import { RouteUtils } from 'app/utils/route-utils'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const AccountsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
-  const { t } = useTranslation()
+const AccountsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { network } = scope
   // TODO: Add query param to sort by rank when API is ready
   const accountsQuery = useGetConsensusAccounts(network, { limit })
+  return (
+    <AccountList
+      accounts={accountsQuery.data?.data.accounts}
+      isLoading={accountsQuery.isLoading}
+      limit={limit}
+      pagination={false}
+    />
+  )
+}
 
+export const AccountsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { t } = useTranslation()
   return (
     <Card>
       <CardHeader
@@ -37,12 +48,9 @@ export const AccountsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <AccountList
-          accounts={accountsQuery.data?.data.accounts}
-          isLoading={accountsQuery.isLoading}
-          limit={limit}
-          pagination={false}
-        />
+        <ErrorBoundary light={true}>
+          <AccountsContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/AccountsCard.tsx
+++ b/src/app/pages/ConsensusDashboardPage/AccountsCard.tsx
@@ -8,14 +8,14 @@ import Link from '@mui/material/Link'
 import { useGetConsensusAccounts } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope } from '../../../types/searchScope'
 import { AccountList } from 'app/components/AccountList'
 import { RouteUtils } from 'app/utils/route-utils'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-const AccountsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+const AccountsContent: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { network } = scope
   // TODO: Add query param to sort by rank when API is ready
   const accountsQuery = useGetConsensusAccounts(network, { limit })
@@ -29,7 +29,7 @@ const AccountsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
   )
 }
 
-export const AccountsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const AccountsCard: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { t } = useTranslation()
   return (
     <Card>

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusBlocks.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusBlocks.tsx
@@ -12,12 +12,12 @@ import { COLORS } from '../../../styles/theme/colors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { SearchScope } from '../../../types/searchScope'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const LatestConsensusBlocks: FC<{ scope: SearchScope }> = ({ scope }) => {
+const LatestConsensusBlocksContent: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
-  const { t } = useTranslation()
   const { network } = scope
   const blocksQuery = useGetConsensusBlocks(
     network,
@@ -28,6 +28,19 @@ export const LatestConsensusBlocks: FC<{ scope: SearchScope }> = ({ scope }) => 
       },
     },
   )
+  return (
+    <ConsensusBlocks
+      isLoading={blocksQuery.isLoading}
+      blocks={blocksQuery.data?.data.blocks}
+      limit={limit}
+      pagination={false}
+      showHash={!isMobile}
+    />
+  )
+}
+
+export const LatestConsensusBlocks: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { t } = useTranslation()
 
   return (
     <Card sx={{ flex: 1 }}>
@@ -45,14 +58,11 @@ export const LatestConsensusBlocks: FC<{ scope: SearchScope }> = ({ scope }) => 
           </Link>
         }
       />
+
       <CardContent>
-        <ConsensusBlocks
-          isLoading={blocksQuery.isLoading}
-          blocks={blocksQuery.data?.data.blocks}
-          limit={limit}
-          pagination={false}
-          showHash={!isMobile}
-        />
+        <ErrorBoundary light={true}>
+          <LatestConsensusBlocksContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusBlocks.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusBlocks.tsx
@@ -11,12 +11,12 @@ import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope } from '../../../types/searchScope'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-const LatestConsensusBlocksContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+const LatestConsensusBlocksContent: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
   const { network } = scope
   const blocksQuery = useGetConsensusBlocks(
@@ -39,7 +39,7 @@ const LatestConsensusBlocksContent: FC<{ scope: SearchScope }> = ({ scope }) => 
   )
 }
 
-export const LatestConsensusBlocks: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const LatestConsensusBlocks: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { t } = useTranslation()
 
   return (

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -20,14 +20,13 @@ import {
 import Box from '@mui/material/Box'
 import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
-export const LatestConsensusTransactions: FC<{
+const LatestConsensusTransactionsContent: FC<{
   scope: SearchScope
   method: ConsensusTxMethodFilterOption
   setMethod: (value: ConsensusTxMethodFilterOption) => void
 }> = ({ scope, method, setMethod }) => {
-  const { isMobile } = useScreenSize()
-  const { t } = useTranslation()
   const { network } = scope
 
   const transactionsQuery = useGetConsensusTransactions(
@@ -43,6 +42,25 @@ export const LatestConsensusTransactions: FC<{
     },
   )
 
+  return (
+    <ConsensusTransactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={limit}
+      pagination={false}
+      verbose={false}
+      filtered={method !== 'any'}
+    />
+  )
+}
+
+export const LatestConsensusTransactions: FC<{
+  scope: SearchScope
+  method: ConsensusTxMethodFilterOption
+  setMethod: (value: ConsensusTxMethodFilterOption) => void
+}> = ({ scope, method, setMethod }) => {
+  const { isMobile } = useScreenSize()
+  const { t } = useTranslation()
   return (
     <Card>
       <CardHeader
@@ -72,14 +90,9 @@ export const LatestConsensusTransactions: FC<{
         <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />
       )}
       <CardContent>
-        <ConsensusTransactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={limit}
-          pagination={false}
-          verbose={false}
-          filtered={method !== 'any'}
-        />
+        <ErrorBoundary light={true}>
+          <LatestConsensusTransactionsContent scope={scope} method={method} setMethod={setMethod} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -6,7 +6,7 @@ import CardContent from '@mui/material/CardContent'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
 import { useGetConsensusTransactions } from '../../../oasis-nexus/api'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope } from '../../../types/searchScope'
 import { ConsensusTransactions } from '../../components/Transactions'
 import {
   NUMBER_OF_ITEMS_ON_DASHBOARD as limit,
@@ -23,10 +23,10 @@ import { useScreenSize } from '../../hooks/useScreensize'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const LatestConsensusTransactionsContent: FC<{
-  scope: SearchScope
+  scope: ConsensusScope
   method: ConsensusTxMethodFilterOption
   setMethod: (value: ConsensusTxMethodFilterOption) => void
-}> = ({ scope, method, setMethod }) => {
+}> = ({ scope, method }) => {
   const { network } = scope
 
   const transactionsQuery = useGetConsensusTransactions(
@@ -55,7 +55,7 @@ const LatestConsensusTransactionsContent: FC<{
 }
 
 export const LatestConsensusTransactions: FC<{
-  scope: SearchScope
+  scope: ConsensusScope
   method: ConsensusTxMethodFilterOption
   setMethod: (value: ConsensusTxMethodFilterOption) => void
 }> = ({ scope, method, setMethod }) => {

--- a/src/app/pages/ConsensusDashboardPage/NetworkProposalsCard.tsx
+++ b/src/app/pages/ConsensusDashboardPage/NetworkProposalsCard.tsx
@@ -8,14 +8,14 @@ import Link from '@mui/material/Link'
 import { useGetConsensusProposals } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope } from '../../../types/searchScope'
 import { NetworkProposalsList } from '../../components/NetworkProposalsList'
 import { RouteUtils } from 'app/utils/route-utils'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-const NetworkProposalsCardContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+const NetworkProposalsCardContent: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { network } = scope
   const proposalsQuery = useGetConsensusProposals(network, { limit })
 
@@ -29,7 +29,7 @@ const NetworkProposalsCardContent: FC<{ scope: SearchScope }> = ({ scope }) => {
   )
 }
 
-export const NetworkProposalsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const NetworkProposalsCard: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network } = scope
 

--- a/src/app/pages/ConsensusDashboardPage/NetworkProposalsCard.tsx
+++ b/src/app/pages/ConsensusDashboardPage/NetworkProposalsCard.tsx
@@ -11,13 +11,27 @@ import { COLORS } from '../../../styles/theme/colors'
 import { SearchScope } from '../../../types/searchScope'
 import { NetworkProposalsList } from '../../components/NetworkProposalsList'
 import { RouteUtils } from 'app/utils/route-utils'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
+
+const NetworkProposalsCardContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { network } = scope
+  const proposalsQuery = useGetConsensusProposals(network, { limit })
+
+  return (
+    <NetworkProposalsList
+      proposals={proposalsQuery.data?.data.proposals}
+      isLoading={proposalsQuery.isLoading}
+      limit={limit}
+      pagination={false}
+    />
+  )
+}
 
 export const NetworkProposalsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network } = scope
-  const proposalsQuery = useGetConsensusProposals(network, { limit })
 
   return (
     <Card>
@@ -36,12 +50,9 @@ export const NetworkProposalsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <NetworkProposalsList
-          proposals={proposalsQuery.data?.data.proposals}
-          isLoading={proposalsQuery.isLoading}
-          limit={limit}
-          pagination={false}
-        />
+        <ErrorBoundary light={true}>
+          <NetworkProposalsCardContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/RuntimePreview.tsx
+++ b/src/app/pages/ConsensusDashboardPage/RuntimePreview.tsx
@@ -22,6 +22,7 @@ import { ChartDuration } from '../../utils/chart-utils'
 import { Network } from '../../../types/network'
 import { TransactionsChartCard } from '../ParatimeDashboardPage/TransactionsChartCard'
 import { ActiveAccounts } from '../ParatimeDashboardPage/ActiveAccounts'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const StyledList = styled(InlineDescriptionList)(({ theme }) => ({
   marginBottom: theme.spacing(4),
@@ -92,7 +93,7 @@ type RuntimeProps = {
   runtime: Runtime
 }
 
-export const EnabledRuntimePreview: FC<RuntimeProps> = ({ prominentItem, network, runtime }) => {
+export const EnabledRuntimePreviewContent: FC<RuntimeProps> = ({ prominentItem, network, runtime }) => {
   const query = useGetRuntimeStatus(network, runtime)
   const { outOfDate } = useRuntimeFreshness({
     network,
@@ -111,6 +112,15 @@ export const EnabledRuntimePreview: FC<RuntimeProps> = ({ prominentItem, network
         outOfDate,
       }}
     />
+  )
+}
+
+export const EnabledRuntimePreview: FC<RuntimeProps> = ({ prominentItem, network, runtime }) => {
+  const { t } = useTranslation()
+  return (
+    <ErrorBoundary light={true} fallbackContent={<b>{t('paratimes.canNotReadStatus', { name: runtime })}</b>}>
+      <EnabledRuntimePreviewContent network={network} runtime={runtime} prominentItem={prominentItem} />
+    </ErrorBoundary>
   )
 }
 

--- a/src/app/pages/ConsensusDashboardPage/Validators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/Validators.tsx
@@ -12,10 +12,11 @@ import { COLORS } from '../../../styles/theme/colors'
 import { SearchScope } from '../../../types/searchScope'
 import { RouteUtils } from 'app/utils/route-utils'
 import { CardHeaderWithCounter } from '../../components/CardHeaderWithCounter'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+const ValidatorsTitle: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network } = scope
 
@@ -23,16 +24,41 @@ export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
   const validators = validatorsQuery.data?.data
 
   return (
+    <CardHeaderWithCounter
+      label={t('validator.listTitle')}
+      totalCount={validators?.total_count}
+      isTotalCountClipped={validators?.is_total_count_clipped}
+    />
+  )
+}
+
+const ValidatorsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { network } = scope
+  const validatorsQuery = useGetConsensusValidators(network, { limit })
+
+  return (
+    <Validators
+      validators={validatorsQuery.data?.data.validators}
+      stats={validatorsQuery.data?.data.stats}
+      isLoading={validatorsQuery.isLoading}
+      limit={limit}
+      pagination={false}
+    />
+  )
+}
+
+export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+  const { t } = useTranslation()
+
+  return (
     <Card>
       <CardHeader
         disableTypography
         component="h3"
         title={
-          <CardHeaderWithCounter
-            label={t('validator.listTitle')}
-            totalCount={validators?.total_count}
-            isTotalCountClipped={validators?.is_total_count_clipped}
-          />
+          <ErrorBoundary fallbackContent={t('validator.listTitle')}>
+            <ValidatorsTitle scope={scope} />
+          </ErrorBoundary>
         }
         action={
           <Link
@@ -45,13 +71,9 @@ export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <Validators
-          validators={validatorsQuery.data?.data.validators}
-          stats={validatorsQuery.data?.data.stats}
-          isLoading={validatorsQuery.isLoading}
-          limit={limit}
-          pagination={false}
-        />
+        <ErrorBoundary light={true}>
+          <ValidatorsContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ConsensusDashboardPage/Validators.tsx
+++ b/src/app/pages/ConsensusDashboardPage/Validators.tsx
@@ -9,14 +9,14 @@ import { useGetConsensusValidators } from '../../../oasis-nexus/api'
 import { Validators } from '../../components/Validators'
 import { NUMBER_OF_ITEMS_ON_DASHBOARD } from '../../../config'
 import { COLORS } from '../../../styles/theme/colors'
-import { SearchScope } from '../../../types/searchScope'
+import { ConsensusScope } from '../../../types/searchScope'
 import { RouteUtils } from 'app/utils/route-utils'
 import { CardHeaderWithCounter } from '../../components/CardHeaderWithCounter'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-const ValidatorsTitle: FC<{ scope: SearchScope }> = ({ scope }) => {
+const ValidatorsTitle: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { t } = useTranslation()
   const { network } = scope
 
@@ -32,7 +32,7 @@ const ValidatorsTitle: FC<{ scope: SearchScope }> = ({ scope }) => {
   )
 }
 
-const ValidatorsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
+const ValidatorsContent: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { network } = scope
   const validatorsQuery = useGetConsensusValidators(network, { limit })
 
@@ -47,7 +47,7 @@ const ValidatorsContent: FC<{ scope: SearchScope }> = ({ scope }) => {
   )
 }
 
-export const ValidatorsCard: FC<{ scope: SearchScope }> = ({ scope }) => {
+export const ValidatorsCard: FC<{ scope: ConsensusScope }> = ({ scope }) => {
   const { t } = useTranslation()
 
   return (

--- a/src/app/pages/ConsensusDashboardPage/index.tsx
+++ b/src/app/pages/ConsensusDashboardPage/index.tsx
@@ -7,7 +7,7 @@ import { useScreenSize } from '../../hooks/useScreensize'
 import { TotalTransactions } from '../../components/TotalTransactions'
 import { TransactionsStats } from '../../components/TransactionsStats'
 import { Social } from '../../components/Social'
-import { useRequiredScopeParam } from '../../hooks/useScopeParam'
+import { useConsensusScope } from '../../hooks/useScopeParam'
 import { LearningMaterials } from './LearningMaterials'
 import { NetworkProposalsCard } from './NetworkProposalsCard'
 import { ValidatorsCard } from './Validators'
@@ -16,12 +16,12 @@ import { LatestConsensusBlocks } from './LatestConsensusBlocks'
 import { AccountsCard } from './AccountsCard'
 import { LatestConsensusTransactions } from './LatestConsensusTransactions'
 import { ParaTimesCard } from './ParaTimesCard'
-import { SearchScope } from 'types/searchScope'
+import { ConsensusScope } from 'types/searchScope'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 
 export const ConsensusDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
-  const scope = useRequiredScopeParam()
+  const scope = useConsensusScope()
   const isLocal = isLocalnet(scope.network)
   const { method, setMethod } = useConsensusTxMethodParam()
 
@@ -54,7 +54,7 @@ export const ConsensusDashboardPage: FC = () => {
   )
 }
 
-const LatestBlocksGrid = ({ scope }: { scope: SearchScope }) => {
+const LatestBlocksGrid = ({ scope }: { scope: ConsensusScope }) => {
   return (
     <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
       <LatestConsensusBlocks scope={scope} />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -676,7 +676,8 @@
     "listTitle": "ParaTimes",
     "noData": "No data available",
     "nodes": "Nodes:",
-    "outdated": "Out-of-date"
+    "outdated": "Out-of-date",
+    "canNotReadStatus": "Can't load status paratime '{{name}}'."
   },
   "pontusx": {
     "devnet": "Pontus-X devnet",


### PR DESCRIPTION
Improves  #1999 

Now a failing query won't collapse the whole consensus dashboard, only the relevant card.
Every card has been split to two component, and the internal parts are now wrapped in the appropriate error boundaries.
The same could be done to the paratime dashboard, too.
Plus, the design could obviously improved, but this already avoids the collapsing of the whole board, so definitely improves the UX.

## Before, if any of the queries have a problem:

![image](https://github.com/user-attachments/assets/98dcd762-f4eb-43e2-a412-33c7c3c60f08)

Instead of this, now we get:

## Failing to load blocks:

![image](https://github.com/user-attachments/assets/8583b0c7-ca35-47a7-b27d-0d18dba04d0e)

## Failing to load validators:

![image](https://github.com/user-attachments/assets/3382fa9d-0db7-41f0-b7b0-c6ddd4f5a593)

## Failing to load paratimes:

![image](https://github.com/user-attachments/assets/26d155ac-0fb0-46fb-b50b-69a2a2d0fb42)

## Failing to load accounts:

![image](https://github.com/user-attachments/assets/c4c67556-f00a-4355-a3e1-7d63b6900d32)

## Failing to load transactions:

![image](https://github.com/user-attachments/assets/04dfc0de-82de-4031-92fc-3e56e50cf095)

## Network change proposals:

![image](https://github.com/user-attachments/assets/89fc118e-07b1-480a-b397-6d5942f226c6)

## TX Stats:

![image](https://github.com/user-attachments/assets/a0163018-8d2f-4772-9aa8-63effe37250c)