### PR TITLE
Add support for filtering Rofl app list by name  (flex search version)

### DIFF
--- a/.changelog/2013.feature.md
+++ b/.changelog/2013.feature.md
@@ -1,0 +1,1 @@
+Add support for filtering Rofl app list by name

--- a/src/app/components/Rofl/RoflAppsList.tsx
+++ b/src/app/components/Rofl/RoflAppsList.tsx
@@ -8,15 +8,23 @@ import { TableHeaderAge } from '../TableHeaderAge'
 import { TableCellAge } from '../TableCellAge'
 import { RoflAppStatusBadge } from './RoflAppStatusBadge'
 import { RoflAppLink } from './RoflAppLink'
+import { HighlightPattern } from '../HighlightedText'
 
 type RoflAppsListProps = {
   apps?: RoflApp[]
   isLoading: boolean
   limit: number
   pagination: TablePaginationProps | false
+  highlightPattern?: HighlightPattern
 }
 
-export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, pagination, apps }) => {
+export const RoflAppsList: FC<RoflAppsListProps> = ({
+  isLoading,
+  limit,
+  pagination,
+  apps,
+  highlightPattern,
+}) => {
   const { t } = useTranslation()
   const { isTablet } = useScreenSize()
 
@@ -50,7 +58,12 @@ export const RoflAppsList: FC<RoflAppsListProps> = ({ isLoading, limit, paginati
         },
         {
           content: app?.metadata['net.oasis.rofl.name'] ? (
-            <RoflAppLink id={app.id} name={app?.metadata['net.oasis.rofl.name']} network={app.network} />
+            <RoflAppLink
+              id={app.id}
+              name={app?.metadata['net.oasis.rofl.name']}
+              network={app.network}
+              highlightPattern={highlightPattern}
+            />
           ) : (
             t('rofl.nameNotProvided')
           ),

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -35,6 +35,7 @@ export interface TableSearchBarProps {
   onChange: (value: string) => void
 
   size?: SearchBarSize
+  autoFocus?: boolean
 }
 
 type SizingInfo = {
@@ -60,6 +61,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   warning,
   fullWidth,
   size = 'medium',
+  autoFocus,
   width = 250,
 }) => {
   const { isTablet } = useScreenSize()
@@ -152,6 +154,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
             margin: 2,
             fontSize: sizeMapping[size].font,
           },
+          autoFocus,
         },
         startAdornment,
         endAdornment,

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -14,6 +14,8 @@ import Button from '@mui/material/Button'
 import { CardEmptyState } from '../CardEmptyState'
 import { inputBaseClasses } from '@mui/material/InputBase'
 
+type SearchBarSize = 'small' | 'medium' | 'large'
+
 export interface TableSearchBarProps {
   placeholder: string
   warning?: string
@@ -31,6 +33,24 @@ export interface TableSearchBarProps {
   width?: string | number
 
   onChange: (value: string) => void
+
+  size?: SearchBarSize
+}
+
+type SizingInfo = {
+  font: number | string
+}
+
+const sizeMapping: Record<SearchBarSize, SizingInfo> = {
+  small: {
+    font: '1em',
+  },
+  medium: {
+    font: '1.25em',
+  },
+  large: {
+    font: '1.5em',
+  },
 }
 
 export const TableSearchBar: FC<TableSearchBarProps> = ({
@@ -39,6 +59,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   placeholder,
   warning,
   fullWidth,
+  size = 'medium',
   width = 250,
 }) => {
   const { isTablet } = useScreenSize()
@@ -129,6 +150,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
             p: 0,
             width: fullWidth ? '100%' : width,
             margin: 2,
+            fontSize: sizeMapping[size].font,
           },
         },
         startAdornment,

--- a/src/app/components/Search/TableSearchBar.tsx
+++ b/src/app/components/Search/TableSearchBar.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, KeyboardEventHandler, useCallback, useEffect, useState } from 'react'
 import TextField from '@mui/material/TextField'
 import SearchIcon from '@mui/icons-material/Search'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
@@ -33,7 +33,7 @@ export interface TableSearchBarProps {
   width?: string | number
 
   onChange: (value: string) => void
-
+  onEnter?: () => void
   size?: SearchBarSize
   autoFocus?: boolean
 }
@@ -62,6 +62,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
   fullWidth,
   size = 'medium',
   autoFocus,
+  onEnter,
   width = 250,
 }) => {
   const { isTablet } = useScreenSize()
@@ -78,6 +79,15 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
       setIsWarningFresh(true)
     }
   }, [warning])
