### PR TITLE
Support filtering Consensus Event lists by event type

### DIFF
--- a/.changelog/2081.feature.md
+++ b/.changelog/2081.feature.md
@@ -1,0 +1,1 @@
+Implement filtering for Consensus event type

--- a/src/app/components/ConsensusEvents/ConsensusEventTypeFilter.tsx
+++ b/src/app/components/ConsensusEvents/ConsensusEventTypeFilter.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Select } from '../Select'
+import Typography from '@mui/material/Typography'
+import { ConsensusEventType, Layer } from '../../../oasis-nexus/api'
+import { ConsensusEventFilteringType } from '../../hooks/useCommonParams'
+import { TFunction } from 'i18next'
+import { paraTimesConfig } from '../../../config'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
+import { getConsensusEventTypeLabel } from './ConsensusEventDetails'
+
+type Option = {
+  value: ConsensusEventFilteringType
+  label: string
+}
+
+const getConsensusEventTypeOptions = (t: TFunction, layer: Layer) => {
+  const hasRofl = !!paraTimesConfig[layer]?.offerRoflTxTypes
+  return Object.values(ConsensusEventType)
+    .filter(type => !type.startsWith('rofl') || hasRofl)
+    .map(
+      (type): Option => ({
+        value: type,
+        label: getConsensusEventTypeLabel(t, type),
+      }),
+    )
+}
+
+const FilterLabel: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <Typography
+      component={'span'}
+      sx={{
+        fontStyle: 'normal',
+        fontWeight: 700,
+        fontSize: 16,
+        lineHeight: '150%',
+        marginRight: 4,
+      }}
+    >
+      {t('event.filterByType')}
+    </Typography>
+  )
+}
+
+export const ConsensusEventTypeFilter: FC<{
+  layer: Layer
+  value: ConsensusEventFilteringType
+  setValue: ParamSetterFunction<ConsensusEventFilteringType>
+  expand?: boolean
+  customOptions?: Option[]
+}> = ({ layer, value, setValue, expand, customOptions }) => {
+  const { t } = useTranslation()
+  const defaultOptions: Option[] = [{ value: 'any', label: 'Any' }]
+  const options = customOptions
+    ? [...defaultOptions, ...customOptions]
+    : [...defaultOptions, ...getConsensusEventTypeOptions(t, layer)]
+
+  return (
+    <Select
+      className={expand ? 'expand' : undefined}
+      light={true}
+      label={<FilterLabel />}
+      options={options}
+      value={value}
+      handleChange={setValue}
+    />
+  )
+}

--- a/src/app/components/ConsensusEvents/ConsensusEventsList.tsx
+++ b/src/app/components/ConsensusEvents/ConsensusEventsList.tsx
@@ -8,6 +8,8 @@ import { TablePagination, TablePaginationProps } from '../Table/TablePagination'
 import { CardEmptyState } from '../CardEmptyState'
 import { TextSkeleton } from '../Skeleton'
 import { ConsensusEventDetails } from './ConsensusEventDetails'
