### PR TITLE
Improve runtime dashboard robustness

### DIFF
--- a/.changelog/2018.feature.md
+++ b/.changelog/2018.feature.md
@@ -1,0 +1,1 @@
+Improve runtime dashboard resilience

--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -29,6 +29,7 @@ const StyledBoxLight = styled(Box)(() => ({
   backgroundPosition: 'center',
   backgroundRepeat: 'no-repeat',
   backgroundSize: 'cover',
+  height: '100%',
 }))
 
 type EmptyStateProps = {

--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -10,7 +10,6 @@ const StyledBox = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'column',
-  minHeight: '250px',
   color: theme.palette.layout.main,
   backgroundColor: theme.palette.background.empty,
   backgroundImage: `url("${backgroundEmptyState}")`,
@@ -25,7 +24,6 @@ const StyledBoxLight = styled(Box)(() => ({
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'column',
-  minHeight: '250px',
   backgroundPosition: 'center',
   backgroundRepeat: 'no-repeat',
   backgroundSize: 'cover',
@@ -36,9 +34,10 @@ type EmptyStateProps = {
   description: ReactNode
   title: string
   light?: boolean
+  minHeight?: number | string
 }
 
-export const EmptyState: FC<EmptyStateProps> = ({ description, title, light }) => {
+export const EmptyState: FC<EmptyStateProps> = ({ description, title, light, minHeight = '250px' }) => {
   const content = (
     <>
       <Typography component="span" sx={{ fontSize: '24px', fontWeight: 600 }}>
@@ -50,11 +49,11 @@ export const EmptyState: FC<EmptyStateProps> = ({ description, title, light }) =
     </>
   )
   return light ? (
-    <StyledBoxLight>
+    <StyledBoxLight sx={{ minHeight }}>
       <CancelIcon color="error" fontSize="large" />
       {content}
     </StyledBoxLight>
   ) : (
-    <StyledBox>{content}</StyledBox>
+    <StyledBox sx={{ minHeight }}>{content}</StyledBox>
   )
 }

--- a/src/app/components/ErrorBoundary/index.tsx
+++ b/src/app/components/ErrorBoundary/index.tsx
@@ -2,11 +2,12 @@ import { Component, ReactNode } from 'react'
 import { ErrorDisplay } from '../ErrorDisplay'
 
 type HasChildren = {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 type ErrorBoundaryProps = HasChildren & {
   light?: boolean
+  minHeight?: number | string
   fallbackContent?: ReactNode
 }
 
@@ -22,7 +23,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boo
 
   render() {
     if (this.state.hasError) {
-      return this.props.fallbackContent ?? <ErrorDisplay error={this.state.error} light={this.props.light} />
+      return (
+        this.props.fallbackContent ?? (
+          <ErrorDisplay error={this.state.error} light={this.props.light} minHeight={this.props.minHeight} />
+        )
+      )
     }
 
     return this.props.children

--- a/src/app/components/ErrorDisplay/index.tsx
+++ b/src/app/components/ErrorDisplay/index.tsx
@@ -85,7 +85,11 @@ export const errorFormatter = (t: TFunction, error: ErrorPayload) => {
   return errorMap[error.code](t, error)
 }
 
-export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, light }) => {
+export const ErrorDisplay: FC<{ error: unknown; light?: boolean; minHeight?: string | number }> = ({
+  error,
+  light,
+  minHeight,
+}) => {
   const { t } = useTranslation()
 
   let errorPayload: ErrorPayload
@@ -103,5 +107,5 @@ export const ErrorDisplay: FC<{ error: unknown; light?: boolean }> = ({ error, l
 
   const { title, message } = errorFormatter(t, errorPayload)
 
-  return <EmptyState title={title} description={message} light={light} />
+  return <EmptyState title={title} description={message} light={light} minHeight={minHeight} />
 }

--- a/src/app/components/TotalTransactions/index.tsx
+++ b/src/app/components/TotalTransactions/index.tsx
@@ -2,22 +2,22 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import { LineChart } from '../../components/charts/LineChart'
+import { LineChart } from '../charts/LineChart'
 import { useGetLayerStatsTxVolume } from '../../../oasis-nexus/api'
 import { chartUseQueryStaleTimeMs, durationToQueryParams } from '../../utils/chart-utils'
-import { DurationPills } from '../../components/DurationPills'
-import { CardHeaderWithResponsiveActions } from '..//../components/CardHeaderWithResponsiveActions'
+import { DurationPills } from '../DurationPills'
+import { CardHeaderWithResponsiveActions } from '../CardHeaderWithResponsiveActions'
 import { ChartDuration, cumulativeSum } from '../../utils/chart-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { SearchScope } from '../../../types/searchScope'
+import { ErrorBoundary } from '../ErrorBoundary'
 
-export const TotalTransactions: FC<{ chartContainerHeight?: number; scope: SearchScope }> = ({
-  chartContainerHeight = 450,
-  scope,
-}) => {
+const TotalTransactionsContent: FC<{
+  scope: SearchScope
+  chartDuration: ChartDuration
+}> = ({ scope, chartDuration }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
-  const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
   const statsParams = {
     ...durationToQueryParams[chartDuration],
     // We want to start from the beginning of offset as cumulative sum generates a line chart that always goes up
@@ -35,6 +35,43 @@ export const TotalTransactions: FC<{ chartContainerHeight?: number; scope: Searc
     : undefined
 
   return (
+    windows && (
+      <LineChart
+        tooltipActiveDotRadius={9}
+        cartesianGrid
+        strokeWidth={3}
+        dataKey="tx_volume"
+        data={windows}
+        margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
+        tickMargin={16}
+        withLabels
+        formatters={{
+          data: (value: number) =>
+            t('totalTransactions.tooltip', {
+              value,
+              formatParams: {
+                value: {
+                  maximumFractionDigits: 2,
+                } satisfies Intl.NumberFormatOptions,
+              },
+            }),
+          label: (value: string) =>
+            t('common.formattedDateTime', {
+              timestamp: new Date(value),
+            }),
+        }}
+      />
+    )
+  )
+}
+
+export const TotalTransactions: FC<{ chartContainerHeight?: number; scope: SearchScope }> = ({
+  chartContainerHeight = 450,
+  scope,
+}) => {
+  const { t } = useTranslation()
+  const [chartDuration, setChartDuration] = useState<ChartDuration>(ChartDuration.MONTH)
+  return (
     <Card sx={{ flex: 1 }}>
       <CardHeaderWithResponsiveActions
         action={<DurationPills handleChange={setChartDuration} value={chartDuration} />}
@@ -43,33 +80,9 @@ export const TotalTransactions: FC<{ chartContainerHeight?: number; scope: Searc
         title={t('totalTransactions.header')}
       />
       <CardContent sx={{ height: chartContainerHeight }}>
-        {windows && (
-          <LineChart
-            tooltipActiveDotRadius={9}
-            cartesianGrid
-            strokeWidth={3}
-            dataKey="tx_volume"
-            data={windows}
-            margin={{ bottom: 16, top: isMobile ? 0 : 16 }}
-            tickMargin={16}
-            withLabels
-            formatters={{
-              data: (value: number) =>
-                t('totalTransactions.tooltip', {
-                  value,
-                  formatParams: {
-                    value: {
-                      maximumFractionDigits: 2,
-                    } satisfies Intl.NumberFormatOptions,
-                  },
-                }),
-              label: (value: string) =>
-                t('common.formattedDateTime', {
-                  timestamp: new Date(value),
-                }),
-            }}
-          />
-        )}
+        <ErrorBoundary light>
+          <TotalTransactionsContent scope={scope} chartDuration={chartDuration} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ParatimeDashboardPage/LatestRoflApps.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRoflApps.tsx
@@ -12,18 +12,24 @@ import { COLORS } from '../../../styles/theme/colors'
 import { AppErrors } from '../../../types/errors'
 import { RouteUtils } from '../../utils/route-utils'
 import { RoflAppsList } from '../../components/Rofl/RoflAppsList'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
-export const LatestRoflApps: FC<{ scope: RuntimeScope }> = ({ scope }) => {
-  const { t } = useTranslation()
+const LatestRoflAppsContent: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { network, layer } = scope
   if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
   const roflAppsQuery = useGetRuntimeRoflApps(network, layer, { limit })
   const { isLoading, data } = roflAppsQuery
   const roflApps = data?.data.rofl_apps
-
   if (!roflApps?.length) {
     return null
   }
+  return <RoflAppsList apps={roflApps} isLoading={isLoading} limit={limit} pagination={false} />
+}
+
+export const LatestRoflApps: FC<{ scope: RuntimeScope }> = ({ scope }) => {
+  const { t } = useTranslation()
+  const { layer } = scope
+  if (!paraTimesConfig[layer]?.offerRoflTxTypes) throw AppErrors.UnsupportedLayer
 
   return (
     <Card>
@@ -42,7 +48,9 @@ export const LatestRoflApps: FC<{ scope: RuntimeScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <RoflAppsList apps={roflApps} isLoading={isLoading} limit={limit} pagination={false} />
+        <ErrorBoundary light>
+          <LatestRoflAppsContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
@@ -12,12 +12,12 @@ import { COLORS } from '../../../styles/theme/colors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { RuntimeScope } from '../../../types/searchScope'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
+const LatestRuntimeBlocksContent: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { isMobile } = useScreenSize()
-  const { t } = useTranslation()
   const { network, layer } = scope
   const blocksQuery = useGetRuntimeBlocks(
     network,
@@ -29,6 +29,20 @@ export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
       },
     },
   )
+
+  return (
+    <RuntimeBlocks
+      isLoading={blocksQuery.isLoading}
+      blocks={blocksQuery.data?.data.blocks}
+      limit={limit}
+      pagination={false}
+      type={isMobile ? BlocksTableType.Mobile : BlocksTableType.DesktopLite}
+    />
+  )
+}
+
+export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
+  const { t } = useTranslation()
 
   return (
     <Card>
@@ -47,13 +61,9 @@ export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <RuntimeBlocks
-          isLoading={blocksQuery.isLoading}
-          blocks={blocksQuery.data?.data.blocks}
-          limit={limit}
-          pagination={false}
-          type={isMobile ? BlocksTableType.Mobile : BlocksTableType.DesktopLite}
-        />
+        <ErrorBoundary light>
+          <LatestRuntimeBlocksContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeBlocks.tsx
@@ -61,7 +61,7 @@ export const LatestRuntimeBlocks: FC<{ scope: RuntimeScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <ErrorBoundary light>
+        <ErrorBoundary light minHeight={400}>
           <LatestRuntimeBlocksContent scope={scope} />
         </ErrorBoundary>
       </CardContent>

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
@@ -15,17 +15,17 @@ import { RuntimeScope } from '../../../types/searchScope'
 import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
 import Box from '@mui/material/Box'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 const shouldFilter = FILTERING_ON_DASHBOARD
 
-export const LatestRuntimeTransactions: FC<{
+const LatestRuntimeTransactionsContent: FC<{
   scope: RuntimeScope
   method: string
   setMethod: (value: string) => void
-}> = ({ scope, method, setMethod }) => {
-  const { isMobile, isTablet } = useScreenSize()
-  const { t } = useTranslation()
+}> = ({ scope, method }) => {
+  const { isTablet } = useScreenSize()
   const { network, layer } = scope
 
   const transactionsQuery = useGetRuntimeTransactions(
@@ -41,6 +41,27 @@ export const LatestRuntimeTransactions: FC<{
       },
     },
   )
+
+  return (
+    <RuntimeTransactions
+      transactions={transactionsQuery.data?.data.transactions}
+      isLoading={transactionsQuery.isLoading}
+      limit={limit}
+      pagination={false}
+      verbose={!isTablet}
+      filtered={method !== 'any'}
+    />
+  )
+}
+
+export const LatestRuntimeTransactions: FC<{
+  scope: RuntimeScope
+  method: string
+  setMethod: (value: string) => void
+}> = ({ scope, method, setMethod }) => {
+  const { isMobile } = useScreenSize()
+  const { t } = useTranslation()
+  const { layer } = scope
 
   return (
     <Card>
@@ -75,14 +96,9 @@ export const LatestRuntimeTransactions: FC<{
         <RuntimeTransactionTypeFilter layer={layer} value={method} setValue={setMethod} expand />
       )}
       <CardContent>
-        <RuntimeTransactions
-          transactions={transactionsQuery.data?.data.transactions}
-          isLoading={transactionsQuery.isLoading}
-          limit={limit}
-          pagination={false}
-          verbose={!isTablet}
-          filtered={method !== 'any'}
-        />
+        <ErrorBoundary light>
+          <LatestRuntimeTransactionsContent scope={scope} method={method} setMethod={setMethod} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )

--- a/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
+++ b/src/app/pages/ParatimeDashboardPage/ParaTimeSnapshot.tsx
@@ -13,6 +13,7 @@ import { TestnetFaucet } from './TestnetFaucet'
 import { RuntimeScope } from '../../../types/searchScope'
 import { Snapshot, StyledGrid } from 'app/components/Snapshots/Snapshot'
 import { getFaucetLink } from '../../utils/faucet-links'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 export const ParaTimeSnapshot: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { t } = useTranslation()
@@ -32,7 +33,7 @@ export const ParaTimeSnapshot: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   }
 
   return (
-    <>
+    <ErrorBoundary>
       <Snapshot
         header={
           <DurationSelect
@@ -57,6 +58,6 @@ export const ParaTimeSnapshot: FC<{ scope: RuntimeScope }> = ({ scope }) => {
           {faucetLink && <TestnetFaucet network={scope.network} layer={scope.layer} ticker={mainTicker} />}
         </StyledGrid>
       </Snapshot>
-    </>
+    </ErrorBoundary>
   )
 }

--- a/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
+++ b/src/app/pages/ParatimeDashboardPage/TopTokens.tsx
@@ -11,13 +11,26 @@ import { COLORS } from '../../../styles/theme/colors'
 import { RouteUtils } from '../../utils/route-utils'
 import { TokenList } from '../../components/Tokens/TokenList'
 import { RuntimeScope } from '../../../types/searchScope'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 
-export const TopTokens: FC<{ scope: RuntimeScope }> = ({ scope }) => {
-  const { t } = useTranslation()
+const TopTokensContent: FC<{ scope: RuntimeScope }> = ({ scope }) => {
   const { network, layer } = scope
   const tokensQuery = useGetRuntimeEvmTokens(network, layer, { limit })
+
+  return (
+    <TokenList
+      tokens={tokensQuery.data?.data.evm_tokens}
+      isLoading={tokensQuery.isLoading}
+      limit={limit}
+      pagination={false}
+    />
+  )
+}
+
+export const TopTokens: FC<{ scope: RuntimeScope }> = ({ scope }) => {
+  const { t } = useTranslation()
 
   return (
     <Card>
@@ -36,12 +49,9 @@ export const TopTokens: FC<{ scope: RuntimeScope }> = ({ scope }) => {
         }
       />
       <CardContent>
-        <TokenList
-          tokens={tokensQuery.data?.data.evm_tokens}
-          isLoading={tokensQuery.isLoading}
-          limit={limit}
-          pagination={false}
-        />
+        <ErrorBoundary light>
+          <TopTokensContent scope={scope} />
+        </ErrorBoundary>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
This is a follow-up to #2004; delivering the second part of #1999.

This makes the paratime dashboard more robust.

With almost everything blocked:

![image](https://github.com/user-attachments/assets/051477d1-cb1e-4415-9e1f-1b4d5a0cad08)
