### PR TITLE
Adjust highlighted link vertical alignment

### DIFF
--- a/.changelog/2091.trivial.md
+++ b/.changelog/2091.trivial.md
@@ -1,0 +1,1 @@
+Adjust highlighted link vertical aligment (margins)

--- a/src/app/components/HighlightingContext/WithHighlighting.tsx
+++ b/src/app/components/HighlightingContext/WithHighlighting.tsx
@@ -25,7 +25,7 @@ export const WithHighlighting: FC<{ children: ReactNode; address: string }> = ({
         alignItems: 'center',
         verticalAlign: 'middle',
         padding: '2px 4px',
-        margin: '-3px -5px',
+        margin: '-5px -5px -3px -5px',
         ...(isHighlighted
           ? {
               background: COLORS.warningLight,


### PR DESCRIPTION
This is an unrelated fix extracted from #2072.

With the current CSS, links that support the hover highlight feature appear ever so slightly bellow the normal baseline, because of margin settings. This PR fixes that, restoring correct alignment.

|Before|After|
|---|---|
| <img width="609" height="62" alt="image" src="https://github.com/user-attachments/assets/4537c936-cc1b-44b5-af56-3beea50ea6a1" /> | <img width="642" height="65" alt="image" src="https://github.com/user-attachments/assets/298ab572-d7bf-47cb-8fa5-aebc28ff3d68" />  |
|<img width="840" height="46" alt="image" src="https://github.com/user-attachments/assets/9255eeba-42df-4b62-bffc-82009a017b5d" /> | <img width="843" height="44" alt="image" src="https://github.com/user-attachments/assets/149c7722-088e-47ed-953c-9f9f359ca795" />  |

(The second screenshot is from the new endorsement display which is not part of the master branch yet, but you get the point.)
