### PR TITLE
Further enhance ROFL app endorsement display

### DIFF
--- a/.changelog/2072.trivial.md
+++ b/.changelog/2072.trivial.md
@@ -1,0 +1,1 @@
+Further enhance endorsement display

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -79,6 +79,105 @@ interface Props {
   labelOnly?: boolean
 }
 
+// We want two lines, one for name (if available), one for address
+// Both lines adaptively shortened to fill available space
+const AdaptivelyTrimmedAccountLink: FC<
+  Pick<Props, 'scope' | 'address' | 'labelOnly' | 'showOnlyAddress' | 'highlightPattern'> & {
+    tooltipTitle: ReactNode
+  }
+> = ({ scope, address, labelOnly, showOnlyAddress, highlightPattern, tooltipTitle }) => {
+  const {
+    metadata: accountMetadata,
+    // isError, // Use this to indicate that we have failed to load the name for this account
+  } = useAccountMetadata(scope, address)
+  const accountName = accountMetadata?.name // TODO: we should also use the description
+  const showAccountName = !showOnlyAddress && !!accountName
+
+  return (
+    <WithTypographyAndLink scope={scope} address={address} mobile labelOnly={labelOnly}>
+      <>
+        {showAccountName && (
+          <Box
+            component="span"
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
+          >
+            <AccountMetadataSourceIndicator source={accountMetadata.source} />
+            <AdaptiveHighlightedText
+              idPrefix="account-name"
+              text={accountName}
+              pattern={highlightPattern}
+              extraTooltip={tooltipTitle}
+              minLength={5}
+            />
+          </Box>
+        )}
+        <AdaptiveTrimmer
+          idPrefix="account-address"
+          text={address}
+          strategy="middle"
+          tooltipOverride={tooltipTitle}
+          minLength={13}
+        />
+      </>
+    </WithTypographyAndLink>
+  )
+}
+
+const TrimmedAccountLink: FC<
+  Pick<Props, 'scope' | 'address' | 'labelOnly' | 'showOnlyAddress'> & { tooltipTitle: ReactNode }
+> = ({ scope, address, labelOnly, tooltipTitle, showOnlyAddress }) => {
+  const {
+    metadata: accountMetadata,
+    // isError, // Use this to indicate that we have failed to load the name for this account
+  } = useAccountMetadata(scope, address)
+  const accountName = accountMetadata?.name // TODO: we should also use the description
+  const showAccountName = !showOnlyAddress && !!accountName
+  return (
+    <WithTypographyAndLink scope={scope} address={address} labelOnly={labelOnly}>
+      <MaybeWithTooltip title={tooltipTitle}>
+        {showAccountName ? (
+          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+            <AccountMetadataSourceIndicator source={accountMetadata!.source} />{' '}
+            {trimLongString(accountName, 12, 0)}
+          </Box>
+        ) : (
+          trimLongString(address, 6, 6)
+        )}
+      </MaybeWithTooltip>
+    </WithTypographyAndLink>
+  )
+}
+
+const DesktopAccountLink: FC<
+  Pick<Props, 'scope' | 'address' | 'labelOnly' | 'showOnlyAddress' | 'highlightPattern'> & {
+    tooltipTitle: ReactNode
+  }
+> = ({ scope, address, labelOnly, showOnlyAddress, highlightPattern, tooltipTitle }) => {
+  const {
+    metadata: accountMetadata,
+    // isError, // Use this to indicate that we have failed to load the name for this account
+  } = useAccountMetadata(scope, address)
+  const accountName = accountMetadata?.name // TODO: we should also use the description
+  const showAccountName = !showOnlyAddress && !!accountName
+  return (
+    <WithTypographyAndLink scope={scope} address={address} labelOnly={labelOnly}>
+      <MaybeWithTooltip title={tooltipTitle}>
+        {showAccountName ? (
+          <Box
+            component="span"
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
+          >
+            <AccountMetadataSourceIndicator source={accountMetadata!.source} />
+            <HighlightedText text={accountName} pattern={highlightPattern} /> ({address})
+          </Box>
+        ) : (
+          address
+        )}
+      </MaybeWithTooltip>
+    </WithTypographyAndLink>
+  )
+}
+
 export const AccountLink: FC<Props> = ({
   showOnlyAddress,
   scope,
@@ -130,18 +229,13 @@ export const AccountLink: FC<Props> = ({
     // In a table, we only ever want a short line
 
     return (
-      <WithTypographyAndLink scope={scope} address={address} labelOnly={labelOnly}>
-        <MaybeWithTooltip title={tooltipTitle}>
-          {showAccountName ? (
-            <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-              <AccountMetadataSourceIndicator source={accountMetadata!.source} />{' '}
-              {trimLongString(accountName, 12, 0)}
-            </Box>
-          ) : (
-            trimLongString(address, 6, 6)
-          )}
-        </MaybeWithTooltip>
-      </WithTypographyAndLink>
+      <TrimmedAccountLink
+        scope={scope}
+        address={address}
+        showOnlyAddress={showOnlyAddress}
+        labelOnly={labelOnly}
+        tooltipTitle={tooltipTitle}
+      />
     )
   }
 
@@ -150,53 +244,26 @@ export const AccountLink: FC<Props> = ({
     // We want one long line, with name and address.
 
     return (
-      <WithTypographyAndLink scope={scope} address={address} labelOnly={labelOnly}>
-        <MaybeWithTooltip title={tooltipTitle}>
-          {showAccountName ? (
-            <Box
-              component="span"
-              sx={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
-            >
-              <AccountMetadataSourceIndicator source={accountMetadata!.source} />
-              <HighlightedText text={accountName} pattern={highlightPattern} /> ({address})
-            </Box>
-          ) : (
-            address
-          )}
-        </MaybeWithTooltip>
-      </WithTypographyAndLink>
+      <DesktopAccountLink
+        scope={scope}
+        address={address}
+        showOnlyAddress={showOnlyAddress}
+        labelOnly={labelOnly}
+        highlightPattern={highlightPattern}
+        tooltipTitle={tooltipTitle}
+      />
     )
   }
 
   // We need to show the data in details mode on mobile.
-  // We want two lines, one for name (if available), one for address
-  // Both lines adaptively shortened to fill available space
   return (
-    <WithTypographyAndLink scope={scope} address={address} mobile labelOnly={labelOnly}>
-      <>
-        {showAccountName && (
-          <Box
-            component="span"
-            sx={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
-          >
-            <AccountMetadataSourceIndicator source={accountMetadata.source} />
-            <AdaptiveHighlightedText
-              idPrefix="account-name"
-              text={accountName}
-              pattern={highlightPattern}
-              extraTooltip={tooltipTitle}
-              minLength={5}
-            />
-          </Box>
-        )}
-        <AdaptiveTrimmer
-          idPrefix="account-address"
-          text={address}
-          strategy="middle"
-          tooltipOverride={tooltipTitle}
-          minLength={13}
-        />
-      </>
-    </WithTypographyAndLink>
+    <AdaptivelyTrimmedAccountLink
+      scope={scope}
+      address={address}
+      showOnlyAddress={showOnlyAddress}
+      labelOnly={labelOnly}
+      highlightPattern={highlightPattern}
+      tooltipTitle={tooltipTitle}
+    />
   )
 }

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -60,6 +60,11 @@ interface Props {
   alwaysTrimOnTablet?: boolean
 
   /**
+   * Use adaptive trimming, ignoring the size
+   */
+  alwaysAdapt?: boolean
+
+  /**
    * What part of the name should be highlighted (if any)
    */
   highlightPattern?: HighlightPattern
@@ -184,6 +189,7 @@ export const AccountLink: FC<Props> = ({
   address,
   alwaysTrim,
   alwaysTrimOnTablet,
+  alwaysAdapt,
   highlightPattern,
   extraTooltip,
   labelOnly,
@@ -227,7 +233,6 @@ export const AccountLink: FC<Props> = ({
   // Are we in a situation when we should always trim?
   if (alwaysTrim || (alwaysTrimOnTablet && isTablet)) {
     // In a table, we only ever want a short line
-
     return (
       <TrimmedAccountLink
         scope={scope}
@@ -239,8 +244,8 @@ export const AccountLink: FC<Props> = ({
     )
   }
 
-  if (!isTablet) {
-    // Details in desktop mode.
+  if (!isTablet && !alwaysTrimOnTablet) {
+    // We are in desktop mode, and there is no need to do adaptive trimming
     // We want one long line, with name and address.
 
     return (
@@ -255,7 +260,8 @@ export const AccountLink: FC<Props> = ({
     )
   }
 
-  // We need to show the data in details mode on mobile.
+  // We need to use adaptive mode, either because we are on tablet or mobile,
+  // or because it has been explicitly requested
   return (
     <AdaptivelyTrimmedAccountLink
       scope={scope}

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -164,7 +164,18 @@ export const RoflAppDetailsView: FC<{
         transaction={app.last_activity_tx}
       />
       <DetailsRow title={t('rofl.endorsement')}>
-        <Endorsement endorsements={app.policy.endorsements} />
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Endorsement
+            endorsements={app.policy.endorsements}
+            groupOp={'or'} // We have an implicit default "or" for toplevel endorsement
+          />
+        </Box>
       </DetailsRow>
       <DetailsRow
         title={

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -731,14 +731,14 @@
     "endorsement": "Endorsement",
     "endorsementLabels": {
       "any": "Any node can endorse the enclave",
-      "entity": "Registered node from a specific entity can endorse the enclave: ",
-      "node": "Specific node can endorse the enclave: ",
-      "role_compute": "Compute node for the current runtime can endorse the enclave",
-      "role_observer": "Observer node for the current runtime can endorse the enclave",
-      "provider": "Any node from a specific provider can endorse the enclave: ",
-      "provider_instance_admin": "Any provider instance where the given address is currently the admin: ",
-      "and": "Evaluate all of the child endorsement policies and allow in case all accept the node: ",
-      "or": "Evaluate all of the child endorsement policies and allow in case any accepts the node: "
+      "entity": "Node from entity <Address />",
+      "node": "Node <address />",
+      "role_compute": "Node has the <i>compute</i> role for the current runtime",
+      "role_observer": "Node has the <i>observer</i> role for the current runtime",
+      "provider": "Node from provider <Address />",
+      "provider_instance_admin": "<Address /> is currently admin on machine",
+      "and": "and",
+      "or": "or"
     },
     "endorsingNodeAddress": "Endorsing node address",
     "endorsingNodeId": "Endorsing node ID",


### PR DESCRIPTION
https://pr-2072.oasis-explorer.pages.dev/testnet/sapphire/rofl/app/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw

Changes:

- Add links to Endorsement display:
  node, provider, provider_instance_admin, and entity are now displayed as links.
- Improve displaying AND and OR structures
- Rephrase the text

| Before | After |
| --- | --- |
| <img width="941" height="335" alt="image" src="https://github.com/user-attachments/assets/38614fa5-52e2-4ed9-a59f-9c7f23d3ed4d" /> | <img width="865" height="282" alt="image" src="https://github.com/user-attachments/assets/83f93fee-d1a1-4dfe-b4bf-e05248f89790" /> |
| <img width="363" height="861" alt="image" src="https://github.com/user-attachments/assets/8144e93a-a937-4cd2-b4f4-3b32a0f7f392" /> | <img width="368" height="437" alt="image" src="https://github.com/user-attachments/assets/7a72125b-31d3-4605-b645-c28a945dff8d" />   |
