### PR TITLE
Clean up TX filtering and listing code

### DIFF
--- a/.changelog/2082.internal.md
+++ b/.changelog/2082.internal.md
@@ -1,0 +1,1 @@
+Clean up TX filtering and listing code

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -18,7 +18,6 @@ import Tooltip from '@mui/material/Tooltip'
 import { tooltipDelay } from '../../../styles/theme'
 import { ConsensusTxMethod, GetConsensusTransactionsParams } from '../../../oasis-nexus/api'
 import { COLORS } from '../../../styles/theme/colors'
-import { SelectOptionBase } from '../Select'
 import { exhaustedTypeWarning } from '../../../types/errors'
 
 type MethodIconProps = {
@@ -293,9 +292,14 @@ const knownConsensusTxMethods = [
 const typeTestExhaustiveArray =
   undefined as unknown as ConsensusTxMethod satisfies (typeof knownConsensusTxMethods)[number]
 
-export const getConsensusTxMethodOptions = (t: TFunction): SelectOptionBase[] =>
+export type ConsensusTransactionTypeFilterOption = {
+  value: ConsensusTxMethodFilterOption
+  label: string
+}
+
+export const getConsensusTxMethodOptions = (t: TFunction) =>
   knownConsensusTxMethods.map(
-    (method): SelectOptionBase => ({
+    (method): ConsensusTransactionTypeFilterOption => ({
       value: method,
       label: getConsensusTransactionLabel(t, method),
     }),

--- a/src/app/components/RuntimeTransactionMethod/index.tsx
+++ b/src/app/components/RuntimeTransactionMethod/index.tsx
@@ -15,9 +15,9 @@ import DeveloperBoardOffIcon from '@mui/icons-material/DeveloperBoardOff'
 import LockIcon from '@mui/icons-material/Lock'
 import { MethodIcon } from '../ConsensusTransactionMethod'
 import { GetRuntimeTransactionsParams, Layer, RuntimeTransaction } from '../../../oasis-nexus/api'
-import { SelectOptionBase } from '../Select'
 import { paraTimesConfig } from '../../../config'
 import { exhaustedTypeWarning } from '../../../types/errors'
+import { RuntimeTxMethodFilteringType } from '../../hooks/useCommonParams'
 
 const getRuntimeTransactionLabel = (t: TFunction, method: KnownRuntimeTxMethod) => {
   // TODO: when adding new types here, please also update knownRuntimeTxMethods below.
@@ -95,25 +95,30 @@ const knownRuntimeTxMethods = [
   'roflmarket.InstanceChangeAdmin',
   '',
 ] as const
-type KnownRuntimeTxMethod = (typeof knownRuntimeTxMethods)[number]
+export type KnownRuntimeTxMethod = (typeof knownRuntimeTxMethods)[number]
 
-export const getRuntimeTxMethodOptions = (t: TFunction, layer: Layer): SelectOptionBase[] => {
+export type RuntimeTxMethodFilterOption = {
+  value: RuntimeTxMethodFilteringType
+  label: string
+}
+
+export const getRuntimeTxMethodOptions = (t: TFunction, layer: Layer) => {
   const hasRofl = !!paraTimesConfig[layer]?.offerRoflTxTypes
   return knownRuntimeTxMethods
     .filter(method => !method.startsWith('rofl') || hasRofl)
     .map(
-      (method): SelectOptionBase => ({
+      (method): RuntimeTxMethodFilterOption => ({
         value: method,
         label: getRuntimeTransactionLabel(t, method),
       }),
     )
 }
 
-export const getRuntimeRoflUpdatesMethodOptions = (t: TFunction): SelectOptionBase[] => {
+export const getRuntimeRoflUpdatesMethodOptions = (t: TFunction) => {
   const options = ['rofl.Create', 'rofl.Remove', 'rofl.Update'] as const
 
   return options.map(
-    (method): SelectOptionBase => ({
+    (method): RuntimeTxMethodFilterOption => ({
       value: method,
       label: getRuntimeTransactionLabel(t, method),
     }),

--- a/src/app/components/Transactions/ConsensusTransactionMethodFilter.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionMethodFilter.tsx
@@ -27,7 +27,7 @@ const FilterLabel: FC = () => {
   )
 }
 
-export const ConsensusTransactionTypeFilter: FC<{
+export const ConsensusTransactionMethodFilter: FC<{
   value: ConsensusTxMethodFilterOption
   setValue: ParamSetterFunction<ConsensusTxMethodFilterOption>
   expand?: boolean

--- a/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
@@ -1,8 +1,13 @@
 import { FC } from 'react'
-import { getConsensusTxMethodOptions, ConsensusTxMethodFilterOption } from '../ConsensusTransactionMethod'
+import {
+  getConsensusTxMethodOptions,
+  ConsensusTxMethodFilterOption,
+  ConsensusTransactionTypeFilterOption,
+} from '../ConsensusTransactionMethod'
 import { useTranslation } from 'react-i18next'
 import { Select } from '../Select'
 import Typography from '@mui/material/Typography'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 const FilterLabel: FC = () => {
   const { t } = useTranslation()
@@ -24,12 +29,12 @@ const FilterLabel: FC = () => {
 
 export const ConsensusTransactionTypeFilter: FC<{
   value: ConsensusTxMethodFilterOption
-  setValue: (value: ConsensusTxMethodFilterOption) => void
+  setValue: ParamSetterFunction<ConsensusTxMethodFilterOption>
   expand?: boolean
 }> = ({ value, setValue, expand }) => {
   const { t } = useTranslation()
   return (
-    <Select
+    <Select<ConsensusTransactionTypeFilterOption>
       className={expand ? 'expand' : undefined}
       light={true}
       label={<FilterLabel />}

--- a/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/ConsensusTransactionTypeFilter.tsx
@@ -17,7 +17,7 @@ const FilterLabel: FC = () => {
         marginRight: 4,
       }}
     >
-      {t('transactions.filterByType')}
+      {t('transactions.filterByMethod')}
     </Typography>
   )
 }
@@ -35,7 +35,7 @@ export const ConsensusTransactionTypeFilter: FC<{
       label={<FilterLabel />}
       options={[{ value: 'any', label: 'Any' }, ...getConsensusTxMethodOptions(t)]}
       value={value}
-      handleChange={setValue as any}
+      handleChange={setValue}
     />
   )
 }

--- a/src/app/components/Transactions/RuntimeTransactionMethodFilter.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionMethodFilter.tsx
@@ -20,12 +20,12 @@ const FilterLabel: FC = () => {
         marginRight: 4,
       }}
     >
-      {t('transactions.filterByType')}
+      {t('transactions.filterByMethod')}
     </Typography>
   )
 }
 
-export const RuntimeTransactionTypeFilter: FC<{
+export const RuntimeTransactionMethodFilter: FC<{
   layer: Layer
   value: RuntimeTxMethodFilteringType
   setValue: ParamSetterFunction<RuntimeTxMethodFilteringType>

--- a/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionTypeFilter.tsx
@@ -1,9 +1,11 @@
 import { FC } from 'react'
-import { getRuntimeTxMethodOptions } from '../RuntimeTransactionMethod'
+import { getRuntimeTxMethodOptions, RuntimeTxMethodFilterOption } from '../RuntimeTransactionMethod'
 import { useTranslation } from 'react-i18next'
-import { Select, SelectOptionBase } from '../Select'
+import { Select } from '../Select'
 import Typography from '@mui/material/Typography'
 import { Layer } from '../../../oasis-nexus/api'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
+import { RuntimeTxMethodFilteringType } from '../../hooks/useCommonParams'
 
 const FilterLabel: FC = () => {
   const { t } = useTranslation()
@@ -25,13 +27,13 @@ const FilterLabel: FC = () => {
 
 export const RuntimeTransactionTypeFilter: FC<{
   layer: Layer
-  value: string
-  setValue: (value: string) => void
+  value: RuntimeTxMethodFilteringType
+  setValue: ParamSetterFunction<RuntimeTxMethodFilteringType>
   expand?: boolean
-  customOptions?: SelectOptionBase[]
+  customOptions?: RuntimeTxMethodFilterOption[]
 }> = ({ layer, value, setValue, expand, customOptions }) => {
   const { t } = useTranslation()
-  const defaultOptions = [{ value: 'any', label: 'Any' }]
+  const defaultOptions: RuntimeTxMethodFilterOption[] = [{ value: 'any', label: 'Any' }]
   const options = customOptions
     ? [...defaultOptions, ...customOptions]
     : [...defaultOptions, ...getRuntimeTxMethodOptions(t, layer)]
@@ -43,7 +45,7 @@ export const RuntimeTransactionTypeFilter: FC<{
       label={<FilterLabel />}
       options={options}
       value={value}
-      handleChange={setValue as any}
+      handleChange={setValue}
     />
   )
 }

--- a/src/app/hooks/useCommonParams.ts
+++ b/src/app/hooks/useCommonParams.ts
@@ -6,6 +6,7 @@ import {
   RuntimeEventType,
   ConsensusEventType,
 } from '../../oasis-nexus/api'
+import { KnownRuntimeTxMethod } from '../components/RuntimeTransactionMethod'
 
 export const TX_METHOD_QUERY_ARG_NAME = 'tx_method'
 
@@ -20,10 +21,16 @@ export const useConsensusTxMethodParam = () => {
   return { txMethod, setTxMethod }
 }
 
+export type RuntimeTxMethodFilteringType = KnownRuntimeTxMethod | 'any'
+
 export const useRuntimeTxMethodParam = () => {
-  const [txMethod, setTxMethod] = useTypedSearchParam(TX_METHOD_QUERY_ARG_NAME, 'any', {
-    deleteParams: ['page', 'date'],
-  })
+  const [txMethod, setTxMethod] = useTypedSearchParam<RuntimeTxMethodFilteringType>(
+    TX_METHOD_QUERY_ARG_NAME,
+    'any',
+    {
+      deleteParams: ['page', 'date'],
+    },
+  )
   return { txMethod, setTxMethod }
 }
 

--- a/src/app/hooks/useTypedSearchParam.ts
+++ b/src/app/hooks/useTypedSearchParam.ts
@@ -21,7 +21,10 @@ export type UrlSettingOptions = {
   deleteParams?: string[]
 }
 
-export type ParamSetterFunction<T> = (value: T | null | undefined, options?: UrlSettingOptions) => void
+export type ParamSetterFunction<T = string> = (
+  value: T | null | undefined,
+  options?: UrlSettingOptions,
+) => void
 
 export function useTypedSearchParam<T = string>(
   paramName: string,

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountTransactionsCard.tsx
@@ -6,7 +6,7 @@ import { useSearchParamsPagination } from '../../components/Table/useSearchParam
 import { ConsensusAccountDetailsContext } from './hooks'
 import { LinkableCardLayout } from 'app/components/LinkableCardLayout'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import { ConsensusTransactionMethodFilter } from '../../components/Transactions/ConsensusTransactionMethodFilter'
 import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
 
@@ -24,11 +24,11 @@ export const ConsensusAccountTransactionsCard: FC<ConsensusAccountDetailsContext
             justifyContent: 'end',
           }}
         >
-          {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
+          {!isMobile && <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} />}
         </Box>
       }
     >
-      {isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />}
+      {isMobile && <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} expand />}
       <ConsensusAccountTransactions {...context} />
     </LinkableCardLayout>
   )

--- a/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/hooks.tsx
@@ -8,7 +8,7 @@ export type ConsensusAccountDetailsContext = {
   scope: ConsensusScope
   address: string
   txMethod: ConsensusTxMethodFilterOption
-  setTxMethod: (value: ConsensusTxMethodFilterOption) => void
+  setTxMethod: ParamSetterFunction<ConsensusTxMethodFilterOption>
   eventType: ConsensusEventFilteringType
   setEventType: ParamSetterFunction<ConsensusEventFilteringType>
 }

--- a/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/ConsensusBlockTransactionsCard.tsx
@@ -8,7 +8,7 @@ import { SearchScope } from '../../../types/searchScope'
 import { ConsensusBlockDetailsContext } from '.'
 import { LinkableCardLayout } from 'app/components/LinkableCardLayout'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
-import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import { ConsensusTransactionMethodFilter } from '../../components/Transactions/ConsensusTransactionMethodFilter'
 import { useScreenSize } from '../../hooks/useScreensize'
 import {
   getConsensusTransactionMethodFilteringParam,
@@ -72,11 +72,11 @@ export const ConsensusBlockTransactionsCard: FC<ConsensusBlockDetailsContext> = 
             justifyContent: 'end',
           }}
         >
-          {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
+          {!isMobile && <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} />}
         </Box>
       }
     >
-      {isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />}
+      {isMobile && <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} expand />}
       <TransactionList scope={scope} blockHeight={blockHeight} method={txMethod} />
     </LinkableCardLayout>
   )

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -18,7 +18,7 @@ import {
   ConsensusTxMethodFilterOption,
 } from '../../components/ConsensusTransactionMethod'
 import Box from '@mui/material/Box'
-import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import { ConsensusTransactionMethodFilter } from '../../components/Transactions/ConsensusTransactionMethodFilter'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
@@ -77,7 +77,7 @@ export const LatestConsensusTransactions: FC<{
           >
             {t('transactions.latest')}
             {shouldFilter && !isMobile && (
-              <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />
+              <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} />
             )}
           </Box>
         }
@@ -88,7 +88,7 @@ export const LatestConsensusTransactions: FC<{
         }
       />
       {shouldFilter && isMobile && (
-        <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />
+        <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} expand />
       )}
       <CardContent>
         <ErrorBoundary light={true}>

--- a/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LatestConsensusTransactions.tsx
@@ -21,18 +21,19 @@ import Box from '@mui/material/Box'
 import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 
 const LatestConsensusTransactionsContent: FC<{
   scope: ConsensusScope
-  method: ConsensusTxMethodFilterOption
-  setMethod: (value: ConsensusTxMethodFilterOption) => void
-}> = ({ scope, method }) => {
+  txMethod: ConsensusTxMethodFilterOption
+  setTxMethod: ParamSetterFunction<ConsensusTxMethodFilterOption>
+}> = ({ scope, txMethod }) => {
   const { network } = scope
 
   const transactionsQuery = useGetConsensusTransactions(
     network,
     {
-      ...getConsensusTransactionMethodFilteringParam(method),
+      ...getConsensusTransactionMethodFilteringParam(txMethod),
       limit,
     },
     {
@@ -49,16 +50,16 @@ const LatestConsensusTransactionsContent: FC<{
       limit={limit}
       pagination={false}
       verbose={false}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }
 
 export const LatestConsensusTransactions: FC<{
   scope: ConsensusScope
-  method: ConsensusTxMethodFilterOption
-  setMethod: (value: ConsensusTxMethodFilterOption) => void
-}> = ({ scope, method, setMethod }) => {
+  txMethod: ConsensusTxMethodFilterOption
+  setTxMethod: ParamSetterFunction<ConsensusTxMethodFilterOption>
+}> = ({ scope, txMethod, setTxMethod }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   return (
@@ -76,7 +77,7 @@ export const LatestConsensusTransactions: FC<{
           >
             {t('transactions.latest')}
             {shouldFilter && !isMobile && (
-              <ConsensusTransactionTypeFilter value={method} setValue={setMethod} />
+              <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />
             )}
           </Box>
         }
@@ -87,11 +88,11 @@ export const LatestConsensusTransactions: FC<{
         }
       />
       {shouldFilter && isMobile && (
-        <ConsensusTransactionTypeFilter value={method} setValue={setMethod} expand />
+        <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />
       )}
       <CardContent>
         <ErrorBoundary light={true}>
-          <LatestConsensusTransactionsContent scope={scope} method={method} setMethod={setMethod} />
+          <LatestConsensusTransactionsContent scope={scope} txMethod={txMethod} setTxMethod={setTxMethod} />
         </ErrorBoundary>
       </CardContent>
     </Card>

--- a/src/app/pages/ConsensusDashboardPage/index.tsx
+++ b/src/app/pages/ConsensusDashboardPage/index.tsx
@@ -41,7 +41,7 @@ export const ConsensusDashboardPage: FC = () => {
       <ValidatorsCard scope={scope} />
       {!isLocal && <ParaTimesCard scope={scope} />}
       <AccountsCard scope={scope} />
-      <LatestConsensusTransactions scope={scope} method={txMethod} setMethod={setTxMethod} />
+      <LatestConsensusTransactions scope={scope} txMethod={txMethod} setTxMethod={setTxMethod} />
       {!isLocal && (
         <>
           <NetworkProposalsCard scope={scope} />

--- a/src/app/pages/ConsensusTransactionsPage/index.tsx
+++ b/src/app/pages/ConsensusTransactionsPage/index.tsx
@@ -17,7 +17,7 @@ import { VerticalList } from '../../components/VerticalList'
 import { ConsensusTransactionDetailView } from '../ConsensusTransactionDetailPage'
 import { useConsensusListBeforeDate } from '../../hooks/useListBeforeDate'
 import { useConsensusTxMethodParam } from '../../hooks/useCommonParams'
-import { ConsensusTransactionTypeFilter } from '../../components/Transactions/ConsensusTransactionTypeFilter'
+import { ConsensusTransactionMethodFilter } from '../../components/Transactions/ConsensusTransactionMethodFilter'
 import { getConsensusTransactionMethodFilteringParam } from '../../components/ConsensusTransactionMethod'
 import Box from '@mui/material/Box'
 
@@ -98,12 +98,12 @@ export const ConsensusTransactionsPage: FC = () => {
             }}
           >
             {t('transactions.latest')}
-            {!isMobile && <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} />}
+            {!isMobile && <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} />}
           </Box>
         }
         title2={
           isMobile ? (
-            <ConsensusTransactionTypeFilter value={txMethod} setValue={setTxMethod} expand />
+            <ConsensusTransactionMethodFilter value={txMethod} setValue={setTxMethod} expand />
           ) : undefined
         }
         action={isMobile && <TableLayoutButton tableView={tableView} setTableView={setTableView} />}

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
@@ -24,9 +24,8 @@ const shouldFilter = FILTERING_ON_DASHBOARD
 
 const LatestRuntimeTransactionsContent: FC<{
   scope: RuntimeScope
-  method: string
-  setMethod: (value: string) => void
-}> = ({ scope, method }) => {
+  txMethod: string
+}> = ({ scope, txMethod }) => {
   const { isTablet } = useScreenSize()
   const { network, layer } = scope
 
@@ -34,7 +33,7 @@ const LatestRuntimeTransactionsContent: FC<{
     network,
     layer,
     {
-      ...getRuntimeTransactionMethodFilteringParam(method),
+      ...getRuntimeTransactionMethodFilteringParam(txMethod),
       limit,
     },
     {
@@ -51,16 +50,16 @@ const LatestRuntimeTransactionsContent: FC<{
       limit={limit}
       pagination={false}
       verbose={!isTablet}
-      filtered={method !== 'any'}
+      filtered={txMethod !== 'any'}
     />
   )
 }
 
 export const LatestRuntimeTransactions: FC<{
   scope: RuntimeScope
-  method: RuntimeTxMethodFilteringType
-  setMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
-}> = ({ scope, method, setMethod }) => {
+  txMethod: RuntimeTxMethodFilteringType
+  setTxMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
+}> = ({ scope, txMethod, setTxMethod }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()
   const { layer } = scope
@@ -80,7 +79,7 @@ export const LatestRuntimeTransactions: FC<{
           >
             {t('transactions.latest')}
             {shouldFilter && !isMobile && (
-              <RuntimeTransactionMethodFilter layer={layer} value={method} setValue={setMethod} />
+              <RuntimeTransactionMethodFilter layer={layer} value={txMethod} setValue={setTxMethod} />
             )}
           </Box>
         }
@@ -95,11 +94,11 @@ export const LatestRuntimeTransactions: FC<{
         }
       />
       {shouldFilter && isMobile && (
-        <RuntimeTransactionMethodFilter layer={layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionMethodFilter layer={layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <CardContent>
         <ErrorBoundary light>
-          <LatestRuntimeTransactionsContent scope={scope} method={method} setMethod={setMethod} />
+          <LatestRuntimeTransactionsContent scope={scope} txMethod={txMethod} />
         </ErrorBoundary>
       </CardContent>
     </Card>

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
@@ -16,6 +16,8 @@ import { RuntimeTransactionTypeFilter } from '../../components/Transactions/Runt
 import Box from '@mui/material/Box'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
+import { RuntimeTxMethodFilteringType } from '../../hooks/useCommonParams'
 
 const limit = NUMBER_OF_ITEMS_ON_DASHBOARD
 const shouldFilter = FILTERING_ON_DASHBOARD
@@ -56,8 +58,8 @@ const LatestRuntimeTransactionsContent: FC<{
 
 export const LatestRuntimeTransactions: FC<{
   scope: RuntimeScope
-  method: string
-  setMethod: (value: string) => void
+  method: RuntimeTxMethodFilteringType
+  setMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
 }> = ({ scope, method, setMethod }) => {
   const { isMobile } = useScreenSize()
   const { t } = useTranslation()

--- a/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LatestRuntimeTransactions.tsx
@@ -12,7 +12,7 @@ import { COLORS } from '../../../styles/theme/colors'
 import { RouteUtils } from '../../utils/route-utils'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { RuntimeScope } from '../../../types/searchScope'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import Box from '@mui/material/Box'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
@@ -80,7 +80,7 @@ export const LatestRuntimeTransactions: FC<{
           >
             {t('transactions.latest')}
             {shouldFilter && !isMobile && (
-              <RuntimeTransactionTypeFilter layer={layer} value={method} setValue={setMethod} />
+              <RuntimeTransactionMethodFilter layer={layer} value={method} setValue={setMethod} />
             )}
           </Box>
         }
@@ -95,7 +95,7 @@ export const LatestRuntimeTransactions: FC<{
         }
       />
       {shouldFilter && isMobile && (
-        <RuntimeTransactionTypeFilter layer={layer} value={method} setValue={setMethod} expand />
+        <RuntimeTransactionMethodFilter layer={layer} value={method} setValue={setMethod} expand />
       )}
       <CardContent>
         <ErrorBoundary light>

--- a/src/app/pages/ParatimeDashboardPage/index.tsx
+++ b/src/app/pages/ParatimeDashboardPage/index.tsx
@@ -27,7 +27,7 @@ export const ParatimeDashboardPage: FC = () => {
     <PageLayout>
       {!isLocal && <ParaTimeSnapshot scope={scope} />}
       <Divider variant="layout" sx={{ mt: isMobile ? 4 : 0 }} />
-      <LatestRuntimeTransactions scope={scope} method={txMethod} setMethod={setTxMethod} />
+      <LatestRuntimeTransactions scope={scope} txMethod={txMethod} setTxMethod={setTxMethod} />
       <Grid container spacing={4}>
         <Grid item xs={12} md={6} sx={{ display: 'flex', order: isMobile ? 1 : 0 }}>
           <LearningMaterials scope={scope} />

--- a/src/app/pages/RoflAppDetailsPage/RoflAppInstanceTransactionsCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/RoflAppInstanceTransactionsCard.tsx
@@ -5,7 +5,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { updatesContainerId } from '../../utils/tabAnchors'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { RuntimeTransactions } from '../../components/Transactions'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import { RoflAppDetailsContext, useRoflAppInstanceTransactions } from './hooks'
 
 export const RoflAppInstanceTransactionsCard: FC<RoflAppDetailsContext> = context => {
@@ -24,13 +24,13 @@ export const RoflAppInstanceTransactionsCard: FC<RoflAppDetailsContext> = contex
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
+            <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
+        <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <RoflAppInstanceTransactions {...context} />
     </LinkableCardLayout>

--- a/src/app/pages/RoflAppDetailsPage/RoflAppUpdatesCard.tsx
+++ b/src/app/pages/RoflAppDetailsPage/RoflAppUpdatesCard.tsx
@@ -6,7 +6,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { updatesContainerId } from '../../utils/tabAnchors'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { RuntimeTransactions } from '../../components/Transactions'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import { getRuntimeRoflUpdatesMethodOptions } from '../../components/RuntimeTransactionMethod'
 import { RoflAppDetailsContext, useRoflAppUpdates } from './hooks'
 
@@ -27,7 +27,7 @@ export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter
+            <RuntimeTransactionMethodFilter
               layer={scope.layer}
               value={txMethod}
               setValue={setTxMethod}
@@ -38,7 +38,7 @@ export const RoflAppUpdatesCard: FC<RoflAppDetailsContext> = context => {
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter
+        <RuntimeTransactionMethodFilter
           layer={scope.layer}
           value={txMethod}
           setValue={setTxMethod}

--- a/src/app/pages/RoflAppDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppDetailsPage/hooks.tsx
@@ -8,12 +8,14 @@ import { RuntimeScope } from '../../../types/searchScope'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit, paraTimesConfig } from '../../../config'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
+import { RuntimeTxMethodFilteringType } from '../../hooks/useCommonParams'
 
 export type RoflAppDetailsContext = {
   scope: RuntimeScope
   id: string
-  txMethod: string
-  setTxMethod: (value: string) => void
+  txMethod: RuntimeTxMethodFilteringType
+  setTxMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
 }
 
 export const useRoflAppDetailsProps = () => useOutletContext<RoflAppDetailsContext>()

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -12,7 +12,7 @@ import { RoflApp, RoflAppPolicy, RuntimeTransaction, useGetRuntimeRoflAppsId } f
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
 import { AppErrors } from '../../../types/errors'
 import { useRuntimeScope } from '../../hooks/useScopeParam'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { COLORS } from '../../../styles/theme/colors'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { PageLayout } from '../../components/PageLayout'
@@ -50,9 +50,7 @@ export const RoflAppDetailsPage: FC = () => {
   const txLink = useHref('')
   const updatesLink = useHref(`updates#${updatesContainerId}`)
   const instancesLink = useHref(`instances#${instancesContainerId}`)
-  const [txMethod, setTxMethod] = useTypedSearchParam('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
   const context: RoflAppDetailsContext = { scope, id, txMethod, setTxMethod }
   const { isFetched, isLoading, data } = useGetRuntimeRoflAppsId(scope.network, scope.layer, id)
   const roflApp = data?.data

--- a/src/app/pages/RoflAppInstanceDetailsPage/RoflAppInstanceRakTransactionsCard.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/RoflAppInstanceRakTransactionsCard.tsx
@@ -5,7 +5,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { transactionsContainerId } from '../../utils/tabAnchors'
 import { LinkableCardLayout } from '../../components/LinkableCardLayout'
 import { RuntimeTransactions } from '../../components/Transactions'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import { RoflAppInstanceDetailsContext, useRoflAppInstanceRakTransactions } from './hooks'
 
 export const RoflAppInstanceRakTransactionsCard: FC<RoflAppInstanceDetailsContext> = context => {
@@ -23,13 +23,13 @@ export const RoflAppInstanceRakTransactionsCard: FC<RoflAppInstanceDetailsContex
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
+            <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
+        <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <RoflAppInstanceRakTransactions {...context} />
     </LinkableCardLayout>

--- a/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/hooks.tsx
@@ -5,13 +5,15 @@ import { RuntimeScope } from '../../../types/searchScope'
 import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE as limit, paraTimesConfig } from '../../../config'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import { useSearchParamsPagination } from '../../components/Table/useSearchParamsPagination'
+import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
+import { RuntimeTxMethodFilteringType } from '../../hooks/useCommonParams'
 
 export type RoflAppInstanceDetailsContext = {
   scope: RuntimeScope
   id: string
   rak: string
-  txMethod: string
-  setTxMethod: (value: string) => void
+  txMethod: RuntimeTxMethodFilteringType
+  setTxMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
 }
 
 export const useRoflAppInstanceDetailsProps = () => useOutletContext<RoflAppInstanceDetailsContext>()

--- a/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
@@ -16,7 +16,7 @@ import { StyledDescriptionList } from '../../components/StyledDescriptionList'
 import { RouterTabs } from '../../components/RouterTabs'
 import { RoflAppLink } from '../../components/Rofl/RoflAppLink'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
-import { useTypedSearchParam } from '../../hooks/useTypedSearchParam'
+import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
 import { AccountLink } from '../../components/Account/AccountLink'
 
 export const RoflAppInstanceDetailsPage: FC = () => {
@@ -25,9 +25,7 @@ export const RoflAppInstanceDetailsPage: FC = () => {
   const id = useParams().id!
   const rak = useParams().rak!
   const txLink = useHref('')
-  const [txMethod, setTxMethod] = useTypedSearchParam('method', 'any', {
-    deleteParams: ['page'],
-  })
+  const { txMethod, setTxMethod } = useRuntimeTxMethodParam()
   const context: RoflAppInstanceDetailsContext = { scope, id, rak, txMethod, setTxMethod }
   const instancesQuery = useGetRuntimeRoflAppsIdInstancesRak(scope.network, scope.layer, id, rak)
   const { isLoading, isFetched, data } = instancesQuery

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountTransactionsCard.tsx
@@ -5,7 +5,7 @@ import { NUMBER_OF_ITEMS_ON_SEPARATE_PAGE } from '../../../config'
 import { useAccountTransactions } from './hook'
 import { RuntimeAccountDetailsContext } from './index'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
 
@@ -25,13 +25,13 @@ export const AccountTransactionsCard: FC<RuntimeAccountDetailsContext> = context
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
+            <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
+        <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <AccountTransactions {...context} />
     </LinkableCardLayout>

--- a/src/app/pages/RuntimeAccountDetailsPage/index.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/index.tsx
@@ -16,6 +16,7 @@ import { AddressLoaderData } from '../../utils/route-utils'
 import { getFiatCurrencyForScope } from '../../../config'
 import {
   RuntimeEventFilteringType,
+  RuntimeTxMethodFilteringType,
   useRuntimeEventTypeParam,
   useRuntimeTxMethodParam,
 } from '../../hooks/useCommonParams'
@@ -32,8 +33,8 @@ export type RuntimeAccountDetailsContext = {
   scope: RuntimeScope
   address: string
   account?: RuntimeAccount
-  txMethod: string
-  setTxMethod: (value: string) => void
+  txMethod: RuntimeTxMethodFilteringType
+  setTxMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
   eventType: RuntimeEventFilteringType
   setEventType: ParamSetterFunction<RuntimeEventFilteringType>
 }

--- a/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/RuntimeBlockTransactionsCard.tsx
@@ -7,7 +7,7 @@ import { RuntimeTransactions } from '../../components/Transactions'
 import { AppErrors } from '../../../types/errors'
 import { RuntimeBlockDetailsContext } from '.'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import Box from '@mui/material/Box'
 import { transactionsContainerId } from '../../utils/tabAnchors'
@@ -67,13 +67,13 @@ export const RuntimeBlockTransactionsCard: FC<RuntimeBlockDetailsContext> = prop
           }}
         >
           {!isMobile && (
-            <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
+            <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
           )}
         </Box>
       }
     >
       {isMobile && (
-        <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
+        <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} expand />
       )}
       <TransactionList {...props} />
     </LinkableCardLayout>

--- a/src/app/pages/RuntimeBlockDetailPage/index.tsx
+++ b/src/app/pages/RuntimeBlockDetailPage/index.tsx
@@ -21,6 +21,7 @@ import { RuntimeNextBlockButton, RuntimePrevBlockButton } from '../../components
 import { RuntimeScope } from 'types/searchScope'
 import {
   RuntimeEventFilteringType,
+  RuntimeTxMethodFilteringType,
   useRuntimeEventTypeParam,
   useRuntimeTxMethodParam,
 } from '../../hooks/useCommonParams'
@@ -30,8 +31,8 @@ import { ParamSetterFunction } from '../../hooks/useTypedSearchParam'
 export type RuntimeBlockDetailsContext = {
   scope: RuntimeScope
   blockHeight?: number
-  txMethod: string
-  setTxMethod: (method: string) => void
+  txMethod: RuntimeTxMethodFilteringType
+  setTxMethod: ParamSetterFunction<RuntimeTxMethodFilteringType>
   eventType: RuntimeEventFilteringType
   setEventType: ParamSetterFunction<RuntimeEventFilteringType>
 }

--- a/src/app/pages/RuntimeTransactionsPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionsPage/index.tsx
@@ -19,7 +19,7 @@ import { VerticalList } from '../../components/VerticalList'
 import { getFiatCurrencyForScope } from '../../../config'
 import { useRuntimeListBeforeDate } from '../../hooks/useListBeforeDate'
 import { useRuntimeTxMethodParam } from '../../hooks/useCommonParams'
-import { RuntimeTransactionTypeFilter } from '../../components/Transactions/RuntimeTransactionTypeFilter'
+import { RuntimeTransactionMethodFilter } from '../../components/Transactions/RuntimeTransactionMethodFilter'
 import { getRuntimeTransactionMethodFilteringParam } from '../../components/RuntimeTransactionMethod'
 import Box from '@mui/material/Box'
 
@@ -107,13 +107,13 @@ export const RuntimeTransactionsPage: FC = () => {
           >
             {t('transactions.latest')}
             {!isMobile && (
-              <RuntimeTransactionTypeFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
+              <RuntimeTransactionMethodFilter layer={scope.layer} value={txMethod} setValue={setTxMethod} />
             )}
           </Box>
         }
         title2={
           isMobile ? (
-            <RuntimeTransactionTypeFilter
+            <RuntimeTransactionMethodFilter
               layer={scope.layer}
               value={txMethod}
               setValue={setTxMethod}

--- a/src/app/pages/ValidatorDetailsPage/hooks.ts
+++ b/src/app/pages/ValidatorDetailsPage/hooks.ts
@@ -8,7 +8,7 @@ export type ValidatorDetailsContext = {
   scope: ConsensusScope
   address: string
   txMethod: ConsensusTxMethodFilterOption
-  setTxMethod: (method: ConsensusTxMethodFilterOption) => void
+  setTxMethod: ParamSetterFunction<ConsensusTxMethodFilterOption>
   eventType: ConsensusEventFilteringType
   setEventType: ParamSetterFunction<ConsensusEventFilteringType>
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -449,7 +449,7 @@
       "publicKey": "Public Key",
       "resultNonce": "Result Nonce"
     },
-    "filterByType": "Filter by type",
+    "filterByMethod": "Filter by method",
     "latest": "Latest Transactions",
     "method": {
       "stakingBurn": "Burn",


### PR DESCRIPTION
In this PR, I am applying new insights gained during implementing event type filtering
to the previously implemented transaction method filtering:

- Rename TX method filter components so that we reference method, not type
- Use dedicated option types, instead using typecasting to any in change handlers