+import { AppErrors } from '../../../types/errors'
+import { EmptyState } from '../EmptyState'
 
 export const ConsensusEventsList: FC<{
   scope: ConsensusScope
@@ -16,24 +18,48 @@ export const ConsensusEventsList: FC<{
   isError: boolean
   pagination: false | TablePaginationProps
   showTxHash: boolean
-}> = ({ scope, events, isLoading, isError, pagination, showTxHash }) => {
+  filtered: boolean
+}> = ({ scope, events, isLoading, isError, pagination, showTxHash, filtered }) => {
   const { t } = useTranslation()
-  return (
-    <>
-      {isError && <CardEmptyState label={t('event.cantLoadEvents')} />}
-      {isLoading && <TextSkeleton numberOfRows={10} />}
-      {events &&
-        events.map((event, index) => (
+  if (isLoading) {
+    // Still loading?
+    return <TextSkeleton numberOfRows={10} />
+  } else if (isError) {
+    // Have we failed?
+    return <CardEmptyState label={t('event.cantLoadEvents')} />
+  } else if (!events || !events?.length) {
+    // No data. Let's see why
+    if (!!pagination && pagination.selectedPage > 1) {
+      // Wrong page?
+      throw AppErrors.PageDoesNotExist
+    } else if (filtered) {
+      // Is it because of filters?
+      return <CardEmptyState label={t('tableSearch.noMatchingResults')} />
+    } else {
+      // There is no particular reason, we just don't have data
+      return (
+        <EmptyState
+          description={t('event.cantFindMatchingEvents')}
+          title={t('event.noEvents')}
+          light={true}
+        />
+      )
+    }
+  } else {
+    return (
+      <>
+        {events.map((event, index) => (
           <div key={`event-${index}`}>
             {index > 0 && <Divider variant="card" />}
             <ConsensusEventDetails scope={scope} event={event} showTxHash={showTxHash} />
           </div>
         ))}
-      {pagination && (
-        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <TablePagination {...pagination} />
-        </Box>
-      )}
-    </>
-  )
+        {pagination && (
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <TablePagination {...pagination} />
+          </Box>
+        )}
+      </>
+    )
+  }
 }

--- a/src/app/components/Transactions/ConsensusTransactionEvents.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionEvents.tsx
@@ -1,35 +1,24 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Transaction, useGetConsensusEvents } from '../../../oasis-nexus/api'
-import { AppErrors } from '../../../types/errors'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { ConsensusEventsList } from '../ConsensusEvents/ConsensusEventsList'
 import { useSearchParamsPagination } from '../Table/useSearchParamsPagination'
-import { EmptyState } from '../EmptyState'
+import { ConsensusEventFilteringType, getConsensusEventTypeFilteringParam } from '../../hooks/useCommonParams'
 
 export const ConsensusTransactionEvents: FC<{
   transaction: Transaction
-}> = ({ transaction }) => {
-  const { t } = useTranslation()
+  eventType: ConsensusEventFilteringType
+}> = ({ transaction, eventType }) => {
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
   const eventsQuery = useGetConsensusEvents(transaction.network, {
     tx_hash: transaction.hash,
+    ...getConsensusEventTypeFilteringParam(eventType),
     limit,
     offset,
   })
-  const { isFetched, isLoading, data, isError } = eventsQuery
+  const { isLoading, data, isError } = eventsQuery
   const events = data?.data.events
-  if (isFetched && pagination.selectedPage > 1 && !events?.length) {
-    throw AppErrors.PageDoesNotExist
-  }
-
-  if (!events?.length && isFetched) {
-    return (
-      <EmptyState description={t('event.cantFindMatchingEvents')} title={t('event.noEvents')} light={true} />
-    )
-  }
-
   return (
     <ConsensusEventsList
       scope={transaction}
@@ -44,6 +33,7 @@ export const ConsensusTransactionEvents: FC<{
         rowsPerPage: limit,
       }}
       showTxHash={false}
+      filtered={eventType !== 'any'}
     />
   )
 }

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -1,6 +1,11 @@
 import { useTypedSearchParam } from './useTypedSearchParam'
 import { ConsensusTxMethodFilterOption } from '../components/ConsensusTransactionMethod'
-import { GetRuntimeEventsParams, RuntimeEventType } from '../../oasis-nexus/api'
+import {
+  GetRuntimeEventsParams,
+  GetConsensusEventsParams,
+  RuntimeEventType,
+  ConsensusEventType,
+} from '../../oasis-nexus/api'
 
 export const TX_METHOD_QUERY_ARG_NAME = 'tx_method'
 
@@ -48,6 +53,30 @@ export const getRuntimeEventTypeFilteringParam = (
         type: RuntimeEventType.evmlog,
         evm_log_signature: 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
       }
+    default:
+      return { type }
+  }
+}
+
+export type ConsensusEventFilteringType = ConsensusEventType | 'any'
+
+export const useConsensusEventTypeParam = () => {
+  const [eventType, setEventType] = useTypedSearchParam<ConsensusEventFilteringType>(
+    EVENT_TYPE_QUERY_ARG_NAME,
+    'any',
+    {
+      deleteParams: ['page', 'date'],
+    },
+  )
+  return { eventType, setEventType }
+}
+
+export const getConsensusEventTypeFilteringParam = (
+  type: ConsensusEventFilteringType,
+): Partial<GetConsensusEventsParams> => {
+  switch (type) {
+    case 'any':
+      return {}
     default:
       return { type }
   }

--- a/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
@@ -1,12 +1,16 @@
 import { useOutletContext } from 'react-router-dom'
 import { ConsensusScope } from '../../../types/searchScope'
 import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
+import { ConsensusEventFilteringType } from '../../hooks/useCommonParams'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 export type ConsensusAccountDetailsContext = {
   scope: ConsensusScope
   address: string
   txMethod: ConsensusTxMethodFilterOption
   setTxMethod: (value: ConsensusTxMethodFilterOption) => void
+  eventType: ConsensusEventFilteringType
+  setEventType: ParamSetterFunction<ConsensusEventFilteringType>
 }
 
 export const useConsensusAccountDetailsProps = () => useOutletContext<ConsensusAccountDetailsContext>()

--- a/src/app/pages/ConsensusAccountDetailsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/index.tsx
@@ -12,7 +12,7 @@ import { RouterTabs } from '../../components/RouterTabs'
 import { BalanceDistribution } from './BalanceDistribution'
 import { Staking } from './Staking'
 import { ConsensusAccountDetailsContext } from './hooks'
-import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
+import { useConsensusEventTypeParam, useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { getHighlightPattern, textSearch } from '../../components/Search/search-utils'
 
@@ -24,12 +24,20 @@ export const ConsensusAccountDetailsPage: FC = () => {
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.accountName(searchQuery))
   const { txMethod, setTxMethod } = useConsensusTxMethodParam()
+  const { eventType, setEventType } = useConsensusEventTypeParam()
   const accountQuery = useGetConsensusAccountsAddress(network, address)
   const { isError, isLoading, data } = accountQuery
   const account = data?.data
   const transactionsLink = useHref('')
   const eventsLink = useHref(`events#${eventsContainerId}`)
-  const context: ConsensusAccountDetailsContext = { scope, address, txMethod, setTxMethod }
+  const context: ConsensusAccountDetailsContext = {
+    scope,
+    address,
+    txMethod,
+    setTxMethod,
+    eventType,
+    setEventType,
+  }
 
   return (
     <PageLayout>

--- a/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockEventsCard.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockEventsCard.tsx
@@ -1,51 +1,48 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useGetConsensusEvents } from '../../../oasis-nexus/api'
-import { AppErrors } from '../../../types/errors'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit } from '../../../config'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
-import { EmptyState } from '../../components/EmptyState'
 import { ConsensusBlockDetailsContext } from '.'
 import { ConsensusEventsList } from '../../components/ConsensusEvents/ConsensusEventsList'
 import { eventsContainerId } from '../../utils/tabAnchors'
+import { getConsensusEventTypeFilteringParam, useConsensusEventTypeParam } from '../../hooks/useCommonParams'
+import { ConsensusEventTypeFilter } from '../../components/ConsensusEvents/ConsensusEventTypeFilter'
+import Divider from '@mui/material/Divider'
 
 const ConsensusBlockEventsList: FC<ConsensusBlockDetailsContext> = ({ scope, blockHeight }) => {
-  const { t } = useTranslation()
+  const { eventType, setEventType } = useConsensusEventTypeParam()
   const pagination = useSearchParamsPagination('page')
   const offset = (pagination.selectedPage - 1) * limit
   const eventsQuery = useGetConsensusEvents(scope.network, {
     block: blockHeight,
+    ...getConsensusEventTypeFilteringParam(eventType),
     limit,
     offset,
   })
-  const { isFetched, isLoading, data, isError } = eventsQuery
+  const { isLoading, data, isError } = eventsQuery
   const events = data?.data.events
-  if (isFetched && pagination.selectedPage > 1 && !events?.length) {
-    throw AppErrors.PageDoesNotExist
-  }
-
-  if (!events?.length && isFetched) {
-    return (
-      <EmptyState description={t('event.cantFindMatchingEvents')} title={t('event.noEvents')} light={true} />
-    )
-  }
 
   return (
-    <ConsensusEventsList
-      scope={scope}
-      events={events}
-      isLoading={isLoading}
-      isError={isError}
-      pagination={{
-        selectedPage: pagination.selectedPage,
-        linkToPage: pagination.linkToPage,
-        totalCount: data?.data.total_count,
-        isTotalCountClipped: data?.data.is_total_count_clipped,
-        rowsPerPage: limit,
-      }}
-      showTxHash
-    />
+    <>
+      <ConsensusEventTypeFilter layer={scope.layer} value={eventType} setValue={setEventType} />
+      <Divider variant={'card'} />
+      <ConsensusEventsList
+        scope={scope}
+        events={events}
+        isLoading={isLoading}
+        isError={isError}
+        pagination={{
+          selectedPage: pagination.selectedPage,
+          linkToPage: pagination.linkToPage,
+          totalCount: data?.data.total_count,
+          isTotalCountClipped: data?.data.is_total_count_clipped,
+          rowsPerPage: limit,
+        }}
+        showTxHash
+        filtered={eventType !== 'any'}
+      />
+    </>
   )
 }
 

--- a/src/app/pages/ConsensusTransactionDetailPage/index.tsx
+++ b/src/app/pages/ConsensusTransactionDetailPage/index.tsx
@@ -27,12 +27,16 @@ import { useWantedTransaction } from '../../hooks/useWantedTransaction'
 import { MultipleTransactionsWarning } from '../../components/Transactions/MultipleTransactionsWarning'
 import { DashboardLink } from '../ParatimeDashboardPage/DashboardLink'
 import Box from '@mui/material/Box'
+import { ConsensusEventTypeFilter } from '../../components/ConsensusEvents/ConsensusEventTypeFilter'
+import Divider from '@mui/material/Divider'
+import { useConsensusEventTypeParam } from '../../hooks/useCommonParams'
 
 const StyledDescriptionDetails = styled('dd')({
   '&&': { padding: 0 },
 })
 
 export const ConsensusTransactionDetailPage: FC = () => {
+  const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const scope = useRequiredScopeParam()
   const hash = useParams().hash!
@@ -41,6 +45,7 @@ export const ConsensusTransactionDetailPage: FC = () => {
   const { wantedTransaction: transaction, warningMultipleTransactionsSameHash } = useWantedTransaction(
     data?.data,
   )
+  const { eventType, setEventType } = useConsensusEventTypeParam()
   if (!transaction && !isLoading) {
     throw AppErrors.NotFoundTxHash
   }
@@ -57,8 +62,21 @@ export const ConsensusTransactionDetailPage: FC = () => {
         />
       </SubPageCard>
       {transaction && (
-        <SubPageCard title={t('common.events')}>
-          <ConsensusTransactionEvents transaction={transaction} />
+        <SubPageCard
+          title={t('common.events')}
+          action={
+            !isMobile && (
+              <ConsensusEventTypeFilter layer={transaction.layer} value={eventType} setValue={setEventType} />
+            )
+          }
+        >
+          {isMobile && (
+            <>
+              <ConsensusEventTypeFilter layer={transaction.layer} value={eventType} setValue={setEventType} />
+              <Divider variant={'card'} />
+            </>
+          )}
+          <ConsensusTransactionEvents transaction={transaction} eventType={eventType} />
         </SubPageCard>
       )}
     </PageLayout>

--- a/src/app/pages/ValidatorDetailsPage/hooks.ts
+++ b/src/app/pages/ValidatorDetailsPage/hooks.ts
@@ -1,12 +1,16 @@
 import { useOutletContext } from 'react-router-dom'
 import { ConsensusScope } from '../../../types/searchScope'
 import { ConsensusTxMethodFilterOption } from '../../components/ConsensusTransactionMethod'
+import { ConsensusEventFilteringType } from '../../hooks/useCommonParams'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 export type ValidatorDetailsContext = {
   scope: ConsensusScope
   address: string
   txMethod: ConsensusTxMethodFilterOption
   setTxMethod: (method: ConsensusTxMethodFilterOption) => void
+  eventType: ConsensusEventFilteringType
+  setEventType: ParamSetterFunction<ConsensusEventFilteringType>
 }
 
 export const useValidatorDetailsProps = () => useOutletContext<ValidatorDetailsContext>()

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -38,7 +38,7 @@ import { ValidatorStatusBadge } from './ValidatorStatusBadge'
 import { PercentageValue } from '../../components/PercentageValue'
 import { BalancesDiff } from '../../components/BalancesDiff'
 import { RoundedBalance } from '../../components/RoundedBalance'
-import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
+import { useConsensusEventTypeParam, useConsensusTxMethodParam } from '../../hooks/useCommonParams'
 import { eventsContainerId } from '../../utils/tabAnchors'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { AccountLink } from '../../components/Account/AccountLink'
@@ -62,6 +62,7 @@ export const ValidatorDetailsPage: FC = () => {
   const { isMobile } = useScreenSize()
   const scope = useConsensusScope()
   const { txMethod, setTxMethod } = useConsensusTxMethodParam()
+  const { eventType, setEventType } = useConsensusEventTypeParam()
   const { address, searchQuery } = useLoaderData() as AddressLoaderData
   const highlightPattern = getHighlightPattern(textSearch.validatorName(searchQuery))
   const validatorQuery = useGetConsensusValidatorsAddress(scope.network, address)
@@ -75,7 +76,7 @@ export const ValidatorDetailsPage: FC = () => {
   const accountQuery = useGetConsensusAccountsAddress(scope.network, address)
   const { isLoading: isAccountLoading, data: accountData } = accountQuery
   const account = accountData?.data
-  const context: ValidatorDetailsContext = { scope, address, txMethod, setTxMethod }
+  const context: ValidatorDetailsContext = { scope, address, txMethod, setTxMethod, eventType, setEventType }
   const isLoading = isValidatorLoading || isAccountLoading
 
   return (


### PR DESCRIPTION
This depends on:
- [x] #2078 
- [x] #2084 

Adds filtering for consensus event list in:
 - Block details
 - Account details
 - Validator details
 - Transaction details

Apparently, we haven't introduced i18n names for consensus event types, so the filter is simply offering the technical names. but this is consistent with the way there events are currently displayed.