### PR TITLE
Quick fix for mobile opening screen on Testnet

### DIFF
--- a/.changelog/2056.bugfix.md
+++ b/.changelog/2056.bugfix.md
@@ -1,0 +1,1 @@
+Quick fix for mobile opening screen on TestNet

--- a/src/app/pages/HomePage/Graph/HelpScreen/index.tsx
+++ b/src/app/pages/HomePage/Graph/HelpScreen/index.tsx
@@ -14,9 +14,8 @@ import { TapIcon } from '../../../../components/CustomIcons/Tap'
 import { PinchIcon } from '../../../../components/CustomIcons/Pinch'
 import { NavigateIcon } from '../../../../components/CustomIcons/Navigate'
 import { Theme } from '@mui/material/styles/createTheme'
-import { COLORS } from 'styles/theme/colors'
 
-const HelpScreenContainer = styled(Box)(() => ({
+const HelpScreenContainer = styled(Box)(({ theme }) => ({
   position: 'absolute',
   top: '65%',
   left: '50%',
@@ -28,7 +27,7 @@ const HelpScreenContainer = styled(Box)(() => ({
   minHeight: '185px',
   width: '90%',
   height: '100%',
-  color: COLORS.white,
+  color: theme.palette.layout.contrastMain,
 }))
 
 const SwiperBox = styled(Box)(() => ({


### PR DESCRIPTION
Make the text layout.contrastMain color, which works for both mainnet and testnet

Fixes #2055 

Now we have:

![image](https://github.com/user-attachments/assets/290a4951-bcd1-4ed6-9e15-649acbd48db5)

![image](https://github.com/user-attachments/assets/a698aede-159e-4a65-b2b7-122053dbf220)

