### PR TITLE
Support flexible searching for multiple words in random order (in all free-text search)

### DIFF
--- a/.changelog/2012.feature.md
+++ b/.changelog/2012.feature.md
@@ -1,0 +1,1 @@
+Enable flexible multi-word searching in names

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -10,7 +10,7 @@ import { useAccountMetadata } from '../../hooks/useAccountMetadata'
 import { trimLongString } from '../../utils/trimLongString'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import Box from '@mui/material/Box'
-import { HighlightedText } from '../HighlightedText'
+import { HighlightedText, HighlightPattern } from '../HighlightedText'
 import { AdaptiveHighlightedText } from '../HighlightedText/AdaptiveHighlightedText'
 import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { AccountMetadataSourceIndicator } from './AccountMetadataSourceIndicator'
@@ -62,7 +62,7 @@ interface Props {
   /**
    * What part of the name should be highlighted (if any)
    */
-  highlightedPartOfName?: string | undefined
+  highlightPattern?: HighlightPattern
 
   /**
    * Any extra tooltips to display
@@ -85,7 +85,7 @@ export const AccountLink: FC<Props> = ({
   address,
   alwaysTrim,
   alwaysTrimOnTablet,
-  highlightedPartOfName,
+  highlightPattern,
   extraTooltip,
   labelOnly,
 }) => {
@@ -158,7 +158,7 @@ export const AccountLink: FC<Props> = ({
               sx={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
             >
               <AccountMetadataSourceIndicator source={accountMetadata!.source} />
-              <HighlightedText text={accountName} pattern={highlightedPartOfName} /> ({address})
+              <HighlightedText text={accountName} pattern={highlightPattern} /> ({address})
             </Box>
           ) : (
             address
@@ -183,7 +183,7 @@ export const AccountLink: FC<Props> = ({
             <AdaptiveHighlightedText
               idPrefix="account-name"
               text={accountName}
-              pattern={highlightedPartOfName}
+              pattern={highlightPattern}
               extraTooltip={tooltipTitle}
               minLength={5}
             />

--- a/src/app/components/Account/ConsensusAccountDetailsView.tsx
+++ b/src/app/components/Account/ConsensusAccountDetailsView.tsx
@@ -14,6 +14,7 @@ import { AccountSizeBadge } from '../AccountSizeBadge'
 import { ConsensusAccountLink } from './ConsensusAccountLink'
 import { CopyToClipboard } from '../CopyToClipboard'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
+import { HighlightPattern } from '../HighlightedText'
 
 export const StyledListTitle = styled('dt')(({ theme }) => ({
   marginLeft: theme.spacing(4),
@@ -25,7 +26,7 @@ type ConsensusAccountDetailsViewProps = {
   isLoading?: boolean
   showLayer?: boolean
   standalone?: boolean
-  highlightedPartOfName?: string
+  highlightPattern?: HighlightPattern
 }
 
 export const ConsensusAccountDetailsView: FC<ConsensusAccountDetailsViewProps> = ({
@@ -34,7 +35,7 @@ export const ConsensusAccountDetailsView: FC<ConsensusAccountDetailsViewProps> =
   isLoading,
   showLayer,
   standalone,
-  highlightedPartOfName,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -64,7 +65,7 @@ export const ConsensusAccountDetailsView: FC<ConsensusAccountDetailsViewProps> =
           alwaysTrim={false}
           network={account.network}
           address={account.address}
-          highlightedPartOfName={highlightedPartOfName}
+          highlightPattern={highlightPattern}
         />
         <CopyToClipboard value={account.address} />
       </dd>

--- a/src/app/components/Account/ConsensusAccountLink.tsx
+++ b/src/app/components/Account/ConsensusAccountLink.tsx
@@ -3,13 +3,14 @@ import { Layer, useGetConsensusValidatorsAddressNameMap } from './../../../oasis
 import { Network } from '../../../types/network'
 import { ValidatorLink } from '../Validators/ValidatorLink'
 import { AccountLink } from './AccountLink'
+import { HighlightPattern } from '../HighlightedText'
 
 type ConsensusAccountLinkProps = {
   address: string
   alwaysTrim?: boolean
   labelOnly?: boolean
   network: Network
-  highlightedPartOfName?: string | undefined
+  highlightPattern?: HighlightPattern
 }
 
 export const ConsensusAccountLink: FC<ConsensusAccountLinkProps> = ({
@@ -17,7 +18,7 @@ export const ConsensusAccountLink: FC<ConsensusAccountLinkProps> = ({
   alwaysTrim = true,
   labelOnly,
   network,
-  highlightedPartOfName,
+  highlightPattern,
 }) => {
   const { data } = useGetConsensusValidatorsAddressNameMap(network)
 
@@ -27,7 +28,7 @@ export const ConsensusAccountLink: FC<ConsensusAccountLinkProps> = ({
         address={address}
         network={network}
         alwaysTrim={alwaysTrim}
-        highlightedPartOfName={highlightedPartOfName}
+        highlightPattern={highlightPattern}
       />
     )
   }
@@ -38,7 +39,7 @@ export const ConsensusAccountLink: FC<ConsensusAccountLinkProps> = ({
       scope={{ network, layer: Layer.consensus }}
       address={address}
       alwaysTrim={alwaysTrim}
-      highlightedPartOfName={highlightedPartOfName}
+      highlightPattern={highlightPattern}
     />
   )
 }

--- a/src/app/components/Account/RuntimeAccountDetailsView.tsx
+++ b/src/app/components/Account/RuntimeAccountDetailsView.tsx
@@ -25,6 +25,7 @@ import { extractMinimalProxyERC1167 } from '../ContractVerificationIcon/extractM
 import { AbiPlaygroundLink } from '../ContractVerificationIcon/AbiPlaygroundLink'
 import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
+import { HighlightPattern } from '../HighlightedText'
 
 type RuntimeAccountDetailsViewProps = {
   isLoading?: boolean
@@ -33,7 +34,7 @@ type RuntimeAccountDetailsViewProps = {
   token?: EvmToken
   tokenPrices: AllTokenPrices
   showLayer?: boolean
-  highlightedPartOfName?: string
+  highlightPattern?: HighlightPattern
 }
 
 export const RuntimeAccountDetailsView: FC<RuntimeAccountDetailsViewProps> = ({
@@ -43,7 +44,7 @@ export const RuntimeAccountDetailsView: FC<RuntimeAccountDetailsViewProps> = ({
   isError,
   tokenPrices,
   showLayer,
-  highlightedPartOfName,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -81,7 +82,7 @@ export const RuntimeAccountDetailsView: FC<RuntimeAccountDetailsViewProps> = ({
             showOnlyAddress={!!token?.name}
             scope={account}
             address={address!}
-            highlightedPartOfName={highlightedPartOfName}
+            highlightPattern={highlightPattern}
           />
           <CopyToClipboard value={address!} />
         </Box>

--- a/src/app/components/HighlightedText/AdaptiveHighlightedText.tsx
+++ b/src/app/components/HighlightedText/AdaptiveHighlightedText.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 import InfoIcon from '@mui/icons-material/Info'
-import { HighlightedText, HighlightOptions } from './index'
+import { HighlightedText, HighlightOptions, HighlightPattern } from './index'
 import { AdaptiveDynamicTrimmer } from '../AdaptiveTrimmer/AdaptiveDynamicTrimmer'
 import { HighlightedTrimmedText } from './HighlightedTrimmedText'
 
@@ -15,7 +15,7 @@ type AdaptiveHighlightedTextProps = {
   /**
    * The pattern to search for (and highlight)
    */
-  pattern: string | undefined
+  pattern?: HighlightPattern
 
   /**
    * Options for highlighting (case sensitivity, styling, etc.)

--- a/src/app/components/HighlightedText/HighlightedTrimmedText.tsx
+++ b/src/app/components/HighlightedText/HighlightedTrimmedText.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { HighlightedText, HighlightOptions } from './index'
+import { HighlightedText, HighlightOptions, HighlightPattern, NoHighlights } from './index'
 import { trimAroundMatch } from './text-trimming'
 
 type HighlightedTrimmedTextProps = {
@@ -12,7 +12,7 @@ type HighlightedTrimmedTextProps = {
   /**
    * The pattern to search for (and highlight)
    */
-  pattern: string | undefined
+  pattern?: HighlightPattern
 
   /**
    * Options for highlighting (case sensitivity, styling, etc.)
@@ -32,7 +32,7 @@ type HighlightedTrimmedTextProps = {
  * Display a text with a part highlighted, trimmed to a specific length around the highlight
  */
 export const HighlightedTrimmedText: FC<HighlightedTrimmedTextProps> = props => {
-  const { text, pattern, fragmentLength, options } = props
+  const { text, pattern = NoHighlights, fragmentLength, options } = props
   const { part, match } = trimAroundMatch(text, pattern, { fragmentLength })
   return <HighlightedText text={part} pattern={pattern} part={match} options={options} />
 }

--- a/src/app/components/HighlightedText/HighlightedTrimmedText.tsx
+++ b/src/app/components/HighlightedText/HighlightedTrimmedText.tsx
@@ -33,6 +33,6 @@ type HighlightedTrimmedTextProps = {
  */
 export const HighlightedTrimmedText: FC<HighlightedTrimmedTextProps> = props => {
   const { text, pattern = NoHighlights, fragmentLength, options } = props
-  const { part, match } = trimAroundMatch(text, pattern, { fragmentLength })
-  return <HighlightedText text={part} pattern={pattern} part={match} options={options} />
+  const { part } = trimAroundMatch(text, pattern, { fragmentLength })
+  return <HighlightedText text={part} pattern={pattern} options={options} />
 }

--- a/src/app/components/HighlightedText/index.tsx
+++ b/src/app/components/HighlightedText/index.tsx
@@ -35,6 +35,10 @@ const defaultHighlight: HighlightOptions = {
   sx: defaultHighlightStyle,
 }
 
+export type HighlightPattern = string | undefined
+
+export const NoHighlights: HighlightPattern = undefined
+
 interface HighlightedTextProps {
   /**
    * The text to display
@@ -44,7 +48,7 @@ interface HighlightedTextProps {
   /**
    * The pattern to search for (and highlight)
    */
-  pattern: string | undefined
+  pattern: HighlightPattern | undefined
 
   /**
    * Instructions about which part to highlight.
@@ -67,7 +71,7 @@ interface HighlightedTextProps {
  */
 export const HighlightedText: FC<HighlightedTextProps> = ({
   text,
-  pattern,
+  pattern = NoHighlights,
   part,
   options = defaultHighlight,
 }) => {

--- a/src/app/components/HighlightedText/index.tsx
+++ b/src/app/components/HighlightedText/index.tsx
@@ -89,29 +89,29 @@ export const HighlightedText: FC<HighlightedTextProps> = ({
 
   const pieces: ReactNode[] = []
   let processedChars = 0
-  let processedTasks = 0
+  let processedMatches = 0
 
   while (processedChars < text.length) {
-    // Do we still have tasks?
-    if (processedTasks < sortedMatches.length) {
-      // Yes, there are more tasks
-      const task = sortedMatches[processedTasks]
-      if (task.startPos < processedChars) {
-        // This task with collude
-        processedTasks++ // just skip this task
+    // Do we still have matches to highlight?
+    if (processedMatches < sortedMatches.length) {
+      // Yes, there are more matches
+      const match = sortedMatches[processedMatches]
+      if (match.startPos < processedChars) {
+        // This match would collude with something already highlighted
+        processedMatches++ // just skip this match
       } else {
-        // We use this task
-        pieces.push(text.substring(processedChars, task.startPos))
-        const focus = text.substring(task.startPos, task.endPos)
+        // We want to highlight this match
+        pieces.push(text.substring(processedChars, match.startPos))
+        const focus = text.substring(match.startPos, match.endPos)
         pieces.push(
-          <Box key={processedTasks} component="mark" sx={sx}>
+          <Box key={processedMatches} component="mark" sx={sx}>
             {focus}
           </Box>,
         )
-        processedChars = task.endPos
+        processedChars = match.endPos
       }
     } else {
-      // No more tasks, just grab the remaining string
+      // No more matches, just grab the remaining string
       pieces.push(text.substring(processedChars))
       processedChars = text.length
     }

--- a/src/app/components/HighlightedText/text-matching.ts
+++ b/src/app/components/HighlightedText/text-matching.ts
@@ -16,16 +16,18 @@ export type MatchInfo = PositiveMatchInfo | typeof NO_MATCH
 /**
  * Identify pattern matches within a corpus, also considering normalization
  *
+ * If there is no match, an empty array is returned.
+ *
  * NOTE: depending on normalization options, the string length can change,
  * and in that case, match position can be incorrect.
  */
-export const findTextMatch = (
+export const findTextMatches = (
   rawCorpus: string | null | undefined,
-  search: (string | undefined)[],
+  pattern: (string | undefined)[],
   options: NormalizerOptions = {},
-): MatchInfo => {
+): PositiveMatchInfo[] => {
   const normalizedCorpus = normalizeTextForSearch(rawCorpus || '', options)
-  const matches: PositiveMatchInfo[] = search
+  const matches: PositiveMatchInfo[] = pattern
     .filter((s): s is string => !!s)
     .map(rawPattern => {
       const normalizedPattern = normalizeTextForSearch(rawPattern!, options)
@@ -38,6 +40,23 @@ export const findTextMatch = (
         : 'NO_MATCH'
     })
     .filter((m): m is PositiveMatchInfo => m !== NO_MATCH)
+  return matches
+}
+
+/**
+ * Identify the first pattern match within a corpus, also considering normalization
+ *
+ * If there is no match, NO_MATCH is returned.
+ *
+ * NOTE: depending on normalization options, the string length can change,
+ * and in that case, match position can be incorrect.
+ */
+export const findTextMatch = (
+  rawCorpus: string | null | undefined,
+  search: (string | undefined)[],
+  options: NormalizerOptions = {},
+): MatchInfo => {
+  const matches = findTextMatches(rawCorpus, search, options)
   return matches[0] ?? NO_MATCH
 }
 

--- a/src/app/components/HighlightedText/text-matching.ts
+++ b/src/app/components/HighlightedText/text-matching.ts
@@ -61,13 +61,19 @@ export const findTextMatch = (
 }
 
 /**
- * Check if a pattern matches within a corpus, also considering normalization
+ * Check if all patterns match within a corpus, also considering normalization
  *
  * NOTE: depending on normalization options, the string length can change,
  * and in that case, match position can be incorrect.
+ *
+ * Also NOTE: if there are no patterns given, the result will be true.
+ *
  */
-export const hasTextMatch = (
+export const hasTextMatchesForAll = (
   rawCorpus: string | null | undefined,
-  search: (string | undefined)[],
+  patterns: (string | undefined)[],
   options: NormalizerOptions = {},
-): boolean => findTextMatch(rawCorpus, search, options) !== NO_MATCH
+): boolean =>
+  patterns
+    .filter(pattern => !!pattern)
+    .every(pattern => findTextMatch(rawCorpus, [pattern], options) !== NO_MATCH)

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -5,7 +5,7 @@ import MuiLink from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import { COLORS } from '../../../styles/theme/colors'
 import { trimLongString } from '../../utils/trimLongString'
-import { HighlightedText } from '../HighlightedText'
+import { HighlightedText, HighlightPattern } from '../HighlightedText'
 import Box from '@mui/material/Box'
 import { AccountMetadataSourceIndicator } from '../Account/AccountMetadataSourceIndicator'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
@@ -21,7 +21,7 @@ type LinkProps = {
   name?: string
   alwaysTrim?: boolean
   trimMode?: TrimMode
-  highlightedPartOfName?: string
+  highlightPattern?: HighlightPattern
   to: string
   withSourceIndicator?: boolean
   labelOnly?: boolean
@@ -32,7 +32,7 @@ export const Link: FC<LinkProps> = ({
   name,
   alwaysTrim,
   trimMode,
-  highlightedPartOfName,
+  highlightPattern,
   to,
   withSourceIndicator = true,
   labelOnly,
@@ -74,7 +74,7 @@ export const Link: FC<LinkProps> = ({
               address={address}
               name={name}
               to={to}
-              highlightedPart={highlightedPartOfName}
+              highlightPattern={highlightPattern}
               labelOnly={labelOnly}
               trimMode={trimMode}
             />
@@ -84,7 +84,7 @@ export const Link: FC<LinkProps> = ({
               alwaysTrim={alwaysTrim}
               name={name}
               to={to}
-              highlightedPart={highlightedPartOfName}
+              highlightPattern={highlightPattern}
               labelOnly={labelOnly}
               trimMode={trimMode}
             />
@@ -98,7 +98,7 @@ export const Link: FC<LinkProps> = ({
 type CustomTrimEndLinkLabelProps = {
   name: string
   to: string
-  highlightedPart?: string
+  highlightPattern?: HighlightPattern
   labelOnly?: boolean
   trimMode?: TrimMode
 }
@@ -112,15 +112,15 @@ const LinkLabel: FC<PropsWithChildren> = ({ children }) => (
 const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({
   name,
   to,
-  highlightedPart,
+  highlightPattern,
   labelOnly,
   trimMode,
 }) => {
   const label =
     trimMode === 'adaptive' ? (
-      <AdaptiveHighlightedText text={name} pattern={highlightedPart} minLength={14} debugMode={true} />
+      <AdaptiveHighlightedText text={name} pattern={highlightPattern} minLength={14} debugMode={true} />
     ) : (
-      <HighlightedTrimmedText text={name} pattern={highlightedPart} fragmentLength={14} />
+      <HighlightedTrimmedText text={name} pattern={highlightPattern} fragmentLength={14} />
     )
   return labelOnly ? (
     <LinkLabel>{label}</LinkLabel>
@@ -135,18 +135,18 @@ type TabletLinkProps = {
   address: string
   name?: string
   to: string
-  highlightedPart?: string
+  highlightPattern?: HighlightPattern
   labelOnly?: boolean
   trimMode?: TrimMode
 }
 
-const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightedPart, labelOnly, trimMode }) => {
+const TabletLink: FC<TabletLinkProps> = ({ address, name, to, highlightPattern, labelOnly, trimMode }) => {
   if (name) {
     return (
       <CustomTrimEndLinkLabel
         name={name}
         to={to}
-        highlightedPart={highlightedPart}
+        highlightPattern={highlightPattern}
         labelOnly={labelOnly}
         trimMode={trimMode}
       />
@@ -179,7 +179,7 @@ const DesktopLink: FC<DesktopLinkProps> = ({
   to,
   alwaysTrim,
   trimMode,
-  highlightedPart,
+  highlightPattern,
   labelOnly,
 }) => {
   if (alwaysTrim) {
@@ -189,7 +189,7 @@ const DesktopLink: FC<DesktopLinkProps> = ({
           <CustomTrimEndLinkLabel
             name={name}
             to={to}
-            highlightedPart={highlightedPart}
+            highlightPattern={highlightPattern}
             labelOnly={labelOnly}
             trimMode={trimMode}
           />
@@ -203,7 +203,7 @@ const DesktopLink: FC<DesktopLinkProps> = ({
       </WithHighlighting>
     )
   }
-  const label = name ? <HighlightedText text={name} pattern={highlightedPart} /> : address
+  const label = name ? <HighlightedText text={name} pattern={highlightPattern} /> : address
   return (
     <WithHighlighting address={address}>
       {labelOnly ? (

--- a/src/app/components/Rofl/RoflAppLink.tsx
+++ b/src/app/components/Rofl/RoflAppLink.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import { RouteUtils } from '../../utils/route-utils'
 import { Network } from '../../../types/network'
 import { Link, TrimMode } from '../Link'
+import { HighlightPattern } from '../HighlightedText'
 
 type RoflAppLinkProps = {
   id: string
@@ -9,7 +10,7 @@ type RoflAppLinkProps = {
   network: Network
   alwaysTrim?: boolean
   trimMode?: TrimMode
-  highlightedPartOfName?: string
+  highlightPattern?: HighlightPattern
   withSourceIndicator?: boolean
   labelOnly?: boolean
 }
@@ -20,7 +21,7 @@ export const RoflAppLink: FC<RoflAppLinkProps> = ({
   network,
   alwaysTrim,
   trimMode,
-  highlightedPartOfName,
+  highlightPattern,
   withSourceIndicator,
   labelOnly,
 }) => {
@@ -33,7 +34,7 @@ export const RoflAppLink: FC<RoflAppLinkProps> = ({
       to={to}
       alwaysTrim={alwaysTrim}
       trimMode={trimMode}
-      highlightedPartOfName={highlightedPartOfName}
+      highlightPattern={highlightPattern}
       withSourceIndicator={withSourceIndicator}
       labelOnly={labelOnly}
     />

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -111,6 +111,7 @@ export type ParsedSimpleSearchQuery = {
 export const textSearchMinimumLength = 3
 
 // A basic search strategy that searches for the whole text as a single token
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const simpleTextSearch = (input: string = '', t?: TFunction): ParsedSimpleSearchQuery => {
   const term = input.length >= textSearchMinimumLength ? input.toLowerCase() : undefined
   const warning =

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -10,6 +10,7 @@ import {
 import { RouteUtils, SpecifiedPerEnabledLayer } from '../../utils/route-utils'
 import { AppError, AppErrors } from '../../../types/errors'
 import { useNetworkParam } from '../../hooks/useScopeParam'
+import { HighlightPattern } from '../HighlightedText'
 
 type LayerSuggestions = {
   suggestedBlock: string
@@ -199,3 +200,5 @@ export const useParamSearch = () => {
 }
 
 export type SearchParams = ReturnType<typeof useParamSearch>
+
+export const getHighlightPattern = (searchQuery: string | undefined): HighlightPattern => searchQuery

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -164,8 +164,7 @@ const multiTermSearch =
 
 export const textSearch = {
   networkProposalName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
-  consensusAccountName: simpleTextSearch,
-  runtimeAccountName: simpleTextSearch,
+  accountName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   evmTokenName: simpleTextSearch,
   roflAppName: simpleTextSearch,
   validatorName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
@@ -225,11 +224,7 @@ export const validateAndNormalize = {
 
   networkProposalNameFragment: (searchTerm: string) => textSearch.networkProposalName(searchTerm).result,
 
-  accountNameFragment: (searchTerm: string) => {
-    if (searchTerm?.length >= textSearchMinimumLength) {
-      return searchTerm.toLowerCase()
-    }
-  },
+  accountNameFragment: (searchTerm: string) => textSearch.accountName(searchTerm).result,
 
   validatorNameFragment: (searchTerm: string) => textSearch.validatorName(searchTerm).result,
 } satisfies { [name: string]: (searchTerm: string) => string | string[] | undefined }

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -192,7 +192,7 @@ export const useParamSearch = () => {
   const query = useSearchParams()[0].get('q')?.trim() ?? ''
   const normalized = Object.fromEntries(
     Object.entries(validateAndNormalize).map(([key, fn]) => [key, fn(query)]),
-  ) as { [Key in keyof typeof validateAndNormalize]: string | undefined }
+  ) as { [Key in keyof typeof validateAndNormalize]: ReturnType<(typeof validateAndNormalize)[Key]> }
   return {
     query,
     ...normalized,

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -165,7 +165,7 @@ const multiTermSearch =
 export const textSearch = {
   networkProposalName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   accountName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
-  evmTokenName: simpleTextSearch,
+  evmTokenName: multiTermSearch(6), // Nexus limits the number of search queries to 6
   roflAppName: multiTermSearch(6), // Nexus limits the number of search queries to 6
   validatorName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   voterName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -168,8 +168,8 @@ export const textSearch = {
   runtimeAccountName: simpleTextSearch,
   evmTokenName: simpleTextSearch,
   roflAppName: simpleTextSearch,
-  validatorName: simpleTextSearch,
-  voterName: multiTermSearch(),  // This is client-side, therefore we can accept unlimited tokens
+  validatorName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
+  voterName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
 } as const
 
 export const validateAndNormalize = {

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -201,4 +201,7 @@ export const useParamSearch = () => {
 
 export type SearchParams = ReturnType<typeof useParamSearch>
 
-export const getHighlightPattern = (searchQuery: string | undefined): HighlightPattern => searchQuery
+export const getHighlightPattern = (searchQuery: string | undefined): HighlightPattern =>
+  (searchQuery === undefined)
+    ? []
+    : [searchQuery]

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -188,12 +188,12 @@ export const useParamSearch = () => {
     throw new AppError(AppErrors.InvalidUrl)
   }
 
-  const searchTerm = useSearchParams()[0].get('q')?.trim() ?? ''
+  const query = useSearchParams()[0].get('q')?.trim() ?? ''
   const normalized = Object.fromEntries(
-    Object.entries(validateAndNormalize).map(([key, fn]) => [key, fn(searchTerm)]),
+    Object.entries(validateAndNormalize).map(([key, fn]) => [key, fn(query)]),
   ) as { [Key in keyof typeof validateAndNormalize]: string | undefined }
   return {
-    searchTerm,
+    query,
     ...normalized,
   }
 }

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -169,7 +169,7 @@ export const textSearch = {
   evmTokenName: simpleTextSearch,
   roflAppName: simpleTextSearch,
   validatorName: simpleTextSearch,
-  voterName: simpleTextSearch,
+  voterName: multiTermSearch(),  // This is client-side, therefore we can accept unlimited tokens
 } as const
 
 export const validateAndNormalize = {

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -163,7 +163,7 @@ const multiTermSearch =
   }
 
 export const textSearch = {
-  networkProposalName: simpleTextSearch,
+  networkProposalName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   consensusAccountName: simpleTextSearch,
   runtimeAccountName: simpleTextSearch,
   evmTokenName: simpleTextSearch,

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -110,7 +110,7 @@ export type ParsedSimpleSearchQuery = {
 export const textSearchMinimumLength = 3
 
 // A basic search strategy that searches for the whole text as a single token
-export const textSearch = (input: string = '', t?: TFunction): ParsedSimpleSearchQuery => {
+const simpleTextSearch = (input: string = '', t?: TFunction): ParsedSimpleSearchQuery => {
   const term = input.length >= textSearchMinimumLength ? input.toLowerCase() : undefined
   const warning =
     !!input && input.length < textSearchMinimumLength
@@ -123,6 +123,16 @@ export const textSearch = (input: string = '', t?: TFunction): ParsedSimpleSearc
     warning,
   }
 }
+
+export const textSearch = {
+  networkProposalName: simpleTextSearch,
+  consensusAccountName: simpleTextSearch,
+  runtimeAccountName: simpleTextSearch,
+  evmTokenName: simpleTextSearch,
+  roflAppName: simpleTextSearch,
+  validatorName: simpleTextSearch,
+  voterName: simpleTextSearch,
+} as const
 
 export const validateAndNormalize = {
   blockHeight: (searchTerm: string) => {
@@ -162,7 +172,7 @@ export const validateAndNormalize = {
     }
   },
 
-  roflAppNameFragment: (searchTerm: string) => textSearch(searchTerm).result,
+  roflAppNameFragment: (searchTerm: string) => textSearch.roflAppName(searchTerm).result,
 
   evmAccount: (searchTerm: string): string | undefined => {
     if (isValidEthAddress(`0x${searchTerm}`)) {
@@ -173,9 +183,9 @@ export const validateAndNormalize = {
     }
   },
 
-  evmTokenNameFragment: (searchTerm: string) => textSearch(searchTerm).result,
+  evmTokenNameFragment: (searchTerm: string) => textSearch.evmTokenName(searchTerm).result,
 
-  networkProposalNameFragment: (searchTerm: string) => textSearch(searchTerm).result,
+  networkProposalNameFragment: (searchTerm: string) => textSearch.networkProposalName(searchTerm).result,
 
   accountNameFragment: (searchTerm: string) => {
     if (searchTerm?.length >= textSearchMinimumLength) {
@@ -183,7 +193,7 @@ export const validateAndNormalize = {
     }
   },
 
-  validatorNameFragment: (searchTerm: string) => textSearch(searchTerm).result,
+  validatorNameFragment: (searchTerm: string) => textSearch.validatorName(searchTerm).result,
 } satisfies { [name: string]: (searchTerm: string) => string | string[] | undefined }
 
 export function isSearchValid(searchTerm: string) {

--- a/src/app/components/Search/search-utils.ts
+++ b/src/app/components/Search/search-utils.ts
@@ -166,7 +166,7 @@ export const textSearch = {
   networkProposalName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   accountName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   evmTokenName: simpleTextSearch,
-  roflAppName: simpleTextSearch,
+  roflAppName: multiTermSearch(6), // Nexus limits the number of search queries to 6
   validatorName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
   voterName: multiTermSearch(), // This is client-side, therefore we can accept unlimited tokens
 } as const

--- a/src/app/components/Tokens/TokenDetails.tsx
+++ b/src/app/components/Tokens/TokenDetails.tsx
@@ -14,14 +14,15 @@ import { COLORS } from '../../../styles/theme/colors'
 import { TokenTypeTag } from './TokenList'
 import { RoundedBalance } from '../RoundedBalance'
 import { HighlightedText } from '../HighlightedText'
+import { HighlightPattern } from "../HighlightedText";
 
 export const TokenDetails: FC<{
   isLoading?: boolean
   token: EvmToken | undefined
   showLayer?: boolean
   standalone?: boolean
-  highlightedPartOfName: string | undefined
-}> = ({ isLoading, token, showLayer, standalone = false, highlightedPartOfName }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ isLoading, token, showLayer, standalone = false, highlightPattern}) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -44,10 +45,10 @@ export const TokenDetails: FC<{
           scope={token}
           address={token.eth_contract_addr ?? token.contract_addr}
           name={token.name}
-          highlightedPart={highlightedPartOfName}
+          highlightPattern={highlightPattern}
         />
         <Box sx={{ ml: 3, fontWeight: 700, color: COLORS.grayMedium, whiteSpace: 'nowrap' }}>
-          <HighlightedText text={token.symbol} pattern={highlightedPartOfName} />
+          <HighlightedText text={token.symbol} pattern={highlightPattern} />
         </Box>
       </dd>
 

--- a/src/app/components/Tokens/TokenDetails.tsx
+++ b/src/app/components/Tokens/TokenDetails.tsx
@@ -14,7 +14,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import { TokenTypeTag } from './TokenList'
 import { RoundedBalance } from '../RoundedBalance'
 import { HighlightedText } from '../HighlightedText'
-import { HighlightPattern } from "../HighlightedText";
+import { HighlightPattern } from '../HighlightedText'
 
 export const TokenDetails: FC<{
   isLoading?: boolean
@@ -22,7 +22,7 @@ export const TokenDetails: FC<{
   showLayer?: boolean
   standalone?: boolean
   highlightPattern?: HighlightPattern
-}> = ({ isLoading, token, showLayer, standalone = false, highlightPattern}) => {
+}> = ({ isLoading, token, showLayer, standalone = false, highlightPattern }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 

--- a/src/app/components/Tokens/TokenLink.tsx
+++ b/src/app/components/Tokens/TokenLink.tsx
@@ -4,17 +4,17 @@ import Link from '@mui/material/Link'
 
 import { RouteUtils } from '../../utils/route-utils'
 import { SearchScope } from '../../../types/searchScope'
-import { HighlightedText } from '../HighlightedText'
+import { HighlightedText, HighlightPattern } from '../HighlightedText'
 
 export const TokenLink: FC<{
   scope: SearchScope
   address: string
   name: string | undefined
-  highlightedPart?: string | undefined
-}> = ({ scope, address, name, highlightedPart }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ scope, address, name, highlightPattern }) => {
   return (
     <Link component={RouterLink} to={RouteUtils.getTokenRoute(scope, address)}>
-      {name ? <HighlightedText text={name} pattern={highlightedPart} /> : address}
+      {name ? <HighlightedText text={name} pattern={highlightPattern} /> : address}
     </Link>
   )
 }

--- a/src/app/components/Tokens/TokenLinkWithIcon.tsx
+++ b/src/app/components/Tokens/TokenLinkWithIcon.tsx
@@ -6,6 +6,7 @@ import { useAccountMetadata } from '../../hooks/useAccountMetadata'
 import Box from '@mui/material/Box'
 import { COLORS } from '../../../styles/theme/colors'
 import { InitialsAvatar } from '../AccountAvatar/InitialsAvatar'
+import { HighlightPattern } from '../HighlightedText'
 import Tooltip from '@mui/material/Tooltip'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -13,8 +14,8 @@ export const TokenLinkWithIcon: FC<{
   scope: SearchScope
   address: string
   name: string | undefined
-  highlightedPart?: string | undefined
-}> = ({ scope, address, name, highlightedPart }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ scope, address, name, highlightPattern }) => {
   const { t } = useTranslation()
   const { metadata } = useAccountMetadata(scope, address)
   return (
@@ -51,7 +52,7 @@ export const TokenLinkWithIcon: FC<{
           scope={scope}
           address={address}
           name={metadata?.name || name}
-          highlightedPart={highlightedPart}
+          highlightPattern={highlightPattern}
         />
         <Box component="span" sx={{ color: COLORS.grayMedium }}>
           {metadata?.origin && ` (${metadata.origin})`}

--- a/src/app/components/Validators/DeferredValidatorLink.tsx
+++ b/src/app/components/Validators/DeferredValidatorLink.tsx
@@ -3,14 +3,15 @@ import { Network } from '../../../types/network'
 import { Layer, Validator } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { ValidatorLink } from './ValidatorLink'
+import { HighlightPattern } from '../HighlightedText'
 
 export const DeferredValidatorLink: FC<{
   network: Network
   address: string
   validator: Validator | undefined
   isError: boolean
-  highlightedPart?: string | undefined
-}> = ({ network, address, validator, isError, highlightedPart }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ network, address, validator, isError, highlightPattern }) => {
   const scope: SearchScope = { network, layer: Layer.consensus }
 
   if (isError) {
@@ -22,7 +23,7 @@ export const DeferredValidatorLink: FC<{
       address={address}
       network={scope.network}
       name={validator?.media?.name}
-      highlightedPartOfName={highlightedPart}
+      highlightPattern={highlightPattern}
     />
   )
 }

--- a/src/app/components/Validators/ValidatorLink.tsx
+++ b/src/app/components/Validators/ValidatorLink.tsx
@@ -3,11 +3,12 @@ import { RouteUtils } from '../../utils/route-utils'
 import { Network } from '../../../types/network'
 import { useValidatorName } from '../../hooks/useValidatorName'
 import { Link } from '../../components/Link'
+import { HighlightPattern } from '../HighlightedText'
 
 type ValidatorLinkProps = {
   address: string
   alwaysTrim?: boolean
-  highlightedPartOfName?: string
+  highlightPattern?: HighlightPattern
   name?: string
   network: Network
   withSourceIndicator?: boolean
@@ -16,7 +17,7 @@ type ValidatorLinkProps = {
 export const ValidatorLink: FC<ValidatorLinkProps> = ({
   address,
   alwaysTrim,
-  highlightedPartOfName,
+  highlightPattern,
   name,
   network,
   withSourceIndicator,
@@ -29,7 +30,7 @@ export const ValidatorLink: FC<ValidatorLinkProps> = ({
     <Link
       address={address}
       alwaysTrim={alwaysTrim}
-      highlightedPartOfName={highlightedPartOfName}
+      highlightPattern={highlightPattern}
       name={displayName}
       to={to}
       withSourceIndicator={withSourceIndicator}

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -16,7 +16,7 @@ import {
   AccountNameSearchResults,
   AccountNameSearchRuntimeMatch,
 } from './named-accounts'
-import { hasTextMatch } from '../components/HighlightedText/text-matching'
+import { hasTextMatchesForAll } from '../components/HighlightedText/text-matching'
 import * as externalLinks from '../utils/externalLinks'
 import { getOasisAddress } from '../utils/helpers'
 import { isUrlSafe } from '../utils/url'
@@ -121,20 +121,18 @@ export const useSearchForOasisAccountsByName = (
     console.log('Failed to load Oasis account metadata', metadataError)
   }
 
-  const textMatcher =
-    nameFragments.length && queryOptions.enabled
-      ? (account: AccountMetadata) =>
-          nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
-      : () => false
-
   const matches =
-    namedAccounts?.list.filter(textMatcher).map(
-      (account): AccountNameSearchMatch => ({
-        network,
-        layer,
-        address: account.address,
-      }),
-    ) ?? []
+    !isMetadataLoading && nameFragments.length && queryOptions.enabled && namedAccounts
+      ? namedAccounts.list
+          .filter(account => hasTextMatchesForAll(account.name, nameFragments))
+          .map(
+            (account): AccountNameSearchMatch => ({
+              network,
+              layer,
+              address: account.address,
+            }),
+          )
+      : []
 
   const consensusMatches = layer === Layer.consensus ? (matches as AccountNameSearchConsensusMatch[]) : []
   const runtimeMatches = layer === Layer.consensus ? [] : (matches as AccountNameSearchRuntimeMatch[])

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -123,7 +123,8 @@ export const useSearchForOasisAccountsByName = (
 
   const textMatcher =
     nameFragments.length && queryOptions.enabled
-      ? (account: AccountMetadata) => nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
+      ? (account: AccountMetadata) =>
+          nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
       : () => false
 
   const matches =

--- a/src/app/data/oasis-account-names.ts
+++ b/src/app/data/oasis-account-names.ts
@@ -108,7 +108,7 @@ export const useOasisAccountMetadata = (
 export const useSearchForOasisAccountsByName = (
   network: Network,
   layer: Layer,
-  nameFragment: string,
+  nameFragments: string[],
   queryOptions: { enabled: boolean } & UseQueryOptions<AccountData, unknown, AccountData, string[]>,
 ): AccountNameSearchResults => {
   const {
@@ -122,8 +122,8 @@ export const useSearchForOasisAccountsByName = (
   }
 
   const textMatcher =
-    nameFragment && queryOptions.enabled
-      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+    nameFragments.length && queryOptions.enabled
+      ? (account: AccountMetadata) => nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
       : () => false
 
   const matches =

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -65,7 +65,7 @@ export const usePontusXAccountMetadata = (
 
 export const useSearchForPontusXAccountsByName = (
   network: Network,
-  nameFragment: string,
+  nameFragments: string[],
   queryOptions: { enabled: boolean } & UseQueryOptions<
     PontusXAccountsMetadata,
     unknown,
@@ -84,8 +84,8 @@ export const useSearchForPontusXAccountsByName = (
   }
 
   const textMatcher =
-    nameFragment && queryOptions.enabled
-      ? (account: AccountMetadata) => hasTextMatch(account.name, [nameFragment])
+    nameFragments.length && queryOptions.enabled
+      ? (account: AccountMetadata) => nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
       : () => false
 
   const matches =

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -9,7 +9,7 @@ import {
 } from './named-accounts'
 import { Layer, useGetRuntimeAccountsAddresses } from '../../oasis-nexus/api'
 import { Network } from '../../types/network'
-import { hasTextMatch } from '../components/HighlightedText/text-matching'
+import { hasTextMatchesForAll } from '../components/HighlightedText/text-matching'
 import { getOasisAddress } from '../utils/helpers'
 import * as externalLinks from '../utils/externalLinks'
 
@@ -83,22 +83,18 @@ export const useSearchForPontusXAccountsByName = (
     console.log('Failed to load Pontus-X account names', metadataError)
   }
 
-  const textMatcher =
-    nameFragments.length && queryOptions.enabled
-      ? (account: AccountMetadata) =>
-          nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
-      : () => false
-
   const matches =
-    isMetadataLoading || isMetadataLoading
+    isMetadataLoading || !nameFragments.length || !queryOptions.enabled
       ? undefined
-      : namedAccounts?.list.filter(textMatcher).map(
-          (account): AccountNameSearchRuntimeMatch => ({
-            network,
-            layer: Layer.pontusxtest,
-            address: account.address,
-          }),
-        )
+      : namedAccounts?.list
+          .filter(account => hasTextMatchesForAll(account.name, nameFragments))
+          .map(
+            (account): AccountNameSearchRuntimeMatch => ({
+              network,
+              layer: Layer.pontusxtest,
+              address: account.address,
+            }),
+          )
 
   const {
     isLoading: areAccountsLoading,

--- a/src/app/data/pontusx-account-names.ts
+++ b/src/app/data/pontusx-account-names.ts
@@ -85,7 +85,8 @@ export const useSearchForPontusXAccountsByName = (
 
   const textMatcher =
     nameFragments.length && queryOptions.enabled
-      ? (account: AccountMetadata) => nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
+      ? (account: AccountMetadata) =>
+          nameFragments.every(nameFragment => hasTextMatch(account.name, [nameFragment]))
       : () => false
 
   const matches =

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -50,16 +50,16 @@ export const useAccountMetadata = (scope: SearchScope, address: string): Account
 /** Doesn't throw if it fails. */
 export const useSearchForAccountsByName = (
   scope: SearchScope,
-  nameFragment = '',
+  nameFragments: string[],
 ): AccountNameSearchResults => {
   const isPontusX = scope.layer === Layer.pontusxtest || scope.layer === Layer.pontusxdev
-  const isValidPontusXSearch = isPontusX && !!nameFragment
-  const pontusXResults = useSearchForPontusXAccountsByName(scope.network, nameFragment, {
+  const isValidPontusXSearch = isPontusX && !!nameFragments.length
+  const pontusXResults = useSearchForPontusXAccountsByName(scope.network, nameFragments, {
     enabled: isValidPontusXSearch,
     useErrorBoundary: false,
   })
-  const isValidOasisSearch = !isPontusX && !!nameFragment
-  const oasisResults = useSearchForOasisAccountsByName(scope.network, scope.layer, nameFragment, {
+  const isValidOasisSearch = !isPontusX && !!nameFragments.length
+  const oasisResults = useSearchForOasisAccountsByName(scope.network, scope.layer, nameFragments, {
     enabled: isValidOasisSearch,
     useErrorBoundary: false,
   })

--- a/src/app/hooks/useSearchForValidatorsByName.ts
+++ b/src/app/hooks/useSearchForValidatorsByName.ts
@@ -1,4 +1,4 @@
-import { hasTextMatch } from 'app/components/HighlightedText/text-matching'
+import { hasTextMatchesForAll } from 'app/components/HighlightedText/text-matching'
 import {
   Layer,
   useGetConsensusValidatorsAddressNameMap,
@@ -10,13 +10,13 @@ import { AccountNameSearchResults, AccountNameSearchConsensusMatch } from '../da
 
 function findAddressesWithMatch(
   addressMap: ValidatorAddressNameMap,
-  nameFragment: string[],
+  nameFragments: string[],
   network: Network,
 ) {
   const matchedAddresses: AccountNameSearchConsensusMatch[] = []
 
   for (const [address, name] of Object.entries(addressMap)) {
-    if (nameFragment.every(nameFragment => hasTextMatch(name, [nameFragment]))) {
+    if (hasTextMatchesForAll(name, nameFragments)) {
       matchedAddresses.push({ address, layer: Layer.consensus, network })
     }
   }

--- a/src/app/hooks/useSearchForValidatorsByName.ts
+++ b/src/app/hooks/useSearchForValidatorsByName.ts
@@ -8,11 +8,15 @@ import {
 import { Network } from 'types/network'
 import { AccountNameSearchResults, AccountNameSearchConsensusMatch } from '../data/named-accounts'
 
-function findAddressesWithMatch(addressMap: ValidatorAddressNameMap, nameFragment: string, network: Network) {
+function findAddressesWithMatch(
+  addressMap: ValidatorAddressNameMap,
+  nameFragment: string[],
+  network: Network,
+) {
   const matchedAddresses: AccountNameSearchConsensusMatch[] = []
 
   for (const [address, name] of Object.entries(addressMap)) {
-    if (hasTextMatch(name, [nameFragment])) {
+    if (nameFragment.every(nameFragment => hasTextMatch(name, [nameFragment]))) {
       matchedAddresses.push({ address, layer: Layer.consensus, network })
     }
   }
@@ -22,10 +26,11 @@ function findAddressesWithMatch(addressMap: ValidatorAddressNameMap, nameFragmen
 
 export const useSearchForValidatorsByName = (
   network: Network,
-  nameFragment: string | undefined,
+  nameFragment: string[],
 ): AccountNameSearchResults => {
   const { isLoading, isError, data } = useGetConsensusValidatorsAddressNameMap(network)
-  const matches = data?.data && nameFragment ? findAddressesWithMatch(data?.data, nameFragment, network) : []
+  const matches =
+    data?.data && !!nameFragment.length ? findAddressesWithMatch(data?.data, nameFragment, network) : []
   const {
     isLoading: areConsensusAccountsLoading,
     isError: areConsensusAccountsError,

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
@@ -3,19 +3,20 @@ import { useTranslation } from 'react-i18next'
 import { Account } from '../../../oasis-nexus/api'
 import { SubPageCard } from '../../components/SubPageCard'
 import { ConsensusAccountDetailsView } from '../../components/Account/ConsensusAccountDetailsView'
+import { HighlightPattern } from "../.../../../components/HighlightedText"
 
 type ConsensusAccountDetailsCardProps = {
   account: Account | undefined
   isError: boolean
   isLoading: boolean
-  highlightedPartOfName?: string | undefined
+  highlightPattern: HighlightPattern,
 }
 
 export const ConsensusAccountDetailsCard: FC<ConsensusAccountDetailsCardProps> = ({
   account,
   isError,
   isLoading,
-  highlightedPartOfName,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
 
@@ -25,7 +26,7 @@ export const ConsensusAccountDetailsCard: FC<ConsensusAccountDetailsCardProps> =
         isError={isError}
         isLoading={isLoading}
         account={account}
-        highlightedPartOfName={highlightedPartOfName}
+        highlightPattern={highlightPattern}
       />
     </SubPageCard>
   )

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountDetailsCard.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Account } from '../../../oasis-nexus/api'
 import { SubPageCard } from '../../components/SubPageCard'
 import { ConsensusAccountDetailsView } from '../../components/Account/ConsensusAccountDetailsView'
-import { HighlightPattern } from "../.../../../components/HighlightedText"
+import { HighlightPattern } from '../.../../../components/HighlightedText'
 
 type ConsensusAccountDetailsCardProps = {
   account: Account | undefined
   isError: boolean
   isLoading: boolean
-  highlightPattern: HighlightPattern,
+  highlightPattern: HighlightPattern
 }
 
 export const ConsensusAccountDetailsCard: FC<ConsensusAccountDetailsCardProps> = ({

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -22,7 +22,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(textSearch.consensusAccountName(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
   const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -20,7 +20,8 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const { network } = scope
-  const { address, searchTerm } = useLoaderData() as AddressLoaderData
+  const { address, searchQuery } = useLoaderData() as AddressLoaderData
+  const highlightPattern = searchQuery
   const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
@@ -35,7 +36,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
         account={account}
         isError={isError}
         isLoading={isLoading}
-        highlightedPartOfName={searchTerm}
+        highlightPattern={highlightPattern}
       />
       <Grid container spacing={4} sx={{ mb: isMobile ? 4 : 5 }}>
         <Grid item xs={12} md={6}>

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -14,7 +14,7 @@ import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from "../../components/Search/search-utils";
 
 export const ConsensusAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -22,7 +22,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(searchQuery)
+  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
   const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -14,7 +14,7 @@ import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
-import { getHighlightPattern, textSearch } from "../../components/Search/search-utils";
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export const ConsensusAccountDetailsPage: FC = () => {
   const { t } = useTranslation()

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -14,6 +14,7 @@ import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export const ConsensusAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
@@ -21,7 +22,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = searchQuery
+  const highlightPattern = getHighlightPattern(searchQuery)
   const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -22,7 +22,7 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const scope = useRequiredScopeParam()
   const { network } = scope
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.consensusAccountName(searchQuery))
   const { method, setMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -29,7 +29,7 @@ const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, rowsNumber, p
   const { t } = useTranslation()
   const scope = useRequiredScopeParam()
 
-  const { wantedNamePattern } = useVoteFiltering()
+  const { highlightPattern } = useVoteFiltering()
 
   const tableColumns: TableColProps[] = [
     { key: 'index', content: <></>, width: '50px' },
@@ -52,7 +52,7 @@ const ProposalVotes: FC<ProposalVotesProps> = ({ isLoading, votes, rowsNumber, p
               address={vote.address}
               isError={vote.haveValidatorsFailed}
               validator={vote.validator}
-              highlightedPart={wantedNamePattern}
+              highlightPattern={highlightPattern}
             />
           ),
         },

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -126,6 +126,7 @@ export const useVoteFiltering = () => {
   })
   const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('voter', '', { deleteParams: ['page'] })
   const wantedNamePattern = wantedNameInput.length < 3 ? undefined : wantedNameInput
+  const highlightPattern = wantedNamePattern
   const nameError = !!wantedNameInput && !wantedNamePattern ? t('tableSearch.error.tooShort') : undefined
   const hasFilters = wantedType !== 'any' || !!wantedNamePattern
   const clearFilters = () => {
@@ -142,6 +143,7 @@ export const useVoteFiltering = () => {
     wantedNameInput,
     setWantedNameInput,
     wantedNamePattern,
+    highlightPattern,
     nameError,
     hasFilters,
     clearFilters,

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -13,6 +13,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export type AllVotesData = List & {
   isLoading: boolean
@@ -126,7 +127,7 @@ export const useVoteFiltering = () => {
   })
   const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('voter', '', { deleteParams: ['page'] })
   const wantedNamePattern = wantedNameInput.length < 3 ? undefined : wantedNameInput
-  const highlightPattern = wantedNamePattern
+  const highlightPattern = getHighlightPattern(wantedNamePattern)
   const nameError = !!wantedNameInput && !wantedNamePattern ? t('tableSearch.error.tooShort') : undefined
   const hasFilters = wantedType !== 'any' || !!wantedNamePattern
   const clearFilters = () => {

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -126,7 +126,7 @@ export const useVoteFiltering = () => {
     deleteParams: ['page'],
   })
   const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('voter', '', { deleteParams: ['page'] })
-  const parsedNameQuery = textSearch(wantedNameInput, t)
+  const parsedNameQuery = textSearch.voterName(wantedNameInput, t)
   const highlightPattern = getHighlightPattern(parsedNameQuery)
   const { result: wantedNamePattern, warning: nameError } = parsedNameQuery
   const hasFilters = wantedType !== 'any' || !!wantedNamePattern

--- a/src/app/pages/ProposalDetailsPage/hooks.ts
+++ b/src/app/pages/ProposalDetailsPage/hooks.ts
@@ -13,7 +13,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export type AllVotesData = List & {
   isLoading: boolean
@@ -126,9 +126,9 @@ export const useVoteFiltering = () => {
     deleteParams: ['page'],
   })
   const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('voter', '', { deleteParams: ['page'] })
-  const wantedNamePattern = wantedNameInput.length < 3 ? undefined : wantedNameInput
-  const highlightPattern = getHighlightPattern(wantedNamePattern)
-  const nameError = !!wantedNameInput && !wantedNamePattern ? t('tableSearch.error.tooShort') : undefined
+  const parsedNameQuery = textSearch(wantedNameInput, t)
+  const highlightPattern = getHighlightPattern(parsedNameQuery)
+  const { result: wantedNamePattern, warning: nameError } = parsedNameQuery
   const hasFilters = wantedType !== 'any' || !!wantedNamePattern
   const clearFilters = () => {
     setSearchParams(searchParams => {

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -31,8 +31,7 @@ export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useConsensusScope()
   const { proposalId, searchQuery } = useLoaderData() as ProposalIdLoaderData
-  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
-
+  const highlightPattern = getHighlightPattern(textSearch.networkProposalName(searchQuery, t))
   const {
     isLoading: areStatsLoading,
     allVotesCount,

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -23,12 +23,14 @@ import { COLORS } from 'styles/theme/colors'
 import { ProposalVotesCard } from './ProposalVotesCard'
 import { useVoteStats } from './hooks'
 import Skeleton from '@mui/material/Skeleton'
+import { HighlightPattern } from '../../components/HighlightedText'
 import { getTypeNameForProposal } from '../../../types/proposalType'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useConsensusScope()
-  const { proposalId, searchTerm } = useLoaderData() as ProposalIdLoaderData
+  const { proposalId, searchQuery } = useLoaderData() as ProposalIdLoaderData
+  const highlightPattern = searchQuery
 
   const {
     isLoading: areStatsLoading,
@@ -49,7 +51,7 @@ export const ProposalDetailsPage: FC = () => {
           totalVotesLoading={areStatsLoading}
           totalVotesProblematic={!areStatsComplete && !areStatsLoading}
           totalVotes={allVotesCount}
-          highlightedPart={searchTerm}
+          highlightPattern={highlightPattern}
         />
       </SubPageCard>
       <ProposalVotesCard />
@@ -68,7 +70,7 @@ const VoteLoadingProblemIndicator: FC = () => {
 
 export const ProposalDetailView: FC<{
   proposal: Proposal | undefined
-  highlightedPart?: string
+  highlightPattern?: HighlightPattern
   isLoading?: boolean
   totalVotesLoading?: boolean
   totalVotesProblematic?: boolean
@@ -83,7 +85,7 @@ export const ProposalDetailView: FC<{
   totalVotes,
   showLayer = false,
   standalone = false,
-  highlightedPart,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -108,7 +110,7 @@ export const ProposalDetailView: FC<{
 
       <dt>{t('common.title')}</dt>
       <dd>
-        <HighlightedText text={proposal.title} pattern={highlightedPart} />
+        <HighlightedText text={proposal.title} pattern={highlightPattern} />
       </dd>
 
       <dt>{t('common.type')}</dt>

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -25,13 +25,13 @@ import { useVoteStats } from './hooks'
 import Skeleton from '@mui/material/Skeleton'
 import { HighlightPattern } from '../../components/HighlightedText'
 import { getTypeNameForProposal } from '../../../types/proposalType'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useConsensusScope()
   const { proposalId, searchQuery } = useLoaderData() as ProposalIdLoaderData
-  const highlightPattern = getHighlightPattern(searchQuery)
+  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
 
   const {
     isLoading: areStatsLoading,

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -25,12 +25,13 @@ import { useVoteStats } from './hooks'
 import Skeleton from '@mui/material/Skeleton'
 import { HighlightPattern } from '../../components/HighlightedText'
 import { getTypeNameForProposal } from '../../../types/proposalType'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export const ProposalDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useConsensusScope()
   const { proposalId, searchQuery } = useLoaderData() as ProposalIdLoaderData
-  const highlightPattern = searchQuery
+  const highlightPattern = getHighlightPattern(searchQuery)
 
   const {
     isLoading: areStatsLoading,

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -40,12 +40,13 @@ import { Ticker } from 'types/ticker'
 import { WithHighlighting } from '../../components/HighlightingContext/WithHighlighting'
 import { HighlightedText, HighlightPattern } from '../../components/HighlightedText'
 import { RoflAppLoaderData } from '../../utils/route-utils'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useRuntimeScope()
   const { id, searchQuery } = useLoaderData() as RoflAppLoaderData
-  const highlightPattern = searchQuery
+  const highlightPattern = getHighlightPattern(searchQuery)
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -40,13 +40,13 @@ import { Ticker } from 'types/ticker'
 import { WithHighlighting } from '../../components/HighlightingContext/WithHighlighting'
 import { HighlightedText, HighlightPattern } from '../../components/HighlightedText'
 import { RoflAppLoaderData } from '../../utils/route-utils'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useRuntimeScope()
   const { id, searchQuery } = useLoaderData() as RoflAppLoaderData
-  const highlightPattern = getHighlightPattern(searchQuery)
+  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -46,7 +46,7 @@ export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useRuntimeScope()
   const { id, searchQuery } = useLoaderData() as RoflAppLoaderData
-  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.roflAppName(searchQuery))
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -38,13 +38,14 @@ import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { SearchScope } from 'types/searchScope'
 import { Ticker } from 'types/ticker'
 import { WithHighlighting } from '../../components/HighlightingContext/WithHighlighting'
-import { HighlightedText } from '../../components/HighlightedText'
+import { HighlightedText, HighlightPattern } from '../../components/HighlightedText'
 import { RoflAppLoaderData } from '../../utils/route-utils'
 
 export const RoflAppDetailsPage: FC = () => {
   const { t } = useTranslation()
   const scope = useRuntimeScope()
-  const { id, searchTerm } = useLoaderData() as RoflAppLoaderData
+  const { id, searchQuery } = useLoaderData() as RoflAppLoaderData
+  const highlightPattern = searchQuery
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)
@@ -72,7 +73,7 @@ export const RoflAppDetailsPage: FC = () => {
                 id={roflApp.id}
                 network={scope.network}
                 name={roflApp.metadata['net.oasis.rofl.name']}
-                highlightedPartOfName={searchTerm}
+                highlightPattern={highlightPattern}
                 labelOnly
                 trimMode={'adaptive'}
                 withSourceIndicator={false}
@@ -81,7 +82,7 @@ export const RoflAppDetailsPage: FC = () => {
           )
         }
       >
-        <RoflAppDetailsView isLoading={isLoading} app={roflApp} highlightedPartOfName={searchTerm} />
+        <RoflAppDetailsView isLoading={isLoading} app={roflApp} highlightPattern={highlightPattern} />
       </SubPageCard>
       <Grid container spacing={4}>
         <StyledGrid item xs={12} md={6}>
@@ -123,8 +124,8 @@ export const StyledGrid = styled(Grid)(({ theme }) => ({
 export const RoflAppDetailsView: FC<{
   isLoading?: boolean
   app: RoflApp | undefined
-  highlightedPartOfName: string
-}> = ({ app, isLoading, highlightedPartOfName }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ app, isLoading, highlightPattern }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -133,7 +134,7 @@ export const RoflAppDetailsView: FC<{
 
   return (
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
-      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightedPartOfName={highlightedPartOfName} />
+      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightPattern={highlightPattern} />
       <VersionRow version={app.metadata['net.oasis.rofl.version']} />
       <TeeRow policy={app.policy} />
       <DetailsRow title={t('rofl.appId')}>
@@ -183,8 +184,8 @@ export const RoflAppDetailsView: FC<{
 export const RoflAppDetailsViewSearchResult: FC<{
   isLoading?: boolean
   app: RoflApp | undefined
-  highlightedPartOfName?: string
-}> = ({ app, isLoading, highlightedPartOfName }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ app, isLoading, highlightPattern }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -196,7 +197,7 @@ export const RoflAppDetailsViewSearchResult: FC<{
       <DetailsRow title={t('common.paratime')}>
         <DashboardLink scope={{ network: app.network, layer: app.layer }} />
       </DetailsRow>
-      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightedPartOfName={highlightedPartOfName} />
+      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightPattern={highlightPattern} />
       <VersionRow version={app.metadata['net.oasis.rofl.version']} />
       <TeeRow policy={app.policy} />
       <DetailsRow title={t('rofl.appId')}>
@@ -204,7 +205,7 @@ export const RoflAppDetailsViewSearchResult: FC<{
           id={app.id}
           name={app.id}
           network={app.network}
-          highlightedPartOfName={highlightedPartOfName}
+          highlightPattern={highlightPattern}
           withSourceIndicator={false}
         />
         <CopyToClipboard value={app.id} />
@@ -263,12 +264,12 @@ export const RoflAppDetailsVerticalListView: FC<{
 
 const NameRow: FC<{
   name?: string
-  highlightedPartOfName?: string
-}> = ({ name, highlightedPartOfName }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ name, highlightPattern }) => {
   const { t } = useTranslation()
   return (
     <DetailsRow title={t('common.name')}>
-      {name ? <HighlightedText text={name} pattern={highlightedPartOfName} /> : t('common.missing')}
+      {name ? <HighlightedText text={name} pattern={highlightPattern} /> : t('common.missing')}
     </DetailsRow>
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/RuntimeAccountDetailsCard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { EvmToken, RuntimeAccount } from '../../../oasis-nexus/api'
 import { RuntimeAccountDetailsView } from '../../components/Account/RuntimeAccountDetailsView'
 import { AllTokenPrices } from '../../../coin-gecko/api'
+import { HighlightPattern } from '../../components/HighlightedText'
 
 type RuntimeAccountDetailsProps = {
   isLoading: boolean
@@ -12,7 +13,7 @@ type RuntimeAccountDetailsProps = {
   account: RuntimeAccount | undefined
   token: EvmToken | undefined
   tokenPrices: AllTokenPrices
-  highlightedPartOfName?: string | undefined
+  highlightPattern: HighlightPattern
 }
 
 export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
@@ -22,7 +23,7 @@ export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
   account,
   token,
   tokenPrices,
-  highlightedPartOfName,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
   return (
@@ -38,7 +39,7 @@ export const RuntimeAccountDetailsCard: FC<RuntimeAccountDetailsProps> = ({
         account={account}
         token={token}
         tokenPrices={tokenPrices}
-        highlightedPartOfName={highlightedPartOfName}
+        highlightPattern={highlightPattern}
       />
     </SubPageCard>
   )

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -21,7 +21,7 @@ import {
   tokenContainerId,
   transfersContainerId,
 } from '../../utils/tabAnchors'
-import { getHighlightPattern, textSearch } from "../../components/Search/search-utils";
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
@@ -38,7 +38,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(textSearch.runtimeAccountName(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -21,6 +21,7 @@ import {
   tokenContainerId,
   transfersContainerId,
 } from '../../utils/tabAnchors'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
@@ -37,7 +38,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = searchQuery
+  const highlightPattern = getHighlightPattern(searchQuery)
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -21,7 +21,7 @@ import {
   tokenContainerId,
   transfersContainerId,
 } from '../../utils/tabAnchors'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from "../../components/Search/search-utils";
 
 export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
@@ -38,7 +38,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(searchQuery)
+  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -36,7 +36,8 @@ export const RuntimeAccountDetailsPage: FC = () => {
   const { t } = useTranslation()
 
   const scope = useRuntimeScope()
-  const { address, searchTerm } = useLoaderData() as AddressLoaderData
+  const { address, searchQuery } = useLoaderData() as AddressLoaderData
+  const highlightPattern = searchQuery
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
@@ -66,7 +67,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
         account={account}
         token={token}
         tokenPrices={tokenPrices}
-        highlightedPartOfName={searchTerm}
+        highlightPattern={highlightPattern}
       />
       <DappBanner scope={scope} ethOrOasisAddress={address} />
       <RouterTabs

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -38,7 +38,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.runtimeAccountName(searchQuery))
   const { method, setMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract

--- a/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/GlobalSearchResultsView.tsx
@@ -31,7 +31,7 @@ export const GlobalSearchResultsView: FC<{
   useRedirectIfSingleResult(undefined, searchParams, searchResults)
 
   const networkNames = getNetworkNames(t)
-  const { searchTerm } = searchParams
+  const { query } = searchParams
 
   if (fixedNetwork) {
     return (
@@ -40,7 +40,7 @@ export const GlobalSearchResultsView: FC<{
         <SearchResultsList
           key={fixedNetwork}
           title={networkNames[fixedNetwork]}
-          searchTerm={searchTerm}
+          searchQuery={query}
           searchResults={searchResults}
           networkForTheme={fixedNetwork}
           tokenPrices={tokenPrices}
@@ -61,7 +61,7 @@ export const GlobalSearchResultsView: FC<{
         <SearchResultsList
           key={Network.mainnet}
           title={networkNames[Network.mainnet]}
-          searchTerm={searchTerm}
+          searchQuery={query}
           searchResults={mainnetResults}
           networkForTheme={Network.mainnet}
           tokenPrices={tokenPrices}
@@ -75,7 +75,7 @@ export const GlobalSearchResultsView: FC<{
               <SearchResultsList
                 key={net}
                 title={networkNames[net]}
-                searchTerm={searchTerm}
+                searchQuery={query}
                 searchResults={otherResults.filter(getFilterForNetwork(net))}
                 networkForTheme={net}
                 tokenPrices={tokenPrices}

--- a/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
+++ b/src/app/pages/SearchResultsPage/ScopedSearchResultsView.tsx
@@ -37,14 +37,14 @@ export const ScopedSearchResultsView: FC<{
 
   useRedirectIfSingleResult(wantedScope, searchParams, searchResults)
 
-  const { searchTerm } = searchParams
+  const { query } = searchParams
 
   return (
     <>
       {wantedResults.length ? (
         <SearchResultsList
           title={getNameForScope(t, wantedScope)}
-          searchTerm={searchTerm}
+          searchQuery={query}
           searchResults={wantedResults}
           networkForTheme={wantedScope.network}
           tokenPrices={tokenPrices}
@@ -62,7 +62,7 @@ export const ScopedSearchResultsView: FC<{
                 key={net}
                 networkForTheme={net}
                 title={networkNames[net]}
-                searchTerm={searchTerm}
+                searchQuery={query}
                 searchResults={otherResults.filter(getFilterForNetwork(net))}
                 tokenPrices={tokenPrices}
               />

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -124,7 +124,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(textSearch.consensusAccountName(searchQuery))}
+                highlightPattern={getHighlightPattern(textSearch.accountName(searchQuery))}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -133,7 +133,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(textSearch.consensusAccountName(searchQuery))}
+                highlightPattern={getHighlightPattern(textSearch.accountName(searchQuery))}
               />
             )
           }
@@ -151,7 +151,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
-              highlightPattern={getHighlightPattern(textSearch.runtimeAccountName(searchQuery))}
+              highlightPattern={getHighlightPattern(textSearch.accountName(searchQuery))}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -171,7 +171,13 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.proposals.title')}
           results={searchResults.filter((item): item is ProposalResult => item.resultType === 'proposal')}
-          resultComponent={item => <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(textSearch.networkProposalName(searchQuery))} showLayer />}
+          resultComponent={item => (
+            <ProposalDetailView
+              proposal={item}
+              highlightPattern={getHighlightPattern(textSearch.networkProposalName(searchQuery))}
+              showLayer
+            />
+          )}
           link={proposal => RouteUtils.getProposalRoute(proposal.network, proposal.id)}
           linkLabel={t('search.results.proposals.viewLink')}
         />

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -41,8 +41,8 @@ export const SearchResultsList: FC<{
   networkForTheme: Network
   searchResults: SearchResults
   tokenPrices: AllTokenPrices
-  searchTerm?: string
-}> = ({ title, networkForTheme, searchResults, tokenPrices, searchTerm = '' }) => {
+  searchQuery?: string
+}> = ({ title, networkForTheme, searchResults, tokenPrices, searchQuery = '' }) => {
   const { t } = useTranslation()
 
   const numberOfResults = searchResults.length
@@ -108,7 +108,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.tokens.title')}
           results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightedPartOfName={searchTerm} showLayer />}
+          resultComponent={item => <TokenDetails token={item} highlightPattern={searchQuery} showLayer />}
           link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
           linkLabel={t('search.results.tokens.viewLink')}
         />
@@ -123,7 +123,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
-                highlightedPartOfName={searchTerm}
+                highlightPattern={searchQuery}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -132,7 +132,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
-                highlightedPartOfName={searchTerm}
+                highlightPattern={searchQuery}
               />
             )
           }
@@ -150,7 +150,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
-              highlightedPartOfName={searchTerm}
+              highlightPattern={searchQuery}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}
@@ -161,7 +161,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.roflApps.title')}
           results={searchResults.filter((item): item is RoflAppResult => item.resultType === 'roflApp')}
           resultComponent={item => (
-            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightedPartOfName={searchTerm} />
+            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={searchQuery} />
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}
@@ -171,7 +171,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.proposals.title')}
           results={searchResults.filter((item): item is ProposalResult => item.resultType === 'proposal')}
           resultComponent={item => (
-            <ProposalDetailView proposal={item} highlightedPart={searchTerm} showLayer />
+            <ProposalDetailView proposal={item} highlightPattern={searchQuery} showLayer />
           )}
           link={proposal => RouteUtils.getProposalRoute(proposal.network, proposal.id)}
           linkLabel={t('search.results.proposals.viewLink')}

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -109,7 +109,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.tokens.title')}
           results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} showLayer />}
+          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(textSearch.evmTokenName(searchQuery))} showLayer />}
           link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
           linkLabel={t('search.results.tokens.viewLink')}
         />
@@ -124,7 +124,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(textSearch(searchQuery))}
+                highlightPattern={getHighlightPattern(textSearch.consensusAccountName(searchQuery))}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -133,7 +133,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(textSearch(searchQuery))}
+                highlightPattern={getHighlightPattern(textSearch.consensusAccountName(searchQuery))}
               />
             )
           }
@@ -151,7 +151,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
-              highlightPattern={getHighlightPattern(textSearch(searchQuery))}
+              highlightPattern={getHighlightPattern(textSearch.runtimeAccountName(searchQuery))}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}
@@ -162,7 +162,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.roflApps.title')}
           results={searchResults.filter((item): item is RoflAppResult => item.resultType === 'roflApp')}
           resultComponent={item => (
-            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} />
+            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(textSearch.roflAppName(searchQuery))} />
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}
@@ -171,7 +171,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.proposals.title')}
           results={searchResults.filter((item): item is ProposalResult => item.resultType === 'proposal')}
-          resultComponent={item => <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} showLayer />}
+          resultComponent={item => <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(textSearch.networkProposalName(searchQuery))} showLayer />}
           link={proposal => RouteUtils.getProposalRoute(proposal.network, proposal.id)}
           linkLabel={t('search.results.proposals.viewLink')}
         />

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -29,7 +29,7 @@ import { TokenDetails } from '../../components/Tokens/TokenDetails'
 import { ProposalDetailView } from '../ProposalDetailsPage'
 import { Account, Layer, RuntimeAccount } from '../../../oasis-nexus/api'
 import { RoflAppDetailsViewSearchResult } from '../RoflAppDetailsPage'
-import { getHighlightPattern } from "../../components/Search/search-utils";
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 /**
  * Component for displaying a list of search results
@@ -109,7 +109,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.tokens.title')}
           results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(searchQuery)} showLayer />}
+          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} showLayer />}
           link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
           linkLabel={t('search.results.tokens.viewLink')}
         />
@@ -124,7 +124,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(searchQuery)}
+                highlightPattern={getHighlightPattern(textSearch(searchQuery))}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -133,7 +133,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
-                highlightPattern={getHighlightPattern(searchQuery)}
+                highlightPattern={getHighlightPattern(textSearch(searchQuery))}
               />
             )
           }
@@ -151,7 +151,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
-              highlightPattern={getHighlightPattern(searchQuery)}
+              highlightPattern={getHighlightPattern(textSearch(searchQuery))}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}
@@ -162,7 +162,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.roflApps.title')}
           results={searchResults.filter((item): item is RoflAppResult => item.resultType === 'roflApp')}
           resultComponent={item => (
-            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(searchQuery)} />
+            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} />
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}
@@ -171,9 +171,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.proposals.title')}
           results={searchResults.filter((item): item is ProposalResult => item.resultType === 'proposal')}
-          resultComponent={item => (
-            <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(searchQuery)} showLayer />
-          )}
+          resultComponent={item => <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(textSearch(searchQuery))} showLayer />}
           link={proposal => RouteUtils.getProposalRoute(proposal.network, proposal.id)}
           linkLabel={t('search.results.proposals.viewLink')}
         />

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -109,7 +109,13 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.tokens.title')}
           results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(textSearch.evmTokenName(searchQuery))} showLayer />}
+          resultComponent={item => (
+            <TokenDetails
+              token={item}
+              highlightPattern={getHighlightPattern(textSearch.evmTokenName(searchQuery))}
+              showLayer
+            />
+          )}
           link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
           linkLabel={t('search.results.tokens.viewLink')}
         />

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -162,7 +162,11 @@ export const SearchResultsList: FC<{
           title={t('search.results.roflApps.title')}
           results={searchResults.filter((item): item is RoflAppResult => item.resultType === 'roflApp')}
           resultComponent={item => (
-            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(textSearch.roflAppName(searchQuery))} />
+            <RoflAppDetailsViewSearchResult
+              isLoading={false}
+              app={item}
+              highlightPattern={getHighlightPattern(textSearch.roflAppName(searchQuery))}
+            />
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}

--- a/src/app/pages/SearchResultsPage/SearchResultsList.tsx
+++ b/src/app/pages/SearchResultsPage/SearchResultsList.tsx
@@ -29,6 +29,7 @@ import { TokenDetails } from '../../components/Tokens/TokenDetails'
 import { ProposalDetailView } from '../ProposalDetailsPage'
 import { Account, Layer, RuntimeAccount } from '../../../oasis-nexus/api'
 import { RoflAppDetailsViewSearchResult } from '../RoflAppDetailsPage'
+import { getHighlightPattern } from "../../components/Search/search-utils";
 
 /**
  * Component for displaying a list of search results
@@ -108,7 +109,7 @@ export const SearchResultsList: FC<{
         <ResultsGroupByType
           title={t('search.results.tokens.title')}
           results={searchResults.filter((item): item is TokenResult => item.resultType === 'token')}
-          resultComponent={item => <TokenDetails token={item} highlightPattern={searchQuery} showLayer />}
+          resultComponent={item => <TokenDetails token={item} highlightPattern={getHighlightPattern(searchQuery)} showLayer />}
           link={token => RouteUtils.getTokenRoute(token, token.eth_contract_addr ?? token.contract_addr)}
           linkLabel={t('search.results.tokens.viewLink')}
         />
@@ -123,7 +124,7 @@ export const SearchResultsList: FC<{
                 isError={false}
                 account={item as Account}
                 showLayer={true}
-                highlightPattern={searchQuery}
+                highlightPattern={getHighlightPattern(searchQuery)}
               />
             ) : (
               <RuntimeAccountDetailsView
@@ -132,7 +133,7 @@ export const SearchResultsList: FC<{
                 account={item as RuntimeAccount}
                 tokenPrices={tokenPrices}
                 showLayer={true}
-                highlightPattern={searchQuery}
+                highlightPattern={getHighlightPattern(searchQuery)}
               />
             )
           }
@@ -150,7 +151,7 @@ export const SearchResultsList: FC<{
               account={item}
               tokenPrices={tokenPrices}
               showLayer={true}
-              highlightPattern={searchQuery}
+              highlightPattern={getHighlightPattern(searchQuery)}
             />
           )}
           link={acc => RouteUtils.getAccountRoute(acc, acc.address_eth ?? acc.address)}
@@ -161,7 +162,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.roflApps.title')}
           results={searchResults.filter((item): item is RoflAppResult => item.resultType === 'roflApp')}
           resultComponent={item => (
-            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={searchQuery} />
+            <RoflAppDetailsViewSearchResult isLoading={false} app={item} highlightPattern={getHighlightPattern(searchQuery)} />
           )}
           link={item => RouteUtils.getRoflAppRoute(item.network, item.id)}
           linkLabel={t('search.results.roflApps.viewLink')}
@@ -171,7 +172,7 @@ export const SearchResultsList: FC<{
           title={t('search.results.proposals.title')}
           results={searchResults.filter((item): item is ProposalResult => item.resultType === 'proposal')}
           resultComponent={item => (
-            <ProposalDetailView proposal={item} highlightPattern={searchQuery} showLayer />
+            <ProposalDetailView proposal={item} highlightPattern={getHighlightPattern(searchQuery)} showLayer />
           )}
           link={proposal => RouteUtils.getProposalRoute(proposal.network, proposal.id)}
           linkLabel={t('search.results.proposals.viewLink')}

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -317,7 +317,7 @@ export function useNetworkProposalsConditionally(nameFragment: string[]): Condit
 
 export function useNamedAccountConditionally(
   currentScope: SearchScope | undefined,
-  nameFragment: string | undefined,
+  nameFragment: string[],
 ): ConditionalResults<Account | RuntimeAccount> {
   const queries = RouteUtils.getVisibleScopes(currentScope).map(scope =>
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -300,9 +300,7 @@ export function useRuntimeTokenConditionally(
   }
 }
 
-export function useNetworkProposalsConditionally(
-  nameFragment: string | undefined,
-): ConditionalResults<Proposal> {
+export function useNetworkProposalsConditionally(nameFragment: string[]): ConditionalResults<Proposal> {
   const queries = RouteUtils.getEnabledNetworksForLayer(Layer.consensus).map(network =>
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useGetConsensusProposalsByName(network, nameFragment),

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -271,7 +271,7 @@ export function useConsensusAccountConditionally(address: string | undefined): C
 
 export function useRuntimeTokenConditionally(
   currentScope: SearchScope | undefined,
-  nameFragment: string | undefined,
+  nameFragment: string[],
 ): ConditionalResults<EvmTokenList> {
   const queries = RouteUtils.getVisibleScopes(currentScope)
     .filter(scope => scope.layer !== Layer.consensus)
@@ -287,7 +287,7 @@ export function useRuntimeTokenConditionally(
         },
         {
           query: {
-            enabled: !!nameFragment,
+            enabled: !!nameFragment.length,
           },
         },
       ),

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -366,7 +366,7 @@ export function useRoflAppIdConditionally(id: string | undefined): ConditionalRe
   }
 }
 
-export function useRoflAppNameConditionally(nameFragment: string | undefined): ConditionalResults<RoflApp> {
+export function useRoflAppNameConditionally(nameFragment: string[]): ConditionalResults<RoflApp> {
   // TODO: also search on other layers that support Rofl
   const queries = RouteUtils.getEnabledNetworksForLayer(Layer.sapphire).map(network =>
     // See explanation above
@@ -375,11 +375,11 @@ export function useRoflAppNameConditionally(nameFragment: string | undefined): C
       network,
       Layer.sapphire,
       {
-        name: nameFragment!,
+        name: nameFragment,
       },
       {
         query: {
-          enabled: !!nameFragment,
+          enabled: !!nameFragment.length,
         },
       },
     ),

--- a/src/app/pages/SearchResultsPage/hooks.ts
+++ b/src/app/pages/SearchResultsPage/hooks.ts
@@ -333,7 +333,7 @@ export function useNamedAccountConditionally(
   }
 }
 
-export function useNamedValidatorConditionally(nameFragment: string | undefined) {
+export function useNamedValidatorConditionally(nameFragment: string[]) {
   const queries = RouteUtils.getEnabledNetworksForLayer(Layer.consensus).map(network =>
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useSearchForValidatorsByName(network, nameFragment),

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { isConsensusBlock, isConsensusTransaction, SearchResults } from './hooks'
-import { encodeStringForUrl, RouteUtils } from '../../utils/route-utils'
+import { encodeURIComponentPretty, RouteUtils } from '../../utils/route-utils'
 import { isItemInScope, SearchScope } from '../../../types/searchScope'
 import { Network } from '../../../types/network'
 import { exhaustedTypeWarning } from '../../../types/errors'
@@ -53,7 +53,7 @@ export function useRedirectIfSingleResult(
             (!!consensusAccount && item.address.toLowerCase() === consensusAccount.toLowerCase())
           ) // If we found this account based on address, then we don't want to highlight that.
         ) {
-          redirectTo += `?q=${encodeStringForUrl(query)}`
+          redirectTo += `?q=${encodeURIComponentPretty(query)}`
         }
         break
       case 'contract':
@@ -63,13 +63,13 @@ export function useRedirectIfSingleResult(
         redirectTo = `${RouteUtils.getTokenRoute(
           item,
           item.eth_contract_addr || item.contract_addr,
-        )}?q=${encodeStringForUrl(query)}`
+        )}?q=${encodeURIComponentPretty(query)}`
         break
       case 'proposal':
-        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${encodeStringForUrl(query)}`
+        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${encodeURIComponentPretty(query)}`
         break
       case 'roflApp':
-        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${encodeStringForUrl(query)}`
+        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${encodeURIComponentPretty(query)}`
         break
       default:
         exhaustedTypeWarning('Unexpected result type', item)

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -16,7 +16,7 @@ export function useRedirectIfSingleResult(
 ) {
   const navigate = useNavigate()
   const { data: validatorsData } = useGetConsensusValidatorsAddressNameMap(results[0]?.network)
-  const { searchTerm, accountNameFragment, evmAccount, consensusAccount } = searchParams
+  const { query, accountNameFragment, evmAccount, consensusAccount } = searchParams
 
   let shouldRedirect = results.length === 1
 
@@ -63,13 +63,13 @@ export function useRedirectIfSingleResult(
         redirectTo = `${RouteUtils.getTokenRoute(
           item,
           item.eth_contract_addr || item.contract_addr,
-        )}?q=${searchTerm}`
+        )}?q=${query}`
         break
       case 'proposal':
-        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${searchTerm}`
+        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${query}`
         break
       case 'roflApp':
-        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${searchTerm}`
+        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${query}`
         break
       default:
         exhaustedTypeWarning('Unexpected result type', item)

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -53,7 +53,7 @@ export function useRedirectIfSingleResult(
             (!!consensusAccount && item.address.toLowerCase() === consensusAccount.toLowerCase())
           ) // If we found this account based on address, then we don't want to highlight that.
         ) {
-          redirectTo += `?q=${accountNameFragment}`
+          redirectTo += `?q=${query}`
         }
         break
       case 'contract':

--- a/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
+++ b/src/app/pages/SearchResultsPage/useRedirectIfSingleResult.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { isConsensusBlock, isConsensusTransaction, SearchResults } from './hooks'
-import { RouteUtils } from '../../utils/route-utils'
+import { encodeStringForUrl, RouteUtils } from '../../utils/route-utils'
 import { isItemInScope, SearchScope } from '../../../types/searchScope'
 import { Network } from '../../../types/network'
 import { exhaustedTypeWarning } from '../../../types/errors'
@@ -53,7 +53,7 @@ export function useRedirectIfSingleResult(
             (!!consensusAccount && item.address.toLowerCase() === consensusAccount.toLowerCase())
           ) // If we found this account based on address, then we don't want to highlight that.
         ) {
-          redirectTo += `?q=${query}`
+          redirectTo += `?q=${encodeStringForUrl(query)}`
         }
         break
       case 'contract':
@@ -63,13 +63,13 @@ export function useRedirectIfSingleResult(
         redirectTo = `${RouteUtils.getTokenRoute(
           item,
           item.eth_contract_addr || item.contract_addr,
-        )}?q=${query}`
+        )}?q=${encodeStringForUrl(query)}`
         break
       case 'proposal':
-        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${query}`
+        redirectTo = `${RouteUtils.getProposalRoute(item.network, item.id)}?q=${encodeStringForUrl(query)}`
         break
       case 'roflApp':
-        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${query}`
+        redirectTo = `${RouteUtils.getRoflAppRoute(item.network, item.id)}?q=${encodeStringForUrl(query)}`
         break
       default:
         exhaustedTypeWarning('Unexpected result type', item)

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -25,11 +25,11 @@ import { holdersContainerId, tokenTransfersContainerId } from '../../utils/tabAn
 import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
 import { HighlightPattern } from '../../components/HighlightedText'
 
-export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; highlighPattern?: HighlightPattern }> = ({
-  scope,
-  address,
-  highlighPattern,
-}) => {
+export const TokenDetailsCard: FC<{
+  scope: RuntimeScope
+  address: string
+  highlightPattern?: HighlightPattern
+}> = ({ scope, address, highlightPattern }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -49,7 +49,7 @@ export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; highli
                 scope={account}
                 address={token.eth_contract_addr || token.contract_addr}
                 name={token.name}
-                highlightPattern={highlighPattern}
+                highlightPattern={highlightPattern}
               />
             </dd>
 

--- a/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenDetailsCard.tsx
@@ -23,11 +23,12 @@ import { AbiPlaygroundLink } from '../../components/ContractVerificationIcon/Abi
 import Box from '@mui/material/Box'
 import { holdersContainerId, tokenTransfersContainerId } from '../../utils/tabAnchors'
 import { TokenLinkWithIcon } from '../../components/Tokens/TokenLinkWithIcon'
+import { HighlightPattern } from '../../components/HighlightedText'
 
-export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; searchTerm: string }> = ({
+export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; highlighPattern?: HighlightPattern }> = ({
   scope,
   address,
-  searchTerm,
+  highlighPattern,
 }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
@@ -48,7 +49,7 @@ export const TokenDetailsCard: FC<{ scope: RuntimeScope; address: string; search
                 scope={account}
                 address={token.eth_contract_addr || token.contract_addr}
                 name={token.name}
-                highlightedPart={searchTerm}
+                highlightPattern={highlighPattern}
               />
             </dd>
 

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -9,11 +9,12 @@ import { useTranslation } from 'react-i18next'
 import { RuntimeScope } from '../../../types/searchScope'
 import { HighlightedText } from '../../components/HighlightedText'
 import { TitleCard } from '../../components/PageLayout/TitleCard'
+import { HighlightPattern } from "../../components/HighlightedText";
 
-export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; searchTerm: string }> = ({
+export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; highlightPattern?: HighlightPattern }> = ({
   scope,
   address,
-  searchTerm,
+  highlightPattern,
 }) => {
   const { t } = useTranslation()
   const { isLoading, token } = useTokenInfo(scope, address)
@@ -44,7 +45,7 @@ export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; searchTe
       isLoading={isLoading}
       title={
         <>
-          {token?.name ? <HighlightedText text={token.name} pattern={searchTerm} /> : t('common.missing')}
+          {token?.name ? <HighlightedText text={token.name} pattern={highlightPattern} />  : t('common.missing')}
           &nbsp;
           <Typography
             component="span"
@@ -54,7 +55,7 @@ export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; searchTe
             }}
           >
             {token?.symbol ? (
-              <HighlightedText text={token.symbol} pattern={searchTerm} />
+              <HighlightedText text={token.symbol} pattern={highlightPattern} />
             ) : (
               t('common.missing')
             )}

--- a/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
+++ b/src/app/pages/TokenDashboardPage/TokenTitleCard.tsx
@@ -9,13 +9,13 @@ import { useTranslation } from 'react-i18next'
 import { RuntimeScope } from '../../../types/searchScope'
 import { HighlightedText } from '../../components/HighlightedText'
 import { TitleCard } from '../../components/PageLayout/TitleCard'
-import { HighlightPattern } from "../../components/HighlightedText";
+import { HighlightPattern } from '../../components/HighlightedText'
 
-export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; highlightPattern?: HighlightPattern }> = ({
-  scope,
-  address,
-  highlightPattern,
-}) => {
+export const TokenTitleCard: FC<{
+  scope: RuntimeScope
+  address: string
+  highlightPattern?: HighlightPattern
+}> = ({ scope, address, highlightPattern }) => {
   const { t } = useTranslation()
   const { isLoading, token } = useTokenInfo(scope, address)
 
@@ -45,7 +45,11 @@ export const TokenTitleCard: FC<{ scope: RuntimeScope; address: string; highligh
       isLoading={isLoading}
       title={
         <>
-          {token?.name ? <HighlightedText text={token.name} pattern={highlightPattern} />  : t('common.missing')}
+          {token?.name ? (
+            <HighlightedText text={token.name} pattern={highlightPattern} />
+          ) : (
+            t('common.missing')
+          )}
           &nbsp;
           <Typography
             component="span"

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -29,7 +29,7 @@ export const TokenDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
+  const highlightPattern = getHighlightPattern(textSearch.evmTokenName(searchQuery))
   const { isError } = useTokenInfo(scope, address)
 
   if (isError) {

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -11,8 +11,8 @@ import { useTokenInfo } from './hook'
 import { AppErrors } from '../../../types/errors'
 import { RouterTabs } from '../../components/RouterTabs'
 import { useTranslation } from 'react-i18next'
-import { RuntimeScope } from '../../../types/searchScope'
 import { DappBanner } from '../../components/DappBanner'
+import { RuntimeScope } from '../../../types/searchScope'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { codeContainerId, holdersContainerId, inventoryContainerId } from '../../utils/tabAnchors'
 
@@ -27,8 +27,8 @@ export const TokenDashboardPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useRuntimeScope()
-  const { address, searchTerm } = useLoaderData() as AddressLoaderData
-
+  const { address, searchQuery } = useLoaderData() as AddressLoaderData
+  const highlightPattern = searchQuery
   const { isError } = useTokenInfo(scope, address)
 
   if (isError) {
@@ -47,11 +47,11 @@ export const TokenDashboardPage: FC = () => {
 
   return (
     <PageLayout>
-      <TokenTitleCard scope={scope} address={address} searchTerm={searchTerm} />
+      <TokenTitleCard scope={scope} address={address} highlightPattern={highlightPattern} />
       <DappBanner scope={scope} ethOrOasisAddress={address} />
       <TokenSnapshot scope={scope} address={address} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <TokenDetailsCard scope={scope} address={address} searchTerm={searchTerm} />
+      <TokenDetailsCard scope={scope} address={address} highlighPattern={highlightPattern} />
       <RouterTabs
         tabs={[
           { label: t('common.transfers'), to: tokenTransfersLink },

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -15,6 +15,7 @@ import { DappBanner } from '../../components/DappBanner'
 import { RuntimeScope } from '../../../types/searchScope'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { codeContainerId, holdersContainerId, inventoryContainerId } from '../../utils/tabAnchors'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 export type TokenDashboardContext = {
   scope: RuntimeScope
@@ -28,7 +29,7 @@ export const TokenDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = searchQuery
+  const highlightPattern = getHighlightPattern(searchQuery)
   const { isError } = useTokenInfo(scope, address)
 
   if (isError) {

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -52,7 +52,7 @@ export const TokenDashboardPage: FC = () => {
       <DappBanner scope={scope} ethOrOasisAddress={address} />
       <TokenSnapshot scope={scope} address={address} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <TokenDetailsCard scope={scope} address={address} highlighPattern={highlightPattern} />
+      <TokenDetailsCard scope={scope} address={address} highlightPattern={highlightPattern} />
       <RouterTabs
         tabs={[
           { label: t('common.transfers'), to: tokenTransfersLink },

--- a/src/app/pages/TokenDashboardPage/index.tsx
+++ b/src/app/pages/TokenDashboardPage/index.tsx
@@ -15,7 +15,7 @@ import { DappBanner } from '../../components/DappBanner'
 import { RuntimeScope } from '../../../types/searchScope'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { codeContainerId, holdersContainerId, inventoryContainerId } from '../../utils/tabAnchors'
-import { getHighlightPattern } from '../../components/Search/search-utils'
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
 export type TokenDashboardContext = {
   scope: RuntimeScope
@@ -29,7 +29,7 @@ export const TokenDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
-  const highlightPattern = getHighlightPattern(searchQuery)
+  const highlightPattern = getHighlightPattern(textSearch(searchQuery))
   const { isError } = useTokenInfo(scope, address)
 
   if (isError) {

--- a/src/app/pages/TokensOverviewPage/index.tsx
+++ b/src/app/pages/TokensOverviewPage/index.tsx
@@ -99,7 +99,6 @@ export const TokensPage: FC = () => {
                   key={key}
                   isLoading={true}
                   token={undefined}
-                  highlightedPartOfName={undefined}
                   standalone
                 />
               ))}
@@ -109,7 +108,6 @@ export const TokensPage: FC = () => {
                 <TokenDetails
                   key={token.contract_addr}
                   token={token}
-                  highlightedPartOfName={undefined}
                   standalone
                 />
               ))}

--- a/src/app/pages/TokensOverviewPage/index.tsx
+++ b/src/app/pages/TokensOverviewPage/index.tsx
@@ -95,22 +95,11 @@ export const TokensPage: FC = () => {
           <VerticalList>
             {isLoading &&
               [...Array(PAGE_SIZE).keys()].map(key => (
-                <TokenDetails
-                  key={key}
-                  isLoading={true}
-                  token={undefined}
-                  standalone
-                />
+                <TokenDetails key={key} isLoading={true} token={undefined} standalone />
               ))}
 
             {!isLoading &&
-              tokens!.map(token => (
-                <TokenDetails
-                  key={token.contract_addr}
-                  token={token}
-                  standalone
-                />
-              ))}
+              tokens!.map(token => <TokenDetails key={token.contract_addr} token={token} standalone />)}
           </VerticalList>
         )}
       </SubPageCard>

--- a/src/app/pages/ValidatorDetailsPage/ValidatorTitleCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/ValidatorTitleCard.tsx
@@ -9,14 +9,24 @@ import { TitleCard } from 'app/components/PageLayout/TitleCard'
 import { Network } from '../../../types/network'
 import { ValidatorStatusBadge } from './ValidatorStatusBadge'
 import { AccountLink } from '../../components/Account/AccountLink'
+import { HighlightedText, HighlightPattern } from '../../components/HighlightedText'
+import { AdaptiveHighlightedText } from '../../components/HighlightedText/AdaptiveHighlightedText'
+import { useScreenSize } from '../../hooks/useScreensize'
 
 type ValidatorTitleCardProps = {
   isLoading: boolean
   network: Network
   validator?: Validator
+  highlightPattern?: HighlightPattern
 }
 
-export const ValidatorTitleCard: FC<ValidatorTitleCardProps> = ({ isLoading, network, validator }) => {
+export const ValidatorTitleCard: FC<ValidatorTitleCardProps> = ({
+  isLoading,
+  network,
+  validator,
+  highlightPattern,
+}) => {
+  const { isTablet } = useScreenSize()
   return (
     <TitleCard
       details={
@@ -47,7 +57,11 @@ export const ValidatorTitleCard: FC<ValidatorTitleCardProps> = ({ isLoading, net
                   name={validator.media?.name}
                   logotype={validator.media?.logoUrl}
                 />
-                {validator?.media?.name}
+                {isTablet ? (
+                  <AdaptiveHighlightedText text={validator?.media?.name} pattern={highlightPattern} />
+                ) : (
+                  <HighlightedText text={validator?.media?.name} pattern={highlightPattern} />
+                )}
               </Box>
               &nbsp;
               <Typography

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -44,6 +44,9 @@ import { eventsContainerId } from '../../utils/tabAnchors'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { AccountLink } from '../../components/Account/AccountLink'
 import { Network } from '../../../types/network'
+import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
+import { HighlightedText, HighlightPattern } from '../../components/HighlightedText'
+import { AdaptiveHighlightedText } from '../../components/HighlightedText/AdaptiveHighlightedText'
 
 export const StyledListTitle = styled('dt')(({ theme }) => ({
   marginLeft: theme.spacing(4),
@@ -60,7 +63,8 @@ export const ValidatorDetailsPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRequiredScopeParam()
   const { method, setMethod } = useConsensusTxMethodParam()
-  const { address } = useLoaderData() as AddressLoaderData
+  const { address, searchQuery } = useLoaderData() as AddressLoaderData
+  const highlightPattern = getHighlightPattern(textSearch.validatorName(searchQuery))
   const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
   const { isLoading: isValidatorLoading, isFetched, data } = validatorQuery
   const validator = data?.data.validators[0]
@@ -77,7 +81,12 @@ export const ValidatorDetailsPage: FC = () => {
 
   return (
     <PageLayout>
-      <ValidatorTitleCard isLoading={isLoading} network={scope.network} validator={validator} />
+      <ValidatorTitleCard
+        isLoading={isLoading}
+        network={scope.network}
+        validator={validator}
+        highlightPattern={highlightPattern}
+      />
       <ValidatorSnapshot scope={scope} validator={validator} stats={stats} />
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
       <ValidatorDetailsCard
@@ -86,6 +95,7 @@ export const ValidatorDetailsPage: FC = () => {
         validator={validator}
         account={account}
         stats={stats}
+        highlightPattern={highlightPattern}
       />
       <Grid container spacing={4}>
         <StyledGrid item xs={12} md={6}>
@@ -115,6 +125,7 @@ type ValidatorDetailsCardProps = {
   validator: Validator | undefined
   account: Account | undefined
   stats: ValidatorAggStats | undefined
+  highlightPattern?: HighlightPattern
 }
 
 const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({
@@ -123,6 +134,7 @@ const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({
   validator,
   account,
   stats,
+  highlightPattern,
 }) => {
   return (
     <Card>
@@ -134,6 +146,7 @@ const ValidatorDetailsCard: FC<ValidatorDetailsCardProps> = ({
           validator={validator}
           account={account}
           stats={stats}
+          highlightPattern={highlightPattern}
         />
       </CardContent>
     </Card>
@@ -148,9 +161,19 @@ export const ValidatorDetailsView: FC<{
   account: Account | undefined
   standalone?: boolean
   stats: ValidatorAggStats | undefined
-}> = ({ network, detailsPage, isLoading, validator, account, standalone = false, stats }) => {
+  highlightPattern?: HighlightPattern
+}> = ({
+  network,
+  detailsPage,
+  isLoading,
+  validator,
+  account,
+  standalone = false,
+  stats,
+  highlightPattern,
+}) => {
   const { t } = useTranslation()
-  const { isMobile } = useScreenSize()
+  const { isMobile, isTablet } = useScreenSize()
   const formattedTime = useFormattedTimestampStringWithDistance(validator?.start_date)
   if (isLoading) return <TextSkeleton numberOfRows={10} />
   if (!validator) return null
@@ -167,7 +190,13 @@ export const ValidatorDetailsView: FC<{
             />
           </dt>
           <dd>
-            <b>{validator.media?.name}</b>
+            <b>
+              {isTablet ? (
+                <AdaptiveHighlightedText text={validator.media?.name} pattern={highlightPattern} />
+              ) : (
+                <HighlightedText text={validator.media?.name} pattern={highlightPattern} />
+              )}
+            </b>
           </dd>
           <dt>{t('common.rank')}</dt>
           <dd>{validator.rank}</dd>

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -311,7 +311,7 @@ const validateRoflAppIdParam = (id: string) => {
 
 export type RoflAppLoaderData = {
   id: string
-  searchTerm: string
+  searchQuery: string
 }
 
 const validateRuntimeAddressParam = (address: string) => {
@@ -350,7 +350,7 @@ const validateRuntimeTxHashParam = (hash: string) => {
 
 export type AddressLoaderData = {
   address: string
-  searchTerm: string
+  searchQuery: string
 }
 
 const validateProposalIdParam = (proposalId: string) => {
@@ -368,7 +368,7 @@ export const consensusAddressParamLoader =
     validateConsensusAddressParam(params[queryParam]!)
     return {
       address: params[queryParam]!,
-      searchTerm: getSearchTermFromRequest(request),
+      searchQuery: getSearchTermFromRequest(request),
     }
   }
 
@@ -379,7 +379,7 @@ export const runtimeAddressParamLoader =
     validateRuntimeAddressParam(rawAddress)
     return {
       address: isValidEthAddress(rawAddress) ? toChecksumAddress(rawAddress) : rawAddress,
-      searchTerm: getSearchTermFromRequest(request),
+      searchQuery: getSearchTermFromRequest(request),
     }
   }
 
@@ -389,7 +389,7 @@ export const roflAppParamLoader =
     validateRoflAppIdParam(params[queryParam]!)
     return {
       id: params[queryParam]!,
-      searchTerm: getSearchTermFromRequest(request),
+      searchQuery: getSearchTermFromRequest(request),
     }
   }
 
@@ -433,14 +433,14 @@ export const assertEnabledScope = (params: {
 
 export type ProposalIdLoaderData = {
   proposalId: number
-  searchTerm: string
+  searchQuery: string
 }
 
 export const proposalIdParamLoader = async ({ params, request }: LoaderFunctionArgs) => {
   validateProposalIdParam(params.proposalId!)
   return {
     proposalId: parseInt(params.proposalId!),
-    searchTerm: getSearchTermFromRequest(request),
+    searchQuery: getSearchTermFromRequest(request),
   }
 }
 

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -80,6 +80,8 @@ export const isScopeHidden = (scope: SearchScope): boolean =>
 
 export const isNotInHiddenScope = (item: HasScope) => !isScopeHidden(item)
 
+export const encodeStringForUrl = (text: string) => encodeURIComponent(text).replace(/%20/g, '+')
+
 const formatPreservedParams = (searchParams: URLSearchParams | undefined, paramsToKeep: string[]): string => {
   if (!searchParams) return ''
   const toDelete: string[] = []
@@ -200,7 +202,7 @@ export abstract class RouteUtils {
   static getSearchRoute = (scope: SearchScope | undefined, searchTerm: string) => {
     return scope
       ? `${this.getScopeRoute(scope)}/search?q=${encodeURIComponent(searchTerm)}`
-      : `/search?q=${encodeURIComponent(searchTerm)}`
+      : `/search?q=${encodeStringForUrl(searchTerm)}`
   }
 
   static getTokenRoute = (scope: SearchScope, tokenAddress: string) => {

--- a/src/app/utils/route-utils.ts
+++ b/src/app/utils/route-utils.ts
@@ -80,7 +80,7 @@ export const isScopeHidden = (scope: SearchScope): boolean =>
 
 export const isNotInHiddenScope = (item: HasScope) => !isScopeHidden(item)
 
-export const encodeStringForUrl = (text: string) => encodeURIComponent(text).replace(/%20/g, '+')
+export const encodeURIComponentPretty = (text: string) => encodeURIComponent(text).replace(/%20/g, '+')
 
 const formatPreservedParams = (searchParams: URLSearchParams | undefined, paramsToKeep: string[]): string => {
   if (!searchParams) return ''
@@ -202,7 +202,7 @@ export abstract class RouteUtils {
   static getSearchRoute = (scope: SearchScope | undefined, searchTerm: string) => {
     return scope
       ? `${this.getScopeRoute(scope)}/search?q=${encodeURIComponent(searchTerm)}`
-      : `/search?q=${encodeStringForUrl(searchTerm)}`
+      : `/search?q=${encodeURIComponentPretty(searchTerm)}`
   }
 
   static getTokenRoute = (scope: SearchScope, tokenAddress: string) => {

--- a/src/app/utils/vote.ts
+++ b/src/app/utils/vote.ts
@@ -13,9 +13,10 @@ const voteFilters: Record<VoteType, VoteFilter> = {
 
 export const getFilterForVoteType = (voteType: VoteType): VoteFilter => voteFilters[voteType]
 
-export const getFilterForVoterNameFragment = (fragment: string | undefined) => {
-  if (!fragment) {
+export const getFilterForVoterNameFragment = (fragment: string[]) => {
+  if (!fragment.length) {
     return () => true
   }
-  return (vote: ExtendedVote) => hasTextMatch(vote.validator?.media?.name, [fragment])
+  return (vote: ExtendedVote) =>
+    fragment.every(fragment => hasTextMatch(vote.validator?.media?.name, [fragment]))
 }

--- a/src/app/utils/vote.ts
+++ b/src/app/utils/vote.ts
@@ -1,5 +1,5 @@
 import { ExtendedVote, ProposalVoteValue, VoteFilter, VoteType } from '../../types/vote'
-import { hasTextMatch } from '../components/HighlightedText/text-matching'
+import { hasTextMatchesForAll } from '../components/HighlightedText/text-matching'
 
 export const getRandomVote = (): ProposalVoteValue =>
   [ProposalVoteValue.yes, ProposalVoteValue.no, ProposalVoteValue.abstain][Math.floor(Math.random() * 3)]
@@ -13,10 +13,7 @@ const voteFilters: Record<VoteType, VoteFilter> = {
 
 export const getFilterForVoteType = (voteType: VoteType): VoteFilter => voteFilters[voteType]
 
-export const getFilterForVoterNameFragment = (fragment: string[]) => {
-  if (!fragment.length) {
-    return () => true
-  }
-  return (vote: ExtendedVote) =>
-    fragment.every(fragment => hasTextMatch(vote.validator?.media?.name, [fragment]))
-}
+export const getFilterForVoterNameFragment = (fragments: string[]) =>
+  fragments.length
+    ? (vote: ExtendedVote) => hasTextMatchesForAll(vote.validator?.media?.name, fragments)
+    : () => true

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -808,7 +808,8 @@
   },
   "tableSearch": {
     "error": {
-      "tooShort": "Please enter at least 3 characters to perform a search."
+      "tooShort": "Please enter at least 3 characters to perform a search.",
+      "tooMany": "Too many words"
     },
     "noMatchingResults": "There are no results matching your filters.",
     "clearFilters": "Clear filters"

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -792,6 +792,7 @@ export const useGetRuntimeEvmTokens: typeof generated.useGetRuntimeEvmTokens = (
     ...options,
     request: {
       ...options?.request,
+      paramsSerializer: paramSerializerWithComma,
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.EvmTokenList, headers, status) => {

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -1501,14 +1501,16 @@ export const useGetConsensusAccountsAddressDelegationsTo: typeof generated.useGe
  * We will use this custom serializer when we need to send an array.
  */
 const paramSerializerWithComma = (params: Record<string, any>) => {
-  return Object.entries(params)
+  const result = Object.entries(params)
     .map(([key, value]) => {
       if (Array.isArray(value)) {
-        return `${key}=${value.join(',')}`
+        return `${key}=${value.map(v => encodeURIComponent(v)).join(',')}`
       }
       return `${key}=${value}`
     })
     .join('&')
+  console.log('Result is', result)
+  return ''
 }
 
 export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -1492,6 +1492,25 @@ export const useGetConsensusAccountsAddressDelegationsTo: typeof generated.useGe
     })
   }
 
+/**
+ * Custom param serializer that uses comma for array
+ *
+ * By default, we would serialize params like this: "a[]=b&a[]=c"
+ * However, Nexus expects "a=b,c" instead.
+ *
+ * We will use this custom serializer when we need to send an array.
+ */
+const paramSerializerWithComma = (params: Record<string, any>) => {
+  return Object.entries(params)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return `${key}=${value.join(',')}`
+      }
+      return `${key}=${value}`
+    })
+    .join('&')
+}
+
 export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (
   network,
   layer,
@@ -1503,6 +1522,7 @@ export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (
     ...options,
     request: {
       ...options?.request,
+      paramsSerializer: paramSerializerWithComma,
       transformResponse: [
         ...arrayify(axios.defaults.transformResponse),
         (data: generated.RoflAppList, headers, status) => {

--- a/src/oasis-nexus/api.ts
+++ b/src/oasis-nexus/api.ts
@@ -1491,7 +1491,7 @@ export const useGetConsensusAccountsAddressDelegationsTo: typeof generated.useGe
  * We will use this custom serializer when we need to send an array.
  */
 const paramSerializerWithComma = (params: Record<string, any>) => {
-  const result = Object.entries(params)
+  return Object.entries(params)
     .map(([key, value]) => {
       if (Array.isArray(value)) {
         return `${key}=${value.map(v => encodeURIComponent(v)).join(',')}`
@@ -1499,8 +1499,6 @@ const paramSerializerWithComma = (params: Record<string, any>) => {
       return `${key}=${value}`
     })
     .join('&')
-  console.log('Result is', result)
-  return ''
 }
 
 export const useGetRuntimeRoflApps: typeof generated.useGetRuntimeRoflApps = (

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -253,9 +253,9 @@ limit?: number;
  */
 offset?: number;
 /**
- * A filter on the name of the ROFL app.
+ * A filter on the name of the ROFL app. If multiple names are provided, the ROFL App must match all of them.
  */
-name?: string;
+name?: string[];
 };
 
 export type GetRuntimeAccountsAddressNftsParams = {

--- a/src/oasis-nexus/generated/api.ts
+++ b/src/oasis-nexus/generated/api.ts
@@ -322,9 +322,9 @@ limit?: number;
  */
 offset?: number;
 /**
- * A filter on the name, the name or symbol must contain this value as a substring.
+ * A filter on the name, the name or symbol must contain this value as a substring. If multiple names are provided, the token must match all of them.
  */
-name?: string;
+name?: string[];
 /**
  * The field to sort the tokens by.
 If unset, the tokens will be sorted by number of holders.


### PR DESCRIPTION
Before this change, we executed all text searches looking for an exact match. So if we searched for "apple pie", it matched "apple pie", but _not_ "apple-pie", and definitely not "pie with apple".

However, Nexus has now (https://github.com/oasisprotocol/nexus/pull/1026) enhanced the search feature for rofl apps and evm tokens to cover these cases, too.

So this PR introduces flexible multi-word searching for **_all_** text searches. The search query is tokenized, and we are searching for all of them independently. We have a match if all of them are found, in whatever order.

Here are a few test searched with work with this PR, but didn't work earlier:

* Account name: https://pr-2012.oasis-explorer.pages.dev/search?q=address+burn
* Network change proposal: https://pr-2012.oasis-explorer.pages.dev/search?q=staking+change
* ROFL app: https://pr-2012.oasis-explorer.pages.dev/search?q=rope+dam
* Validator: https://pr-2012.oasis-explorer.pages.dev/search?q=one+chorus
* Token: https://pr-2012.oasis-explorer.pages.dev/testnet/sapphire/search?q=gold+duck
* Voter name (for proposal): https://pr-2012.oasis-explorer.pages.dev/mainnet/consensus/proposal/4?voter=sta+ma

For reviewers: I suggest going commit by commit.
