### PR TITLE
Add tooltip to Fee Proxy field

### DIFF
--- a/.changelog/2066.trivial.md
+++ b/.changelog/2066.trivial.md
@@ -1,0 +1,1 @@
+Add tooltip to Fee Proxy field

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -43,6 +43,7 @@ import { transactionEventsContainerId } from '../../utils/tabAnchors'
 import Link from '@mui/material/Link'
 import { Link as RouterLink } from 'react-router-dom'
 import { RouteUtils } from '../../utils/route-utils'
+import Tooltip from '@mui/material/Tooltip'
 
 export const RuntimeTransactionDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -324,17 +325,26 @@ export const RuntimeTransactionDetailView: FC<{
               <dt>{t('common.feeProxy')}</dt>
               <dd>
                 {transaction.fee_proxy_module === 'rofl' ? (
-                  <Link
-                    component={RouterLink}
-                    to={RouteUtils.getRoflAppRoute(
-                      transaction.network,
-                      oasis.address.toBech32('rofl', Buffer.from(transaction.fee_proxy_id, 'base64')),
-                    )}
-                  >
-                    {oasis.address.toBech32('rofl', Buffer.from(transaction.fee_proxy_id, 'base64'))}
-                  </Link>
+                  <Tooltip title={t('common.feeProxyTooltip')} arrow placement="top">
+                    <span>
+                      <Link
+                        component={RouterLink}
+                        to={RouteUtils.getRoflAppRoute(
+                          transaction.network,
+                          oasis.address.toBech32('rofl', Buffer.from(transaction.fee_proxy_id, 'base64')),
+                        )}
+                      >
+                        {oasis.address.toBech32('rofl', Buffer.from(transaction.fee_proxy_id, 'base64'))}
+                      </Link>
+                    </span>
+                  </Tooltip>
                 ) : (
-                  `${t('common.module')}: ${transaction.fee_proxy_module}, ${t('common.id')}: ${base64ToHex(transaction.fee_proxy_id)}`
+                  <>
+                    {t('common.module')}: {transaction.fee_proxy_module}, {t('common.id')}:&nbsp;
+                    <Tooltip title={t('common.feeProxyTooltip')} arrow placement="top">
+                      <span> {base64ToHex(transaction.fee_proxy_id)}</span>
+                    </Tooltip>
+                  </>
                 )}
               </dd>
             </>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -151,6 +151,7 @@
     "transactionAbbreviation": "Txs",
     "fee": "Fee",
     "feeProxy": "Fee proxy",
+    "feeProxyTooltip": "Account paying for the transaction fee on behalf of the caller",
     "transfers": "Transfers",
     "type": "Type",
     "quantity": "Quantity",


### PR DESCRIPTION
Add tooltip to Fee proxy field. 
Closes [#2046](https://github.com/oasisprotocol/explorer/issues/2046).

Before:
<img width="642" alt="Screenshot 2025-07-09 at 12 00 03" src="https://github.com/user-attachments/assets/1b232bc0-690f-465e-9279-bbe21ae573be" />

After:
<img width="661" alt="Screenshot 2025-07-09 at 12 00 32" src="https://github.com/user-attachments/assets/799d3299-ed9a-4d4d-98b6-4ee9b41311fe" />
