### PR TITLE
Fix CSS module build config

### DIFF
--- a/.changelog/2087.bugfix.md
+++ b/.changelog/2087.bugfix.md
@@ -1,0 +1,1 @@
+Fix CSS module build config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vite'
+import { defineConfig, UserConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-export default defineConfig(() => {
+export default defineConfig((): UserConfig => {
   return {
     plugins: [react(), tsconfigPaths()],
     build: {
@@ -16,5 +16,10 @@ export default defineConfig(() => {
     },
     publicDir: 'public',
     envPrefix: 'REACT_APP_',
+    css: {
+      modules: {
+        localsConvention: 'camelCase', // Optional: Ensures class names are imported as camelCase
+      },
+    },
   }
 })


### PR DESCRIPTION
This is needed so that the class names loaded from CSS modules are applied properly.

This fixes regression sneaked into #2075 at the last minute before merging, which broke some CSS:

| Before | After |
|---|---|
|  <img width="877" height="833" alt="image" src="https://github.com/user-attachments/assets/caeebc99-0aab-491d-acd2-2c5a66e771fd" />  |  <img width="879" height="446" alt="image" src="https://github.com/user-attachments/assets/991660b1-3ffa-4fce-8dc0-b831a1219295" />  |