### PR TITLE
Adjust positioning and width of Staking Trend line chart

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -18,6 +18,10 @@ html {
 
 svg.recharts-surface {
   overflow: visible;
+  position: absolute;
+  top: 0;
+  left: 24px;
+  max-width: calc(100% - 24px);
 }
 
 .expand {


### PR DESCRIPTION
Adjust positioning and width of Staking Trend line chart to show numbers on y-axis fully. Fixes Issue [#1930 ](https://github.com/oasisprotocol/explorer/issues/1930).

Before:
<img width="379" height="673" alt="Screenshot 2025-07-20 at 21 25 30" src="https://github.com/user-attachments/assets/bc5aed96-f7fd-43f5-ada0-89b1a044e29e" />

After:
<img width="379" height="672" alt="Screenshot 2025-07-20 at 21 24 42" src="https://github.com/user-attachments/assets/d330666d-42fc-4d64-a97c-8d073c4597e0" />
