### PR TITLE
Support filtering runtime event lists by type

### DIFF
--- a/.changelog/2078.feature.md
+++ b/.changelog/2078.feature.md
@@ -1,0 +1,1 @@
+Implement filtering for Runtime event type

--- a/playwright/tests/accounts.spec.ts
+++ b/playwright/tests/accounts.spec.ts
@@ -119,10 +119,12 @@ async function setup(page: Page) {
 
 test.describe('Account details page', () => {
   test('does not crash when rendering new event types', async ({ page }) => {
+    // We don't care about options in the runtime event type filter
+    const excludeListOptions = page.locator(':not(.MuiTypography-select)')
     await setup(page)
     await expect(page.getByText('Unknown error')).not.toBeVisible()
-    await expect(page.getByText('Delegate to consensus')).toBeVisible()
-    await expect(page.getByText('Start to undelegate')).toBeVisible()
-    await expect(page.getByText('Undelegate finished')).toBeVisible()
+    await expect(page.getByText('Delegate to consensus').and(excludeListOptions)).toBeVisible()
+    await expect(page.getByText('Start to undelegate').and(excludeListOptions)).toBeVisible()
+    await expect(page.getByText('Undelegate finished').and(excludeListOptions)).toBeVisible()
   })
 })

--- a/src/app/components/BlockNavigationButtons/index.tsx
+++ b/src/app/components/BlockNavigationButtons/index.tsx
@@ -8,7 +8,7 @@ import { ConsensusScope, RuntimeScope, SearchScope } from '../../../types/search
 import { COLORS } from '../../../styles/theme/colors'
 import { useConsensusFreshness, useRuntimeFreshness } from '../OfflineBanner/hook'
 import { RouteUtils } from '../../utils/route-utils'
-import { METHOD_QUERY_ARG_NAME } from '../../hooks/useCommonParams'
+import { TX_METHOD_QUERY_ARG_NAME } from '../../hooks/useCommonParams'
 
 const PrevBlockButton: FC<{ scope: SearchScope; currentRound: number }> = ({ scope, currentRound }) => {
   const { t } = useTranslation()
@@ -19,7 +19,7 @@ const PrevBlockButton: FC<{ scope: SearchScope; currentRound: number }> = ({ sco
       <Box>
         <PaginationItem
           component={RouterLink}
-          to={RouteUtils.getBlockRoute(scope, currentRound - 1, searchParams, [METHOD_QUERY_ARG_NAME])}
+          to={RouteUtils.getBlockRoute(scope, currentRound - 1, searchParams, [TX_METHOD_QUERY_ARG_NAME])}
           type="previous"
           disabled={disabled}
           sx={{
@@ -48,7 +48,7 @@ const NextBlockButton: FC<{ disabled: boolean; scope: SearchScope; currentRound:
       <Box>
         <PaginationItem
           component={RouterLink}
-          to={RouteUtils.getBlockRoute(scope, currentRound + 1, searchParams, [METHOD_QUERY_ARG_NAME])}
+          to={RouteUtils.getBlockRoute(scope, currentRound + 1, searchParams, [TX_METHOD_QUERY_ARG_NAME])}
           type="next"
           disabled={disabled}
           sx={{ background: COLORS.grayMediumLight }}

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -39,7 +39,7 @@ import { fromBaseUnits } from '../../utils/number-utils'
 import { RoflAppLink } from '../Rofl/RoflAppLink'
 import { RoflAppInstanceLink } from '../Rofl/RoflAppInstanceLink'
 
-const getRuntimeEventMethodLabel = (t: TFunction, method: RuntimeEventType | undefined) => {
+export const getRuntimeEventMethodLabel = (t: TFunction, method: RuntimeEventType | undefined) => {
   switch (method) {
     case RuntimeEventType.accountstransfer:
       return t('runtimeEvent.accountstransfer')

--- a/src/app/components/RuntimeEvents/RuntimeEventTypeFilter.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventTypeFilter.tsx
@@ -1,0 +1,69 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Select } from '../Select'
+import Typography from '@mui/material/Typography'
+import { Layer, RuntimeEventType } from '../../../oasis-nexus/api'
+import { RuntimeEventFilteringType } from '../../hooks/useCommonParams'
+import { TFunction } from 'i18next'
+import { paraTimesConfig } from '../../../config'
+import { getRuntimeEventMethodLabel } from './RuntimeEventDetails'
+
+type RuntimeEventTypeFilterOption = { value: RuntimeEventFilteringType; label: string }
+
+const getRuntimeEventTypeOptions = (t: TFunction, layer: Layer) => {
+  const hasRofl = !!paraTimesConfig[layer]?.offerRoflTxTypes
+  return Object.values(RuntimeEventType)
+    .filter(type => !type.startsWith('rofl') || hasRofl)
+    .map(
+      (type): RuntimeEventTypeFilterOption => ({
+        value: type,
+        label: getRuntimeEventMethodLabel(t, type),
+      }),
+    )
+}
+
+const FilterLabel: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <Typography
+      component={'span'}
+      sx={{
+        fontStyle: 'normal',
+        fontWeight: 700,
+        fontSize: 16,
+        lineHeight: '150%',
+        marginRight: 4,
+      }}
+    >
+      {t('event.filterByType')}
+    </Typography>
+  )
+}
+
+export const RuntimeEventTypeFilter: FC<{
+  layer: Layer
+  value: RuntimeEventFilteringType
+  setValue: (value: RuntimeEventFilteringType | null) => void
+  expand?: boolean
+  customOptions?: RuntimeEventTypeFilterOption[]
+}> = ({ layer, value, setValue, expand, customOptions }) => {
+  const { t } = useTranslation()
+  const defaultOptions: RuntimeEventTypeFilterOption[] = [
+    { value: 'any', label: 'Any' },
+    { value: 'erc20transfer', label: t('tokens.transferEventType.erc20Transfer') },
+  ]
+  const options = customOptions
+    ? [...defaultOptions, ...customOptions]
+    : [...defaultOptions, ...getRuntimeEventTypeOptions(t, layer)]
+
+  return (
+    <Select
+      className={expand ? 'expand' : undefined}
+      light={true}
+      label={<FilterLabel />}
+      options={options}
+      value={value}
+      handleChange={setValue}
+    />
+  )
+}

--- a/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
@@ -16,11 +16,15 @@ export const RuntimeEventsDetailedList: FC<{
   isError: boolean
   pagination: false | TablePaginationProps
   showTxHash: boolean
-}> = ({ scope, events, isLoading, isError, pagination, showTxHash }) => {
+  filtered: boolean
+}> = ({ scope, events, isLoading, isError, pagination, showTxHash, filtered }) => {
   const { t } = useTranslation()
   return (
     <>
       {isError && <CardEmptyState label={t('event.cantLoadEvents')} />}
+      {!isError && filtered && (!pagination || pagination.selectedPage === 1) && !events?.length && (
+        <CardEmptyState label={t('tableSearch.noMatchingResults')} />
+      )}
       {isLoading && <TextSkeleton numberOfRows={10} />}
       {events &&
         events.map((event, index) => (

--- a/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventsDetailedList.tsx
@@ -8,6 +8,8 @@ import { TextSkeleton } from '../Skeleton'
 import { RuntimeEventDetails } from './RuntimeEventDetails'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
+import { AppErrors } from '../../../types/errors'
+import { EmptyState } from '../EmptyState'
 
 export const RuntimeEventsDetailedList: FC<{
   scope: SearchScope
@@ -19,25 +21,46 @@ export const RuntimeEventsDetailedList: FC<{
   filtered: boolean
 }> = ({ scope, events, isLoading, isError, pagination, showTxHash, filtered }) => {
   const { t } = useTranslation()
-  return (
-    <>
-      {isError && <CardEmptyState label={t('event.cantLoadEvents')} />}
-      {!isError && filtered && (!pagination || pagination.selectedPage === 1) && !events?.length && (
-        <CardEmptyState label={t('tableSearch.noMatchingResults')} />
-      )}
-      {isLoading && <TextSkeleton numberOfRows={10} />}
-      {events &&
-        events.map((event, index) => (
+  if (isLoading) {
+    // Are we still loading?
+    return <TextSkeleton numberOfRows={10} />
+  } else if (isError) {
+    // Have we failed to load?
+    return <CardEmptyState label={t('event.cantLoadEvents')} />
+  } else if (!events || !events.length) {
+    // Apparently there is no data. Let's see why!
+    if (pagination && pagination.selectedPage > 1) {
+      // Are we on the wrong page?
+      throw AppErrors.PageDoesNotExist
+    } else if (filtered) {
+      // Maybe it's because of filters?
+      return <CardEmptyState label={t('tableSearch.noMatchingResults')} />
+    } else {
+      // There is no special reason, there is just no data
+      return (
+        <EmptyState
+          description={t('event.cantFindMatchingEvents')}
+          title={t('event.noEvents')}
+          light={true}
+        />
+      )
+    }
+  } else {
+    // We have data. Show it normally.
+    return (
+      <>
+        {events.map((event, index) => (
           <div key={`event-${index}`}>
             {index > 0 && <Divider variant="card" />}
             <RuntimeEventDetails scope={scope} event={event} showTxHash={showTxHash} />
           </div>
         ))}
-      {pagination && (
-        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <TablePagination {...pagination} />
-        </Box>
-      )}
-    </>
-  )
+        {pagination && (
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <TablePagination {...pagination} />
+          </Box>
+        )}
+      </>
+    )
+  }
 }

--- a/src/app/components/Transactions/RuntimeTransactionEvents.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionEvents.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react'
 import { RuntimeTransaction, useGetRuntimeEvents } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { useSearchParamsPagination } from '../Table/useSearchParamsPagination'
-import { AppErrors } from '../../../types/errors'
 import { RuntimeEventsDetailedList } from '../RuntimeEvents/RuntimeEventsDetailedList'
 import { getRuntimeEventTypeFilteringParam, RuntimeEventFilteringType } from '../../hooks/useCommonParams'
 
@@ -19,11 +18,8 @@ export const RuntimeTransactionEvents: FC<{
     offset,
     ...getRuntimeEventTypeFilteringParam(eventType),
   })
-  const { isFetched, isLoading, data, isError } = eventsQuery
+  const { isLoading, data, isError } = eventsQuery
   const events = data?.data.events
-  if (isFetched && pagination.selectedPage > 1 && !events?.length) {
-    throw AppErrors.PageDoesNotExist
-  }
 
   return (
     <RuntimeEventsDetailedList

--- a/src/app/components/Transactions/RuntimeTransactionEvents.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionEvents.tsx
@@ -4,10 +4,12 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { useSearchParamsPagination } from '../Table/useSearchParamsPagination'
 import { AppErrors } from '../../../types/errors'
 import { RuntimeEventsDetailedList } from '../RuntimeEvents/RuntimeEventsDetailedList'
+import { getRuntimeEventTypeFilteringParam, RuntimeEventFilteringType } from '../../hooks/useCommonParams'
 
 export const RuntimeTransactionEvents: FC<{
   transaction: RuntimeTransaction
-}> = ({ transaction }) => {
+  eventType: RuntimeEventFilteringType
+}> = ({ transaction, eventType }) => {
   const { network, layer } = transaction
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -15,6 +17,7 @@ export const RuntimeTransactionEvents: FC<{
     tx_hash: transaction.hash,
     limit,
     offset,
+    ...getRuntimeEventTypeFilteringParam(eventType),
   })
   const { isFetched, isLoading, data, isError } = eventsQuery
   const events = data?.data.events
@@ -36,6 +39,7 @@ export const RuntimeTransactionEvents: FC<{
         rowsPerPage: limit,
       }}
       showTxHash={false}
+      filtered={eventType !== 'any'}
     />
   )
 }

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -1,22 +1,22 @@
 import { useTypedSearchParam } from './useTypedSearchParam'
 import { ConsensusTxMethodFilterOption } from '../components/ConsensusTransactionMethod'
 
-export const METHOD_QUERY_ARG_NAME = 'tx_method'
+export const TX_METHOD_QUERY_ARG_NAME = 'tx_method'
 
 export const useConsensusTxMethodParam = () => {
-  const [method, setMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>(
-    METHOD_QUERY_ARG_NAME,
+  const [txMethod, setTxMethod] = useTypedSearchParam<ConsensusTxMethodFilterOption>(
+    TX_METHOD_QUERY_ARG_NAME,
     'any',
     {
       deleteParams: ['page', 'date'],
     },
   )
-  return { method, setMethod }
+  return { txMethod, setTxMethod }
 }
 
 export const useRuntimeTxMethodParam = () => {
-  const [method, setMethod] = useTypedSearchParam(METHOD_QUERY_ARG_NAME, 'any', {
+  const [txMethod, setTxMethod] = useTypedSearchParam(TX_METHOD_QUERY_ARG_NAME, 'any', {
     deleteParams: ['page', 'date'],
   })
-  return { method, setMethod }
+  return { txMethod, setTxMethod }
 }

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -1,5 +1,6 @@
 import { useTypedSearchParam } from './useTypedSearchParam'
 import { ConsensusTxMethodFilterOption } from '../components/ConsensusTransactionMethod'
+import { GetRuntimeEventsParams, RuntimeEventType } from '../../oasis-nexus/api'
 
 export const TX_METHOD_QUERY_ARG_NAME = 'tx_method'
 
@@ -19,4 +20,35 @@ export const useRuntimeTxMethodParam = () => {
     deleteParams: ['page', 'date'],
   })
   return { txMethod, setTxMethod }
+}
+
+export type RuntimeEventFilteringType = RuntimeEventType | 'erc20transfer' | 'any'
+
+export const EVENT_TYPE_QUERY_ARG_NAME = 'event_type'
+
+export const useRuntimeEventTypeParam = () => {
+  const [eventType, setEventType] = useTypedSearchParam<RuntimeEventFilteringType>(
+    EVENT_TYPE_QUERY_ARG_NAME,
+    'any',
+    {
+      deleteParams: ['page', 'date'],
+    },
+  )
+  return { eventType, setEventType }
+}
+
+export const getRuntimeEventTypeFilteringParam = (
+  type: RuntimeEventFilteringType,
+): Partial<GetRuntimeEventsParams> => {
+  switch (type) {
+    case 'any':
+      return {}
+    case 'erc20transfer':
+      return {
+        type: RuntimeEventType.evmlog,
+        evm_log_signature: 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      }
+    default:
+      return { type }
+  }
 }

--- a/src/app/hooks/useTypedSearchParam.ts
+++ b/src/app/hooks/useTypedSearchParam.ts
@@ -21,18 +21,18 @@ export type UrlSettingOptions = {
   deleteParams?: string[]
 }
 
-type SetterFunction<T> = (value: T, options?: UrlSettingOptions) => void
+export type ParamSetterFunction<T> = (value: T | null | undefined, options?: UrlSettingOptions) => void
 
 export function useTypedSearchParam<T = string>(
   paramName: string,
   defaultValue: T,
   defaultSetterOptions: UrlSettingOptions = {},
-): [T, SetterFunction<T>] {
+): [T, ParamSetterFunction<T>] {
   const [searchParams, setSearchParams] = useSearchParams()
   const value = (searchParams.get(paramName) as T) ?? defaultValue
-  const setValue = (newValue: T, options: UrlSettingOptions = defaultSetterOptions) => {
+  const setValue: ParamSetterFunction<T> = (newValue, options = defaultSetterOptions) => {
     const { replace, preventScrollReset = true, deleteParams = [] } = options
-    if (newValue === defaultValue) {
+    if (newValue === undefined || newValue === null || newValue === defaultValue) {
       searchParams.delete(paramName)
     } else {
       searchParams.set(paramName, newValue as string)

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
@@ -12,7 +12,7 @@ import { transactionsContainerId } from '../../utils/tabAnchors'
 
 export const ConsensusAccountTransactionsCard: FC<ConsensusAccountDetailsContext> = context => {
   const { isMobile } = useScreenSize()
-  const { method, setMethod } = context
+  const { txMethod, setTxMethod } = context
 
   return (
     <LinkableCardLayout
@@ -24,17 +24,17 @@ export const ConsensusAccountTransactionsCard: FC<ConsensusAccountDetailsContext
             justifyContent: 'end',
           }}
         >
-          {!isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />}
+          {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
         </Box>
       }
     >
-      {isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />}
+      {isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />}
       <ConsensusAccountTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scope, address, method }) => {
+const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scope, address, txMethod }) => {
   const { network } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -42,7 +42,7 @@ const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scop
     limit,
     offset,
     rel: address,
-    method: method === 'any' ? undefined : method,
+    method: txMethod === 'any' ? undefined : txMethod,
   })
   const { isLoading, data } = transactionsQuery
   const transactions = data?.data.transactions
@@ -60,7 +60,7 @@ const ConsensusAccountTransactions: FC<ConsensusAccountDetailsContext> = ({ scop
         isTotalCountClipped: data?.data.is_total_count_clipped,
         rowsPerPage: limit,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }

--- a/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
@@ -5,8 +5,8 @@ import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransac
 export type ConsensusAccountDetailsContext = {
   scope: ConsensusScope
   address: string
-  method: ConsensusTxMethodFilterOption
-  setMethod: (value: ConsensusTxMethodFilterOption) => void
+  txMethod: ConsensusTxMethodFilterOption
+  setTxMethod: (value: ConsensusTxMethodFilterOption) => void
 }
 
 export const useConsensusAccountDetailsProps = () => useOutletContext<ConsensusAccountDetailsContext>()

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -23,13 +23,13 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const { network } = scope
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
-  const { method, setMethod } = useConsensusTxMethodParam()
+  const { txMethod, setTxMethod } = useConsensusTxMethodParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
   const account = data?.data
   const transactionsLink = useHref('')
   const eventsLink = useHref(`events#${eventsContainerId}`)
-  const context: ConsensusAccountDetailsContext = { scope, address, method, setMethod }
+  const context: ConsensusAccountDetailsContext = { scope, address, txMethod, setTxMethod }
 
   return (
     <PageLayout>

--- a/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
@@ -55,7 +55,7 @@ const TransactionList: FC<{
 }
 
 export const ConsensusBlockTransactionsCard: FC<ConsensusBlockDetailsContext> = ({ scope, blockHeight }) => {
-  const { method, setMethod } = useConsensusTxMethodParam()
+  const { txMethod, setTxMethod } = useConsensusTxMethodParam()
   const { isMobile } = useScreenSize()
 
   if (!blockHeight) {
@@ -72,12 +72,12 @@ export const ConsensusBlockTransactionsCard: FC<ConsensusBlockDetailsContext> = 
             justifyContent: 'end',
           }}
         >
-          {!isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />}
+          {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
         </Box>
       }
     >
-      {isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />}
-      <TransactionList scope={scope} blockHeight={blockHeight} method={method} />
+      {isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />}
+      <TransactionList scope={scope} blockHeight={blockHeight} method={txMethod} />
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/index.tsx
+++ b/src/app/pages/ConsensusDashboardPage/index.tsx
@@ -23,7 +23,7 @@ export const ConsensusDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useConsensusScope()
   const isLocal = isLocalnet(scope.network)
-  const { method, setMethod } = useConsensusTxMethodParam()
+  const { txMethod, setTxMethod } = useConsensusTxMethodParam()
 
   return (
     <PageLayout>
@@ -41,7 +41,7 @@ export const ConsensusDashboardPage: FC = () => {
       <ValidatorsCard scope={scope} />
       {!isLocal && <ParaTimesCard scope={scope} />}
       <AccountsCard scope={scope} />
-      <LatestConsensusTransactions scope={scope} method={method} setMethod={setMethod} />
+      <LatestConsensusTransactions scope={scope} method={txMethod} setMethod={setTxMethod} />
       {!isLocal && (
         <>
           <NetworkProposalsCard scope={scope} />

--- a/src/app/pages/ConsensusTransactionsPage/index.tsx
+++ b/src/app/pages/ConsensusTransactionsPage/index.tsx
@@ -26,7 +26,7 @@ export const ConsensusTransactionsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const pagination = useSearchParamsPagination('page')
-  const { method, setMethod } = useConsensusTxMethodParam()
+  const { txMethod, setTxMethod } = useConsensusTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
   const scope = useConsensusScope()
   const enablePolling = offset === 0
@@ -44,7 +44,7 @@ export const ConsensusTransactionsPage: FC = () => {
       limit: tableView === TableLayout.Vertical ? offset + limit : limit,
       offset: tableView === TableLayout.Vertical ? 0 : offset,
       before: enablePolling ? undefined : beforeDate,
-      ...getConsensusTransactionMethodFilteringParam(method),
+      ...getConsensusTransactionMethodFilteringParam(txMethod),
     },
     {
       query: {
@@ -98,11 +98,13 @@ export const ConsensusTransactionsPage: FC = () => {
             }}
           >
             {t('transactions.latest')}
-            {!isMobile && <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />}
+            {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
           </Box>
         }
         title2={
-          isMobile ? <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand /> : undefined
+          isMobile ? (
+            <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />
+          ) : undefined
         }
         action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
         noPadding={tableView === TableLayout.Vertical}
@@ -121,7 +123,7 @@ export const ConsensusTransactionsPage: FC = () => {
               rowsPerPage: limit,
             }}
             verbose={false}
-            filtered={method !== 'any'}
+            filtered={txMethod !== 'any'}
           />
         )}
 

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -21,13 +21,13 @@ export const ParatimeDashboardPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useRuntimeScope()
   const isLocal = isLocalnet(scope.network)
-  const { method, setMethod } = useRuntimeTxMethodParam()
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
 
   return (
     <PageLayout>
       {!isLocal && <ParaTimeSnapshot scope={scope} />}
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <LatestRuntimeTransactions scope={scope} method={method} setMethod={setMethod} />
+      <LatestRuntimeTransactions scope={scope} method={txMethod} setMethod={setTxMethod} />
       <Grid container spacing={4}>
         <Grid item xs={12} md={6} sx={{ display: 'flex', order: isMobile ? 1 : 0 }}>
           <LearningMaterials scope={scope} />

--- a/src/app/pages/RoflAppDetailsPage/RoflAppInstanceTransactionsCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/RoflAppInstanceTransactionsCard.tsx
@@ -9,7 +9,7 @@ import { RuntimeTransactionTypeFilter } from '../../components/Transactions/Runt
 import { RoflAppDetailsContext, useRoflAppInstanceTransactions } from './hooks'
 
 export const RoflAppInstanceTransactionsCard: FC<RoflAppDetailsContext> = context => {
-  const { method, setMethod, scope } = context
+  const { txMethod, setTxMethod, scope } = context
 
   const { isMobile } = useScreenSize()
 
@@ -24,22 +24,22 @@ export const RoflAppInstanceTransactionsCard: FC<RoflAppDetailsContext> = contex
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} />
+            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <RoflAppInstanceTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const RoflAppInstanceTransactions: FC<RoflAppDetailsContext> = ({ scope, id, method }) => {
+const RoflAppInstanceTransactions: FC<RoflAppDetailsContext> = ({ scope, id, txMethod }) => {
   const { isLoading, transactions, pagination, totalCount, isTotalCountClipped } =
-    useRoflAppInstanceTransactions(scope, id, method)
+    useRoflAppInstanceTransactions(scope, id, txMethod)
   return (
     <RuntimeTransactions
       transactions={transactions}
@@ -52,7 +52,7 @@ const RoflAppInstanceTransactions: FC<RoflAppDetailsContext> = ({ scope, id, met
         isTotalCountClipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }

--- a/src/app/pages/RoflAppDetailsPage/RoflAppUpdatesCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/RoflAppUpdatesCard.tsx
@@ -12,7 +12,7 @@ import { RoflAppDetailsContext, useRoflAppUpdates } from './hooks'
 
 export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
   const { t } = useTranslation()
-  const { method, setMethod, scope } = context
+  const { txMethod, setTxMethod, scope } = context
   const { isMobile } = useScreenSize()
   const customOptions = getRuntimeRoflUpdatesMethodOptions(t)
 
@@ -29,8 +29,8 @@ export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
           {!isMobile && (
             <RuntimeTransactionTypeFilter
               layer={scope.layer}
-              value={method}
-              setValue={setMethod}
+              value={txMethod}
+              setValue={setTxMethod}
               customOptions={customOptions}
             />
           )}
@@ -40,8 +40,8 @@ export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
       {isMobile && (
         <RuntimeTransactionTypeFilter
           layer={scope.layer}
-          value={method}
-          setValue={setMethod}
+          value={txMethod}
+          setValue={setTxMethod}
           expand
           customOptions={customOptions}
         />
@@ -51,11 +51,11 @@ export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
   )
 }
 
-const RoflAppUpdates: FC<RoflAppDetailsContext> = ({ scope, id, method }) => {
+const RoflAppUpdates: FC<RoflAppDetailsContext> = ({ scope, id, txMethod }) => {
   const { isLoading, transactions, pagination, totalCount, isTotalCountClipped } = useRoflAppUpdates(
     scope,
     id,
-    method,
+    txMethod,
   )
   return (
     <RuntimeTransactions
@@ -69,7 +69,7 @@ const RoflAppUpdates: FC<RoflAppDetailsContext> = ({ scope, id, method }) => {
         isTotalCountClipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }

--- a/src/app/pages/RoflAppDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppDetailsPage/hooks.tsx
@@ -12,8 +12,8 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 export type RoflAppDetailsContext = {
   scope: RuntimeScope
   id: string
-  method: string
-  setMethod: (value: string) => void
+  txMethod: string
+  setTxMethod: (value: string) => void
 }
 
 export const useRoflAppDetailsProps = () => useOutletContext<RoflAppDetailsContext>()

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -50,10 +50,10 @@ export const RoflAppDetailsPage: FC = () => {
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)
-  const [method, setMethod] = useTypedSearchParam('method', 'any', {
+  const [txMethod, setTxMethod] = useTypedSearchParam('method', 'any', {
     deleteParams: ['page'],
   })
-  const context: RoflAppDetailsContext = { scope, id, method, setMethod }
+  const context: RoflAppDetailsContext = { scope, id, txMethod, setTxMethod }
   const { isFetched, isLoading, data } = useGetRuntimeRoflAppsId(scope.network, scope.layer, id)
   const roflApp = data?.data
 

--- a/src/app/pages/RoflAppInstanceDetailsPage/RoflAppInstanceRakTransactionsCard.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/RoflAppInstanceRakTransactionsCard.tsx
@@ -9,7 +9,7 @@ import { RuntimeTransactionTypeFilter } from '../../components/Transactions/Runt
 import { RoflAppInstanceDetailsContext, useRoflAppInstanceRakTransactions } from './hooks'
 
 export const RoflAppInstanceRakTransactionsCard: FC<RoflAppInstanceDetailsContext> = context => {
-  const { method, setMethod, scope } = context
+  const { txMethod, setTxMethod, scope } = context
   const { isMobile } = useScreenSize()
 
   return (
@@ -23,22 +23,22 @@ export const RoflAppInstanceRakTransactionsCard: FC<RoflAppInstanceDetailsContex
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} />
+            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <RoflAppInstanceRakTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const RoflAppInstanceRakTransactions: FC<RoflAppInstanceDetailsContext> = ({ scope, id, rak, method }) => {
+const RoflAppInstanceRakTransactions: FC<RoflAppInstanceDetailsContext> = ({ scope, id, rak, txMethod }) => {
   const { isLoading, transactions, pagination, totalCount, isTotalCountClipped } =
-    useRoflAppInstanceRakTransactions(scope, id, rak, method)
+    useRoflAppInstanceRakTransactions(scope, id, rak, txMethod)
 
   return (
     <RuntimeTransactions
@@ -52,7 +52,7 @@ const RoflAppInstanceRakTransactions: FC<RoflAppInstanceDetailsContext> = ({ sco
         isTotalCountClipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }

--- a/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
@@ -10,8 +10,8 @@ export type RoflAppInstanceDetailsContext = {
   scope: RuntimeScope
   id: string
   rak: string
-  method: string
-  setMethod: (value: string) => void
+  txMethod: string
+  setTxMethod: (value: string) => void
 }
 
 export const useRoflAppInstanceDetailsProps = () => useOutletContext<RoflAppInstanceDetailsContext>()

--- a/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
@@ -25,10 +25,10 @@ export const RoflAppInstanceDetailsPage: FC = () => {
   const id = useParams().id!
   const rak = useParams().rak!
   const txLink = useHref('')
-  const [method, setMethod] = useTypedSearchParam('method', 'any', {
+  const [txMethod, setTxMethod] = useTypedSearchParam('method', 'any', {
     deleteParams: ['page'],
   })
-  const context: RoflAppInstanceDetailsContext = { scope, id, rak, method, setMethod }
+  const context: RoflAppInstanceDetailsContext = { scope, id, rak, txMethod, setTxMethod }
   const instancesQuery = useGetRuntimeRoflAppsIdInstancesRak(scope.network, scope.layer, id, rak)
   const { isLoading, isFetched, data } = instancesQuery
   const instance = data?.data

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
@@ -5,15 +5,25 @@ import { RuntimeEventsDetailedList } from '../../components/RuntimeEvents/Runtim
 import { useAccountEvents } from './hook'
 import { RuntimeAccountDetailsContext } from '.'
 import { eventsContainerId } from '../../utils/tabAnchors'
+import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
+import Divider from '@mui/material/Divider'
 
-export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = ({ scope, address }) => {
+export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = ({
+  scope,
+  address,
+  eventType,
+  setEventType,
+}) => {
   const { isLoading, isError, events, pagination, totalCount, isTotalCountClipped } = useAccountEvents(
     scope,
     address,
+    eventType,
   )
 
   return (
     <LinkableCardLayout containerId={eventsContainerId} title="">
+      <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
+      <Divider variant="card" />
       <RuntimeEventsDetailedList
         scope={scope}
         events={events}
@@ -27,6 +37,7 @@ export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = ({ scope, add
           rowsPerPage: limit,
         }}
         showTxHash
+        filtered={eventType !== 'any'}
       />
     </LinkableCardLayout>
   )

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountEventsCard.tsx
@@ -7,38 +7,43 @@ import { RuntimeAccountDetailsContext } from '.'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
 import Divider from '@mui/material/Divider'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
-export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = ({
-  scope,
-  address,
-  eventType,
-  setEventType,
-}) => {
+const AccountEventsCardContent: FC<RuntimeAccountDetailsContext> = props => {
+  const { scope, address, eventType } = props
   const { isLoading, isError, events, pagination, totalCount, isTotalCountClipped } = useAccountEvents(
     scope,
     address,
     eventType,
   )
+  return (
+    <RuntimeEventsDetailedList
+      scope={scope}
+      events={events}
+      isLoading={isLoading}
+      isError={isError}
+      pagination={{
+        selectedPage: pagination.selectedPage,
+        linkToPage: pagination.linkToPage,
+        totalCount,
+        isTotalCountClipped,
+        rowsPerPage: limit,
+      }}
+      showTxHash
+      filtered={eventType !== 'any'}
+    />
+  )
+}
 
+export const AccountEventsCard: FC<RuntimeAccountDetailsContext> = props => {
+  const { scope, eventType, setEventType } = props
   return (
     <LinkableCardLayout containerId={eventsContainerId} title="">
       <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
       <Divider variant="card" />
-      <RuntimeEventsDetailedList
-        scope={scope}
-        events={events}
-        isLoading={isLoading}
-        isError={isError}
-        pagination={{
-          selectedPage: pagination.selectedPage,
-          linkToPage: pagination.linkToPage,
-          totalCount,
-          isTotalCountClipped,
-          rowsPerPage: limit,
-        }}
-        showTxHash
-        filtered={eventType !== 'any'}
-      />
+      <ErrorBoundary light>
+        <AccountEventsCardContent {...props} />
+      </ErrorBoundary>
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
@@ -10,7 +10,7 @@ import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
 
 export const AccountTransactionsCard: FC<RuntimeAccountDetailsContext> = context => {
-  const { method, setMethod, scope } = context
+  const { txMethod, setTxMethod, scope } = context
 
   const { isMobile } = useScreenSize()
 
@@ -25,24 +25,24 @@ export const AccountTransactionsCard: FC<RuntimeAccountDetailsContext> = context
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} />
+            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <AccountTransactions {...context} />
     </LinkableCardLayout>
   )
 }
 
-const AccountTransactions: FC<RuntimeAccountDetailsContext> = ({ scope, address, method }) => {
+const AccountTransactions: FC<RuntimeAccountDetailsContext> = ({ scope, address, txMethod }) => {
   const { isLoading, transactions, pagination, totalCount, isTotalCountClipped } = useAccountTransactions(
     scope,
     address,
-    method,
+    txMethod,
   )
   return (
     <RuntimeTransactions
@@ -57,7 +57,7 @@ const AccountTransactions: FC<RuntimeAccountDetailsContext> = ({ scope, address,
         isTotalCountClipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/hook.ts
+++ b/src/app/pages/RuntimeAccountDetailsPage/hook.ts
@@ -8,6 +8,7 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { RuntimeScope } from '../../../types/searchScope'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
+import { getRuntimeEventTypeFilteringParam, RuntimeEventFilteringType } from '../../hooks/useCommonParams'
 
 export const useAccount = (scope: RuntimeScope, address: string) => {
   const { network, layer } = scope
@@ -53,7 +54,7 @@ export const useAccountTransactions = (scope: RuntimeScope, address: string, met
   }
 }
 
-export const useAccountEvents = (scope: RuntimeScope, address: string) => {
+export const useAccountEvents = (scope: RuntimeScope, address: string, type: RuntimeEventFilteringType) => {
   const { network, layer } = scope
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -61,7 +62,7 @@ export const useAccountEvents = (scope: RuntimeScope, address: string) => {
     limit,
     offset: offset,
     rel: address,
-    // TODO: implement filtering for non-transactional events
+    ...getRuntimeEventTypeFilteringParam(type),
   })
   const { isFetched, isLoading, isError, data } = query
   const events = data?.data.events

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -27,8 +27,8 @@ export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
   address: string
   account?: RuntimeAccount
-  method: string
-  setMethod: (value: string) => void
+  txMethod: string
+  setTxMethod: (value: string) => void
 }
 
 export const useRuntimeAccountDetailsProps = () => useOutletContext<RuntimeAccountDetailsContext>()
@@ -39,7 +39,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
   const scope = useRuntimeScope()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
-  const { method, setMethod } = useRuntimeTxMethodParam()
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, { enabled: isContract })
@@ -57,7 +57,13 @@ export const RuntimeAccountDetailsPage: FC = () => {
 
   const isLoading = isAccountLoading || isTokenLoading
 
-  const context: RuntimeAccountDetailsContext = { scope, address, account, method, setMethod }
+  const context: RuntimeAccountDetailsContext = {
+    scope,
+    address,
+    account,
+    txMethod,
+    setTxMethod,
+  }
 
   return (
     <PageLayout>

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -14,7 +14,11 @@ import { RuntimeAccountDetailsCard } from './RuntimeAccountDetailsCard'
 import { DappBanner } from '../../components/DappBanner'
 import { AddressLoaderData } from '../../utils/route-utils'
 import { getFiatCurrencyForScope } from '../../../config'
-import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
+import {
+  RuntimeEventFilteringType,
+  useRuntimeEventTypeParam,
+  useRuntimeTxMethodParam,
+} from '../../hooks/useCommonParams'
 import {
   codeContainerId,
   eventsContainerId,
@@ -22,6 +26,7 @@ import {
   transfersContainerId,
 } from '../../utils/tabAnchors'
 import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
@@ -29,6 +34,8 @@ export type RuntimeAccountDetailsContext = {
   account?: RuntimeAccount
   txMethod: string
   setTxMethod: (value: string) => void
+  eventType: RuntimeEventFilteringType
+  setEventType: ParamSetterFunction<RuntimeEventFilteringType>
 }
 
 export const useRuntimeAccountDetailsProps = () => useOutletContext<RuntimeAccountDetailsContext>()
@@ -40,6 +47,7 @@ export const RuntimeAccountDetailsPage: FC = () => {
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
   const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
+  const { eventType, setEventType } = useRuntimeEventTypeParam()
   const { account, isLoading: isAccountLoading, isError } = useAccount(scope, address)
   const isContract = !!account?.evm_contract
   const { token, isLoading: isTokenLoading } = useTokenInfo(scope, address, { enabled: isContract })
@@ -63,6 +71,8 @@ export const RuntimeAccountDetailsPage: FC = () => {
     account,
     txMethod,
     setTxMethod,
+    eventType,
+    setEventType,
   }
 
   return (

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -8,8 +8,11 @@ import { RuntimeEventsDetailedList } from '../../components/RuntimeEvents/Runtim
 import { EmptyState } from '../../components/EmptyState'
 import { RuntimeBlockDetailsContext } from '.'
 import { eventsContainerId } from '../../utils/tabAnchors'
+import { getRuntimeEventTypeFilteringParam } from '../../hooks/useCommonParams'
+import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
+import Divider from '@mui/material/Divider'
 
-const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
+const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, eventType }) => {
   const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
@@ -18,6 +21,7 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
     // TODO: search for tx_hash = null
     limit,
     offset,
+    ...getRuntimeEventTypeFilteringParam(eventType),
   })
 
   const { isLoading, isError, data } = eventsQuery
@@ -44,17 +48,21 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight }) => {
         rowsPerPage: limit,
       }}
       showTxHash
+      filtered={eventType !== 'any'}
     />
   )
 }
 
 export const RuntimeBlockEventsCard: FC<RuntimeBlockDetailsContext> = props => {
-  if (!props.blockHeight) {
+  const { scope, blockHeight, eventType, setEventType } = props
+  if (!blockHeight) {
     return null
   }
 
   return (
     <LinkableCardLayout containerId={eventsContainerId} title="">
+      <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
+      <Divider variant={'card'} />
       <EventsList {...props} />
     </LinkableCardLayout>
   )

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -9,6 +9,7 @@ import { eventsContainerId } from '../../utils/tabAnchors'
 import { getRuntimeEventTypeFilteringParam } from '../../hooks/useCommonParams'
 import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
 import Divider from '@mui/material/Divider'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, eventType }) => {
   const pagination = useSearchParamsPagination('page')
@@ -53,7 +54,9 @@ export const RuntimeBlockEventsCard: FC<RuntimeBlockDetailsContext> = props => {
     <LinkableCardLayout containerId={eventsContainerId} title="">
       <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
       <Divider variant={'card'} />
-      <EventsList {...props} />
+      <ErrorBoundary light>
+        <EventsList {...props} />
+      </ErrorBoundary>
     </LinkableCardLayout>
   )
 }

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockEventsCard.tsx
@@ -1,11 +1,9 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useGetRuntimeEvents } from '../../../oasis-nexus/api'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
 import { RuntimeEventsDetailedList } from '../../components/RuntimeEvents/RuntimeEventsDetailedList'
-import { EmptyState } from '../../components/EmptyState'
 import { RuntimeBlockDetailsContext } from '.'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { getRuntimeEventTypeFilteringParam } from '../../hooks/useCommonParams'
@@ -13,7 +11,6 @@ import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEv
 import Divider from '@mui/material/Divider'
 
 const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, eventType }) => {
-  const { t } = useTranslation()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
   const eventsQuery = useGetRuntimeEvents(scope.network, scope.layer, {
@@ -25,14 +22,7 @@ const EventsList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, eventT
   })
 
   const { isLoading, isError, data } = eventsQuery
-
   const events = data?.data.events
-
-  if (!events?.length && !isLoading) {
-    return (
-      <EmptyState description={t('event.cantFindMatchingEvents')} title={t('event.noEvents')} light={true} />
-    )
-  }
 
   return (
     <RuntimeEventsDetailedList

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
@@ -12,7 +12,7 @@ import { getRuntimeTransactionMethodFilteringParam } from '../../components/Runt
 import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
 
-const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, method }) => {
+const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, txMethod }) => {
   const txsPagination = useSearchParamsPagination('page')
   const txsOffset = (txsPagination.selectedPage - 1) * NUMBER_OF_ITEMS_ON_SEPARATE_PAGE
 
@@ -20,7 +20,7 @@ const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, m
     block: blockHeight,
     limit: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
     offset: txsOffset,
-    ...getRuntimeTransactionMethodFilteringParam(method),
+    ...getRuntimeTransactionMethodFilteringParam(txMethod),
   })
 
   const { isLoading, isFetched, data } = transactionsQuery
@@ -43,14 +43,14 @@ const TransactionList: FC<RuntimeBlockDetailsContext> = ({ scope, blockHeight, m
         isTotalCountClipped: data?.data.is_total_count_clipped,
         rowsPerPage: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
       }}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }
 
 export const RuntimeBlockTransactionsCard: FC<RuntimeBlockDetailsContext> = props => {
   const { isMobile } = useScreenSize()
-  const { blockHeight, method, setMethod, scope } = props
+  const { blockHeight, txMethod, setTxMethod, scope } = props
 
   if (!blockHeight) {
     return null
@@ -67,13 +67,13 @@ export const RuntimeBlockTransactionsCard: FC<RuntimeBlockDetailsContext> = prop
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} />
+            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <TransactionList {...props} />
     </LinkableCardLayout>

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -25,8 +25,8 @@ import { eventsContainerId, transactionsContainerId } from '../../utils/tabAncho
 export type RuntimeBlockDetailsContext = {
   scope: RuntimeScope
   blockHeight?: number
-  method: string
-  setMethod: (method: string) => void
+  txMethod: string
+  setTxMethod: (method: string) => void
 }
 
 export const useRuntimeBlockDetailsProps = () => useOutletContext<RuntimeBlockDetailsContext>()
@@ -46,8 +46,8 @@ export const RuntimeBlockDetailPage: FC = () => {
     throw AppErrors.NotFoundBlockHeight
   }
   const block = data?.data
-  const { method, setMethod } = useRuntimeTxMethodParam()
-  const context: RuntimeBlockDetailsContext = { scope, blockHeight, method, setMethod }
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
+  const context: RuntimeBlockDetailsContext = { scope, blockHeight, txMethod, setTxMethod }
 
   return (
     <PageLayout>

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -19,14 +19,21 @@ import { useRuntimeScope } from '../../hooks/useScopeParam'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import { RuntimeNextBlockButton, RuntimePrevBlockButton } from '../../components/BlockNavigationButtons'
 import { RuntimeScope } from 'types/searchScope'
-import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
+import {
+  RuntimeEventFilteringType,
+  useRuntimeEventTypeParam,
+  useRuntimeTxMethodParam,
+} from '../../hooks/useCommonParams'
 import { eventsContainerId, transactionsContainerId } from '../../utils/tabAnchors'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 export type RuntimeBlockDetailsContext = {
   scope: RuntimeScope
   blockHeight?: number
   txMethod: string
   setTxMethod: (method: string) => void
+  eventType: RuntimeEventFilteringType
+  setEventType: ParamSetterFunction<RuntimeEventFilteringType>
 }
 
 export const useRuntimeBlockDetailsProps = () => useOutletContext<RuntimeBlockDetailsContext>()
@@ -47,7 +54,15 @@ export const RuntimeBlockDetailPage: FC = () => {
   }
   const block = data?.data
   const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
-  const context: RuntimeBlockDetailsContext = { scope, blockHeight, txMethod, setTxMethod }
+  const { eventType, setEventType } = useRuntimeEventTypeParam()
+  const context: RuntimeBlockDetailsContext = {
+    scope,
+    blockHeight,
+    txMethod,
+    setTxMethod,
+    eventType,
+    setEventType,
+  }
 
   return (
     <PageLayout>

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -45,12 +45,17 @@ import { Link as RouterLink } from 'react-router-dom'
 import { RouteUtils } from '../../utils/route-utils'
 import Tooltip from '@mui/material/Tooltip'
 import { yamlDump } from '../../utils/yamlDump'
+import { useRuntimeEventTypeParam } from '../../hooks/useCommonParams'
+import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
+import Divider from '@mui/material/Divider'
 
 export const RuntimeTransactionDetailPage: FC = () => {
   const { t } = useTranslation()
+  const { isMobile } = useScreenSize()
 
   const scope = useRuntimeScope()
   const hash = useParams().hash!
+  const { eventType, setEventType } = useRuntimeEventTypeParam()
 
   const { isLoading, data } = useGetRuntimeTransactionsTxHash(
     scope.network,
@@ -88,8 +93,21 @@ export const RuntimeTransactionDetailPage: FC = () => {
       {transaction?.to && <DappBanner scope={scope} ethOrOasisAddress={transaction?.to} />}
       {transaction && (
         <LinkableDiv id={transactionEventsContainerId}>
-          <SubPageCard title={t('common.events')}>
-            <RuntimeTransactionEvents transaction={transaction} />
+          <SubPageCard
+            title={t('common.events')}
+            action={
+              !isMobile && (
+                <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
+              )
+            }
+          >
+            {isMobile && (
+              <>
+                <RuntimeEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
+                <Divider variant={'card'} />
+              </>
+            )}
+            <RuntimeTransactionEvents transaction={transaction} eventType={eventType} />
           </SubPageCard>
         </LinkableDiv>
       )}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -48,6 +48,7 @@ import { yamlDump } from '../../utils/yamlDump'
 import { useRuntimeEventTypeParam } from '../../hooks/useCommonParams'
 import { RuntimeEventTypeFilter } from '../../components/RuntimeEvents/RuntimeEventTypeFilter'
 import Divider from '@mui/material/Divider'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 export const RuntimeTransactionDetailPage: FC = () => {
   const { t } = useTranslation()
@@ -107,7 +108,9 @@ export const RuntimeTransactionDetailPage: FC = () => {
                 <Divider variant={'card'} />
               </>
             )}
-            <RuntimeTransactionEvents transaction={transaction} eventType={eventType} />
+            <ErrorBoundary light>
+              <RuntimeTransactionEvents transaction={transaction} eventType={eventType} />
+            </ErrorBoundary>
           </SubPageCard>
         </LinkableDiv>
       )}

--- a/src/app/pages/RuntimeTransactionsPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionsPage/index.tsx
@@ -30,7 +30,7 @@ export const RuntimeTransactionsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const pagination = useSearchParamsPagination('page')
-  const { method, setMethod } = useRuntimeTxMethodParam()
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
   const offset = (pagination.selectedPage - 1) * limit
   const scope = useRuntimeScope()
   const enablePolling = offset === 0
@@ -51,7 +51,7 @@ export const RuntimeTransactionsPage: FC = () => {
       limit: tableView === TableLayout.Vertical ? offset + limit : limit,
       offset: tableView === TableLayout.Vertical ? 0 : offset,
       before: enablePolling ? undefined : beforeDate,
-      ...getRuntimeTransactionMethodFilteringParam(method),
+      ...getRuntimeTransactionMethodFilteringParam(txMethod),
     },
     {
       query: {
@@ -107,13 +107,18 @@ export const RuntimeTransactionsPage: FC = () => {
           >
             {t('transactions.latest')}
             {!isMobile && (
-              <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} />
+              <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
             )}
           </Box>
         }
         title2={
           isMobile ? (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={method} setValue={setMethod} expand />
+            <RuntimeTransactionTypeFilter
+              layer={scope.layer}
+              value={txMethod}
+              setValue={setTxMethod}
+              expand
+            />
           ) : undefined
         }
         action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}
@@ -132,7 +137,7 @@ export const RuntimeTransactionsPage: FC = () => {
               isTotalCountClipped: data?.data.is_total_count_clipped,
               rowsPerPage: limit,
             }}
-            filtered={method !== 'any'}
+            filtered={txMethod !== 'any'}
           />
         )}
 

--- a/src/app/pages/ValidatorDetailsPage/hooks.ts
+++ b/src/app/pages/ValidatorDetailsPage/hooks.ts
@@ -5,8 +5,8 @@ import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransac
 export type ValidatorDetailsContext = {
   scope: ConsensusScope
   address: string
-  method: ConsensusTxMethodFilterOption
-  setMethod: (method: ConsensusTxMethodFilterOption) => void
+  txMethod: ConsensusTxMethodFilterOption
+  setTxMethod: (method: ConsensusTxMethodFilterOption) => void
 }
 
 export const useValidatorDetailsProps = () => useOutletContext<ValidatorDetailsContext>()

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -61,7 +61,7 @@ export const ValidatorDetailsPage: FC = () => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
   const scope = useConsensusScope()
-  const { method, setMethod } = useConsensusTxMethodParam()
+  const { txMethod, setTxMethod } = useConsensusTxMethodParam()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.validatorName(searchQuery))
   const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
@@ -75,7 +75,7 @@ export const ValidatorDetailsPage: FC = () => {
   const accountQuery = useGetConsensusAccountsAddress(scope.network, address)
   const { isLoading: isAccountLoading, data: accountData } = accountQuery
   const account = accountData?.data
-  const context: ValidatorDetailsContext = { scope, address, method, setMethod }
+  const context: ValidatorDetailsContext = { scope, address, txMethod, setTxMethod }
   const isLoading = isValidatorLoading || isAccountLoading
 
   return (

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -420,6 +420,7 @@
     "totalSupply": "Total Supply",
     "totalSupplyValue": "{{ value, number }} {{ticker}}",
     "transferEventType": {
+      "erc20Transfer": "ERC-20 token transfer",
       "transfer": "Transfer",
       "approval": "Approval",
       "minting": "Minting",
@@ -541,6 +542,7 @@
   "event": {
     "cantLoadEvents": "Unfortunately we couldn't load the list of events. Please try again later.",
     "cantFindMatchingEvents": "We can't find any matching events.",
+    "filterByType": "Filter by type",
     "noEvents": "No events",
     "fields": {
       "emittingTransaction": "Transaction"


### PR DESCRIPTION
Add support for filtering Runtime Event lists by type. This works on:

- Runtime Account events
- Runtime transaction events
- Runtime block events

Besides the real event types, there is a pseudo-type called "Token transfer", which actually means "EVM log message with a signature denoting a token transfer.

Currently there is one unresolved issue: token transfer are returned both when filtering for "Token transfers" and "EVM log messages", since they _are_ technically both. To solve this we need some support from the Nexus side, but it's unlikely to land during the current sprint, so I say we should merge this now, and improve later when the Nexus team has the bandwidth to add what we need.