+
+  const handleKeyPress: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    event => {
+      if (event.key === 'Enter') {
+        if (onEnter) onEnter()
+      }
+    },
+    [onEnter],
+  )
 
   const startAdornment = (
     <InputAdornment
@@ -146,6 +156,7 @@ export const TableSearchBar: FC<TableSearchBarProps> = ({
       variant={'outlined'}
       value={value}
       onChange={e => onChange(e.target.value)}
+      onKeyDown={handleKeyPress}
       InputProps={{
         inputProps: {
           sx: {

--- a/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
+++ b/src/app/pages/ProposalDetailsPage/ProposalVotesCard.tsx
@@ -140,6 +140,7 @@ export const ProposalVotesCard: FC = () => {
               placeholder={t('networkProposal.searchForVoter')}
               warning={nameError}
               fullWidth={isTablet}
+              size={'small'}
             />
           </Box>
         }

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -229,7 +229,8 @@ export const RoflAppDetailsViewSearchResult: FC<{
 export const RoflAppDetailsVerticalListView: FC<{
   isLoading?: boolean
   app: RoflApp | undefined
-}> = ({ app, isLoading }) => {
+  highlightPattern?: HighlightPattern
+}> = ({ app, isLoading, highlightPattern }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -238,7 +239,7 @@ export const RoflAppDetailsVerticalListView: FC<{
 
   return (
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'} standalone>
-      <NameRow name={app.metadata['net.oasis.rofl.name']} />
+      <NameRow name={app.metadata['net.oasis.rofl.name']} highlightPattern={highlightPattern} />
       <StatusBadgeRow hasActiveInstances={!!app.num_active_instances} removed={app.removed} />
       <DetailsRow title={t('rofl.appId')}>
         <RoflAppLink id={app.id} network={app.network} withSourceIndicator={false} />

--- a/src/app/pages/RoflAppsPage/hook.ts
+++ b/src/app/pages/RoflAppsPage/hook.ts
@@ -6,6 +6,10 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { TablePaginationProps } from '../../components/Table/TablePagination'
 import { Network } from '../../../types/network'
+import { useTranslation } from 'react-i18next'
+import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { textSearch } from '../../components/Search/search-utils'
+import { getHighlightPattern } from '../../components/Search/search-utils'
 
 const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -22,11 +26,28 @@ export const useTableViewMode = () => {
   return { tableView, setTableView }
 }
 
+export const useROFLAppFiltering = () => {
+  const { t } = useTranslation()
+  const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('name', '', { deleteParams: ['page'] })
+  const search = textSearch.roflAppName(wantedNameInput, t)
+  const { result: wantedNamePattern, warning: nameError } = search
+  const highlightPattern = getHighlightPattern(search)
+  return {
+    wantedNameInput,
+    setWantedNameInput,
+    nameError,
+    wantedNamePattern,
+    highlightPattern,
+  }
+}
+
 export const useRoflApps = (network: Network, layer: Runtime) => {
   const { tableView } = useTableViewMode()
   const pagination = useSearchParamsPagination('page')
+  const { wantedNamePattern } = useROFLAppFiltering()
   const offset = (pagination.selectedPage - 1) * limit
   const roflAppsQuery = useGetRuntimeRoflApps(network, layer, {
+    name: wantedNamePattern,
     limit: tableView === TableLayout.Vertical ? offset + limit : limit,
     offset: tableView === TableLayout.Vertical ? 0 : offset,
   })

--- a/src/app/pages/RoflAppsPage/hook.ts
+++ b/src/app/pages/RoflAppsPage/hook.ts
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
 import { textSearch } from '../../components/Search/search-utils'
 import { getHighlightPattern } from '../../components/Search/search-utils'
+import { useSearchParams } from 'react-router-dom'
 
 const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -27,24 +28,35 @@ export const useTableViewMode = () => {
 }
 
 export const useROFLAppFiltering = () => {
+  const setSearchParams = useSearchParams()[1]
   const { t } = useTranslation()
   const [wantedNameInput, setWantedNameInput] = useTypedSearchParam('name', '', { deleteParams: ['page'] })
   const search = textSearch.roflAppName(wantedNameInput, t)
   const { result: wantedNamePattern, warning: nameError } = search
   const highlightPattern = getHighlightPattern(search)
+  const hasFilters = !!wantedNamePattern.length
+  const clearFilters = () => {
+    setSearchParams(searchParams => {
+      searchParams.delete('name')
+      searchParams.delete('page')
+      return searchParams
+    })
+  }
   return {
     wantedNameInput,
     setWantedNameInput,
     nameError,
     wantedNamePattern,
     highlightPattern,
+    hasFilters,
+    clearFilters,
   }
 }
 
 export const useRoflApps = (network: Network, layer: Runtime) => {
   const { tableView } = useTableViewMode()
   const pagination = useSearchParamsPagination('page')
-  const { wantedNamePattern } = useROFLAppFiltering()
+  const { wantedNamePattern, hasFilters } = useROFLAppFiltering()
   const offset = (pagination.selectedPage - 1) * limit
   const roflAppsQuery = useGetRuntimeRoflApps(network, layer, {
     name: wantedNamePattern,
@@ -62,7 +74,11 @@ export const useRoflApps = (network: Network, layer: Runtime) => {
     rowsPerPage: limit,
   }
 
-  const hasNoResultsOnSelectedPage = isFetched && pagination.selectedPage > 1 && !roflApps?.length
+  const hasData = !!roflApps?.length
+  const isOnFirstPage = pagination.selectedPage === 1
+
+  const hasNoResultsOnSelectedPage = isFetched && !isOnFirstPage && !hasData
+  const hasNoResultsBecauseOfFilters = !isLoading && !hasData && isOnFirstPage && hasFilters
 
   return {
     isLoading,
@@ -71,5 +87,6 @@ export const useRoflApps = (network: Network, layer: Runtime) => {
     pagination,
     tablePagination,
     hasNoResultsOnSelectedPage,
+    hasNoResultsBecauseOfFilters,
   }
 }

--- a/src/app/pages/RoflAppsPage/hook.ts
+++ b/src/app/pages/RoflAppsPage/hook.ts
@@ -1,0 +1,54 @@
+import { Runtime, useGetRuntimeRoflApps } from 'oasis-nexus/api'
+import { TableLayout } from '../../components/TableLayoutButton'
+import { useEffect, useState } from 'react'
+import { useScreenSize } from '../../hooks/useScreensize'
+import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
+import { TablePaginationProps } from '../../components/Table/TablePagination'
+import { Network } from '../../../types/network'
+
+const limit = NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
+
+export const useTableViewMode = () => {
+  const { isMobile } = useScreenSize()
+  const [tableView, setTableView] = useState<TableLayout>(TableLayout.Horizontal)
+
+  useEffect(() => {
+    if (!isMobile) {
+      setTableView(TableLayout.Horizontal)
+    }
+  }, [isMobile, setTableView])
+
+  return { tableView, setTableView }
+}
+
+export const useRoflApps = (network: Network, layer: Runtime) => {
+  const { tableView } = useTableViewMode()
+  const pagination = useSearchParamsPagination('page')
+  const offset = (pagination.selectedPage - 1) * limit
+  const roflAppsQuery = useGetRuntimeRoflApps(network, layer, {
+    limit: tableView === TableLayout.Vertical ? offset + limit : limit,
+    offset: tableView === TableLayout.Vertical ? 0 : offset,
+  })
+  const { isLoading, isFetched, data } = roflAppsQuery
+  const roflApps = data?.data.rofl_apps
+
+  const tablePagination: TablePaginationProps = {
+    selectedPage: pagination.selectedPage,
+    linkToPage: pagination.linkToPage,
+    totalCount: data?.data.total_count,
+    isTotalCountClipped: data?.data.is_total_count_clipped,
+    rowsPerPage: limit,
+  }
+
+  const hasNoResultsOnSelectedPage = isFetched && pagination.selectedPage > 1 && !roflApps?.length
+
+  return {
+    isLoading,
+    limit,
+    roflApps,
+    pagination,
+    tablePagination,
+    hasNoResultsOnSelectedPage,
+  }
+}

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -17,6 +17,7 @@ import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
 import { TableSearchBar } from '../../components/Search/TableSearchBar'
 import { Network } from 'types/network'
 import { Runtime } from 'oasis-nexus/api'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const RoflAppsView: FC<{ network: Network; layer: Runtime; tableView: TableLayout }> = ({
   network,
@@ -100,7 +101,9 @@ export const RoflAppsPage: FC = () => {
         noPadding={tableView === TableLayout.Vertical}
         mainTitle
       >
-        <RoflAppsView network={network} layer={layer} tableView={tableView} />
+        <ErrorBoundary>
+          <RoflAppsView network={network} layer={layer} tableView={tableView} />
+        </ErrorBoundary>
       </SubPageCard>
     </PageLayout>
   )

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -13,8 +13,8 @@ import { LoadMoreButton } from '../../components/LoadMoreButton'
 import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButton'
 import { VerticalList } from '../../components/VerticalList'
 import { RoflAppDetailsVerticalListView } from '../RoflAppDetailsPage'
-
-import { useRoflApps, useTableViewMode } from './hook'
+import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
+import { TableSearchBar } from '../../components/Search/TableSearchBar'
 
 export const RoflAppsPage: FC = () => {
   const { tableView, setTableView } = useTableViewMode()
@@ -25,6 +25,7 @@ export const RoflAppsPage: FC = () => {
 
   if (!paraTimesConfig[scope.layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
+  const { wantedNameInput, setWantedNameInput, nameError, highlightPattern } = useROFLAppFiltering()
   const { pagination, tablePagination, isLoading, roflApps, limit, hasNoResultsOnSelectedPage } = useRoflApps(
     scope.network,
     scope.layer,
@@ -33,6 +34,17 @@ export const RoflAppsPage: FC = () => {
   if (hasNoResultsOnSelectedPage) {
     throw AppErrors.PageDoesNotExist
   }
+
+  const searchBar = (
+    <TableSearchBar
+      value={wantedNameInput}
+      onChange={setWantedNameInput}
+      placeholder={t('rofl.searchByNameOrKeyword')}
+      warning={nameError}
+      fullWidth={isMobile}
+      autoFocus={!isMobile}
+    />
+  )
 
   return (
     <PageLayout
@@ -43,12 +55,21 @@ export const RoflAppsPage: FC = () => {
       {!isMobile && <Divider variant="layout" />}
       <SubPageCard
         title={t('rofl.listTitle')}
-        action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
+        action={
+          isMobile ? <TableLayoutButton tableView={tableView} setTableView={setTableView} /> : searchBar
+        }
+        title2={isMobile && searchBar}
         noPadding={tableView === TableLayout.Vertical}
         mainTitle
       >
         {tableView === TableLayout.Horizontal && (
-          <RoflAppsList apps={roflApps} isLoading={isLoading} limit={limit} pagination={tablePagination} />
+          <RoflAppsList
+            apps={roflApps}
+            isLoading={isLoading}
+            limit={limit}
+            pagination={tablePagination}
+            highlightPattern={highlightPattern}
+          />
         )}
 
         {tableView === TableLayout.Vertical && (
@@ -57,7 +78,14 @@ export const RoflAppsPage: FC = () => {
               [...Array(limit).keys()].map(key => (
                 <RoflAppDetailsVerticalListView key={key} isLoading={true} app={undefined} />
               ))}
-            {!isLoading && roflApps?.map(app => <RoflAppDetailsVerticalListView key={app.id} app={app} />)}
+            {!isLoading &&
+              roflApps?.map(app => (
+                <RoflAppDetailsVerticalListView
+                  key={app.id}
+                  app={app}
+                  highlightPattern={highlightPattern}
+                />
+              ))}
           </VerticalList>
         )}
       </SubPageCard>

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -80,7 +80,10 @@ export const RoflAppsPage: FC = () => {
   if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
   const { wantedNameInput, setWantedNameInput, nameError } = useROFLAppFiltering()
-  const { pagination, isLoading, hasNoResultsBecauseOfFilters } = useRoflApps(network, layer)
+  const { pagination, isLoading, hasNoResultsBecauseOfFilters, jumpToSingleResult } = useRoflApps(
+    network,
+    layer,
+  )
 
   const searchBar = (
     <TableSearchBar
@@ -90,6 +93,7 @@ export const RoflAppsPage: FC = () => {
       warning={nameError}
       fullWidth={isMobile}
       autoFocus={!isMobile}
+      onEnter={jumpToSingleResult}
     />
   )
 

--- a/src/app/pages/RoflAppsPage/index.tsx
+++ b/src/app/pages/RoflAppsPage/index.tsx
@@ -14,7 +14,7 @@ import { TableLayout, TableLayoutButton } from '../../components/TableLayoutButt
 import { VerticalList } from '../../components/VerticalList'
 import { RoflAppDetailsVerticalListView } from '../RoflAppDetailsPage'
 import { useROFLAppFiltering, useRoflApps, useTableViewMode } from './hook'
-import { TableSearchBar } from '../../components/Search/TableSearchBar'
+import { NoMatchingDataMaybeClearFilters, TableSearchBar } from '../../components/Search/TableSearchBar'
 import { Network } from 'types/network'
 import { Runtime } from 'oasis-nexus/api'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
@@ -24,14 +24,22 @@ const RoflAppsView: FC<{ network: Network; layer: Runtime; tableView: TableLayou
   layer,
   tableView,
 }) => {
-  const { highlightPattern } = useROFLAppFiltering()
-  const { tablePagination, isLoading, hasNoResultsOnSelectedPage, roflApps, limit } = useRoflApps(
-    network,
-    layer,
-  )
+  const { highlightPattern, clearFilters } = useROFLAppFiltering()
+  const {
+    tablePagination,
+    isLoading,
+    hasNoResultsOnSelectedPage,
+    hasNoResultsBecauseOfFilters,
+    roflApps,
+    limit,
+  } = useRoflApps(network, layer)
 
   if (hasNoResultsOnSelectedPage) {
     throw AppErrors.PageDoesNotExist
+  }
+
+  if (hasNoResultsBecauseOfFilters) {
+    return <NoMatchingDataMaybeClearFilters clearFilters={clearFilters} />
   }
 
   return (
@@ -72,7 +80,7 @@ export const RoflAppsPage: FC = () => {
   if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
   const { wantedNameInput, setWantedNameInput, nameError } = useROFLAppFiltering()
-  const { pagination, isLoading } = useRoflApps(network, layer)
+  const { pagination, isLoading, hasNoResultsBecauseOfFilters } = useRoflApps(network, layer)
 
   const searchBar = (
     <TableSearchBar
@@ -88,7 +96,8 @@ export const RoflAppsPage: FC = () => {
   return (
     <PageLayout
       mobileFooterAction={
-        tableView === TableLayout.Vertical && <LoadMoreButton pagination={pagination} isLoading={isLoading} />
+        tableView === TableLayout.Vertical &&
+        !hasNoResultsBecauseOfFilters && <LoadMoreButton pagination={pagination} isLoading={isLoading} />
       }
     >
       {!isMobile && <Divider variant="layout" />}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -732,6 +732,7 @@
     "roflName": "ROFL name",
     "roleCompute": "Role compute",
     "roleObserver": "Role observer",
+    "searchByNameOrKeyword":  "Search by name or keyword",
     "secretLength": "[{{value}} bytes]",
     "secrets": "Secrets",
     "secretsTooltip": "These secrets are end-to-end encrypted and can only be read by the ROFL app.",


### PR DESCRIPTION
This PR is an updated version of #1987, rebased on top of #2012, so that it has the latest multi-word flex search.

See demo of flex search in the Rofl app list here: https://pr-2013.oasis-explorer.pages.dev/testnet/sapphire/rofl/app?name=tg+cha

Original description follows.

===========

The Nexus API has already added support for filtering the Rofl app list by name in https://github.com/oasisprotocol/nexus/pull/997.

In Explorer, currently this is only unitized in the global search since #1973/. (So that we can find Rofl apps from the global search field.)

This PR adds name/based filtering to the Rofl app list page itself.

I suggest reviewing commit by commit, because the different commits add different (small) features, and also there were some preparatory code refactorings, which would otherwise obscure the actual changes.

## Screenshots

Filtering the list on the desktop

![image](https://github.com/user-attachments/assets/938687bf-69de-4dd6-9bd9-e6d288d64e1d)

When no match:

![image](https://github.com/user-attachments/assets/496fe763-587c-4470-aa04-876763c588d0)

On mobile:

![image](https://github.com/user-attachments/assets/00614379-7c10-499f-99e6-a0f933ed6e45)

On mobile, vertical mode:

![image](https://github.com/user-attachments/assets/abd2f27d-347f-405b-be98-8aadb327b6a2)

No match on mobile:

![image](https://github.com/user-attachments/assets/6bee310b-2932-4b58-8083-0e1feb797d2d)

