### PR TITLE
Adjust some consensus event types

### DIFF
--- a/.changelog/2085.internal.md
+++ b/.changelog/2085.internal.md
@@ -1,0 +1,1 @@
+Adjust some consensus event types

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -565,9 +565,9 @@
     "roothashInMsgProcessed": "Incoming Runtime Message Processed",
     "stakingAllowanceChange": "Allowance Changed",
     "stakingBurn": "Burn",
-    "stakingEscrowAdd": "Stake Added",
-    "stakingEscrowDebondingStart": "Started to debond stake",
-    "stakingEscrowReclaim": "Finished reclaiming stake",
+    "stakingEscrowAdd": "Delegate",
+    "stakingEscrowDebondingStart": "Start to undelegate",
+    "stakingEscrowReclaim": "Undelegate finished",
     "stakingEscrowTake": "Stake Slashed",
     "stakingTransfer": "Transfer"
   },


### PR DESCRIPTION
Following @lukaw3d's suggestion, let's use patterns that are more consistent with what we have for sapphire event names.