### PR TITLE
Adjust the titleOnBackground color in the default theme

### DIFF
--- a/.changelog/2051.bugfix.md
+++ b/.changelog/2051.bugfix.md
@@ -1,0 +1,1 @@
+Adjust the titleOnBackground color in the default theme

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -107,7 +107,7 @@ export const defaultTheme = createTheme({
       primaryBackground: COLORS.brandExtraDark,
       secondaryBackground: COLORS.iconBackground,
       networkBubbleBorder: COLORS.white,
-      titleOnBackground: COLORS.white,
+      titleOnBackground: COLORS.brandExtraDark,
       graphZoomOutText: COLORS.white,
       helpScreenIconColor: COLORS.aqua,
     },


### PR DESCRIPTION
Since we are now using white instead of blue bg, the "title on bg" color must be dark, not white, since it must have a contrast with the white bg.

|Before|After|
| --- | --- |
| ![image](https://github.com/user-attachments/assets/d0af1f1d-f4a5-43ca-98c2-900b7d5659a4)  | ![image](https://github.com/user-attachments/assets/1122864f-286d-4b42-8438-4d651ccdc17a)  |
| ![image](https://github.com/user-attachments/assets/3d7e4f2c-178c-413a-bc97-ae41971c0a60)  | ![image](https://github.com/user-attachments/assets/bd6b69dc-06c6-498a-97c0-2f17900a627d)  |

Fixes #2049 