### PR TITLE
Assume "unknown" method and status means encrypted so show a lock icon

### DIFF
--- a/.changelog/2032.bugfix.md
+++ b/.changelog/2032.bugfix.md
@@ -1,0 +1,1 @@
+Assume "unknown" method and status means encrypted so show a lock icon

--- a/src/app/components/RuntimeTransactionMethod/index.tsx
+++ b/src/app/components/RuntimeTransactionMethod/index.tsx
@@ -12,6 +12,7 @@ import LanIcon from '@mui/icons-material/Lan'
 import LanOutlinedIcon from '@mui/icons-material/LanOutlined'
 import DeveloperBoard from '@mui/icons-material/DeveloperBoard'
 import DeveloperBoardOffIcon from '@mui/icons-material/DeveloperBoardOff'
+import LockIcon from '@mui/icons-material/Lock'
 import { MethodIcon } from '../ConsensusTransactionMethod'
 import { GetRuntimeTransactionsParams, Layer, RuntimeTransaction } from '../../../oasis-nexus/api'
 import { SelectOptionBase } from '../Select'
@@ -23,6 +24,7 @@ const getRuntimeTransactionLabel = (t: TFunction, method: KnownRuntimeTxMethod) 
   switch (method) {
     case '':
       // Method may be empty if the transaction was malformed, or encrypted (oasis_encryption_envelope).
+      // TODO: differentiate malformed and encrypted
       return t('common.unknown')
     case 'accounts.Transfer':
       return t('transactions.method.accounts.transfer')
@@ -183,7 +185,9 @@ const getRuntimeTransactionIcon = (method: KnownRuntimeTxMethod, label: string, 
     case 'roflmarket.InstanceExecuteCmds':
       return <MethodIcon icon={<DeveloperBoard />} {...props} />
     case '':
-      return <MethodIcon color="gray" icon={<QuestionMarkIcon />} {...props} />
+      // Method may be empty if the transaction was malformed, or encrypted (oasis_encryption_envelope).
+      // TODO: differentiate malformed and encrypted
+      return <MethodIcon color="green" icon={<LockIcon />} {...props} />
     default:
       exhaustedTypeWarning('Unknown runtime tx method', method)
       return <MethodIcon color="gray" icon={<QuestionMarkIcon />} {...props} />

--- a/src/app/components/StatusIcon/index.tsx
+++ b/src/app/components/StatusIcon/index.tsx
@@ -6,6 +6,7 @@ import CancelIcon from '@mui/icons-material/Cancel'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 import HelpIcon from '@mui/icons-material/Help'
+import LockIcon from '@mui/icons-material/Lock'
 import { TxError } from '../../../oasis-nexus/api'
 import Tooltip from '@mui/material/Tooltip'
 import { useTxErrorMessage } from '../../hooks/useTxErrorMessage'
@@ -30,7 +31,7 @@ const statusFgColor: Record<TxStatus, string> = {
 }
 
 export const statusIcon: Record<TxStatus, ReactNode> = {
-  unknown: <HelpIcon color="inherit" fontSize="inherit" />,
+  unknown: <LockIcon color="inherit" fontSize="inherit" />,
   success: <CheckCircleIcon color="inherit" fontSize="inherit" />,
   partialsuccess: <CheckCircleIcon color="success" fontSize="inherit" />,
   failure: <CancelIcon color="error" fontSize="inherit" />,


### PR DESCRIPTION
Status already differentiates two-step transactions with unknown status as pending. And there are currently no other transactions that are missing these.

![Screenshot from 2025-06-11 23-07-25](https://github.com/user-attachments/assets/17eaca2c-0058-4cf3-b454-d801fff2a039)
