### PR TITLE
Update tag for accounts with 0 balance

### DIFF
--- a/.changelog/2073.trivial.md
+++ b/.changelog/2073.trivial.md
@@ -1,0 +1,1 @@
+Update tag for accounts with 0 balance.

--- a/src/app/utils/helpers.ts
+++ b/src/app/utils/helpers.ts
@@ -100,17 +100,19 @@ export function uniq<T>(input: T[] | undefined): T[] {
 export const isValidMnemonic = (candidate: string): boolean => validateMnemonic(candidate)
 
 export const getAccountSize = (value: bigint) => {
-  if (value >= 100_000_000_000_000_000n) {
+  if (value === 0n) {
+    return '-'
+  } else if (value >= 100_000_000_000_000_000n) {
     return 'XXL'
-  } else if (value >= 50_000_000_000_000_000n && value <= 99_999_999_000_000_000n) {
+  } else if (value >= 50_000_000_000_000_000n && value <= 99_999_999_999_999_999n) {
     return 'XL'
-  } else if (value >= 25_000_000_000_000_000n && value <= 49_999_999_000_000_000n) {
+  } else if (value >= 25_000_000_000_000_000n && value <= 49_999_999_999_999_999n) {
     return 'L'
-  } else if (value >= 1_000_000_000_000_000n && value <= 24_999_999_000_000_000n) {
+  } else if (value >= 1_000_000_000_000_000n && value <= 24_999_999_999_999_999n) {
     return 'M'
-  } else if (value >= 500_000_000_000_000n && value <= 999_999_000_000_000n) {
+  } else if (value >= 500_000_000_000_000n && value <= 999_999_999_999_999n) {
     return 'S'
-  } else if (value >= 100_000_000_000_000n && value <= 499_99_000_000_0009n) {
+  } else if (value >= 100_000_000_000_000n && value <= 499_999_999_999_999n) {
     return 'XS'
   } else {
     return 'XXS'


### PR DESCRIPTION
Mark accounts with 0 balance as '-' instead of 'XXS'. Fixes issue [#1857](https://github.com/oasisprotocol/explorer/issues/1857)

Before:
<img width="1618" height="821" alt="Screenshot 2025-07-18 at 13 04 26" src="https://github.com/user-attachments/assets/a2b6fc15-8ec3-492d-9c8a-a6de297115d7" />

After:
<img width="1614" height="810" alt="Screenshot 2025-07-18 at 13 03 19" src="https://github.com/user-attachments/assets/960c21c6-1663-456c-8d1d-7faa95b69b27" />
