### PR TITLE
Improve formatting of ROFL app LastActivity

### DIFF
--- a/.changelog/2092.trivial.md
+++ b/.changelog/2092.trivial.md
@@ -1,0 +1,1 @@
+Improve formatting of LastActivity

--- a/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
+++ b/src/app/pages/RoflAppDetailsPage/LastActivity.tsx
@@ -10,6 +10,7 @@ import { useScreenSize } from '../../hooks/useScreensize'
 
 const StyledBox = styled(Box)(() => ({
   display: 'flex',
+  flexWrap: 'wrap',
   alignItems: 'center',
   gap: 5,
 }))


### PR DESCRIPTION
Another bit extracted from #2072 

Make the "last activity" row look good at all widths:

|Before|After|
| --- | --- |
| <img width="566" height="97" alt="image" src="https://github.com/user-attachments/assets/53896dfd-7e1b-4825-94f8-c3375f026a86" />  | <img width="437" height="114" alt="image" src="https://github.com/user-attachments/assets/21ff751a-52a8-49e0-8f55-b95869c8f14d" />  |
| <img width="613" height="53" alt="image" src="https://github.com/user-attachments/assets/8120bc10-4483-45ef-80fb-91e48d12ab45" /> | <img width="607" height="59" alt="image" src="https://github.com/user-attachments/assets/f6fbe38e-97eb-42e2-88f4-22f533040d77" /> |
|  <img width="719" height="109" alt="image" src="https://github.com/user-attachments/assets/91c04d19-95e0-4d85-9544-0e43ae45b4b1" /> |  <img width="597" height="114" alt="image" src="https://github.com/user-attachments/assets/f6923fea-6713-4ff0-adf3-717bf6304064" /> |
| <img width="815" height="69" alt="image" src="https://github.com/user-attachments/assets/de0cdbc1-7ad7-46d8-9ca9-07de7a059ec8" />  |  <img width="796" height="63" alt="image" src="https://github.com/user-attachments/assets/7fcc99c4-db69-4876-a7bf-e29c8c435433" /> |
| <img width="1255" height="121" alt="image" src="https://github.com/user-attachments/assets/edf6ba3b-bcb2-4383-92dd-1ddb8a18a9c0" /> |  <img width="1250" height="147" alt="image" src="https://github.com/user-attachments/assets/8ed0a991-25bb-4533-80d1-f65056f48fa6" />  |
| <img width="1629" height="54" alt="image" src="https://github.com/user-attachments/assets/310d2110-8190-457a-b41c-fd020604be76" /> | <img width="1615" height="63" alt="image" src="https://github.com/user-attachments/assets/d92374b1-4c4f-4b29-b891-b9dedc2d0b5f" />  |



