### PR TITLE
Remove ui-library directory

### DIFF
--- a/.changelog/2027.trivial.md
+++ b/.changelog/2027.trivial.md
@@ -1,0 +1,1 @@
+Remove ui-library directory


### PR DESCRIPTION
I added this by accident in https://github.com/oasisprotocol/explorer/pull/2026