### PR TITLE
Fix color of info button on mobile opening screen

### DIFF
--- a/.changelog/2057.bugfix.md
+++ b/.changelog/2057.bugfix.md
@@ -1,0 +1,1 @@
+Fix color of info button on mobile opening screen

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -164,7 +164,7 @@ export const HomePage: FC = () => {
             </SearchInputBox>
             {showInfoScreenBtn && (
               <InfoScreenBtn aria-label={infoAriaLabel} onClick={onToggleInfoScreenClick}>
-                <InfoOutlinedIcon fontSize="medium" sx={{ color: 'white' }} />
+                <InfoOutlinedIcon fontSize="medium" sx={{ color: COLORS.grayMedium2 }} />
               </InfoScreenBtn>
             )}
           </SearchInputContainer>


### PR DESCRIPTION
The small "i" button on the top left is now visible

 | Before | After |
| --- | --- |
|  ![image](https://github.com/user-attachments/assets/922f349c-2240-4f3b-8f1a-c7b6d3b2cf40)   |  ![image](https://github.com/user-attachments/assets/b7f38d87-6fab-44c3-add4-e6c77d01f966)  |
|  ![image](https://github.com/user-attachments/assets/48039594-aaa1-4db4-a0da-38182f01312d)  | ![image](https://github.com/user-attachments/assets/27905212-44b6-49e9-b124-2ad86f38aba1)  |

Fixes remaining problem from #2055