### PR TITLE
Fix testnet 404 text colors

### DIFF
--- a/.changelog/2094.bugfix.md
+++ b/.changelog/2094.bugfix.md
@@ -1,0 +1,1 @@
+Fix 404 text color on testnet

--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -42,17 +42,7 @@ type EmptyStateProps = {
 
 export const EmptyState: FC<EmptyStateProps> = ({ description, title, light, minHeight = '360px' }) => {
   const content = (
-    <Box
-      sx={{
-        ...(light
-          ? { color: 'inherit' }
-          : {
-              color: COLORS.white,
-              '& span a': { color: COLORS.white },
-            }),
-        textAlign: 'center',
-      }}
-    >
+    <Box sx={{ color: light ? 'inherit' : COLORS.white, textAlign: 'center' }}>
       <Typography component="span" sx={{ fontSize: '30px', fontWeight: 500, display: 'block' }}>
         {title}
       </Typography>

--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -5,7 +5,6 @@ import { styled } from '@mui/material/styles'
 import lightBackgroundEmptyState from './images/background-empty-state.svg'
 import darkBackgroundEmptyState from './images/background-empty-state-dark.svg'
 import CancelIcon from '@mui/icons-material/Cancel'
-import { useTheme } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -42,9 +41,18 @@ type EmptyStateProps = {
 }
 
 export const EmptyState: FC<EmptyStateProps> = ({ description, title, light, minHeight = '360px' }) => {
-  const theme = useTheme()
   const content = (
-    <Box sx={{ color: light ? 'inherit' : theme.palette.layout.contrastMain, textAlign: 'center' }}>
+    <Box
+      sx={{
+        ...(light
+          ? { color: 'inherit' }
+          : {
+              color: COLORS.white,
+              '& span a': { color: COLORS.white },
+            }),
+        textAlign: 'center',
+      }}
+    >
       <Typography component="span" sx={{ fontSize: '30px', fontWeight: 500, display: 'block' }}>
         {title}
       </Typography>

--- a/src/app/pages/SearchResultsPage/NoResults.tsx
+++ b/src/app/pages/SearchResultsPage/NoResults.tsx
@@ -6,7 +6,6 @@ import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
 import { SearchSuggestionsLinksForNoResults } from '../../components/Search/SearchSuggestionsLinksForNoResults'
 import { OptionalBreak } from '../../components/OptionalBreak'
-import { useTheme } from '@mui/material/styles'
 import { getNameForScope, SearchScope } from '../../../types/searchScope'
 import { getNetworkNames, Network } from '../../../types/network'
 import { Layer } from '../../../oasis-nexus/api'
@@ -17,7 +16,6 @@ export const NoResults: FC<{
   layer?: Layer
 }> = ({ network, layer }) => {
   const { t } = useTranslation()
-  const theme = useTheme()
   const title = network
     ? t('search.noResults.scopeHeader', {
         scope: layer ? getNameForScope(t, { network, layer }) : getNetworkNames(t)[network],
@@ -28,12 +26,7 @@ export const NoResults: FC<{
     <EmptyState
       title={title}
       description={
-        <Box
-          sx={{
-            textAlign: 'center',
-            a: { color: theme.palette.layout.contrastMain, textDecoration: 'underline' },
-          }}
-        >
+        <Box sx={{ a: { color: 'inherit', textDecoration: 'underline' } }}>
           <p>
             <Box>
               <Trans


### PR DESCRIPTION
Background: earlier, we had a 404 dialog with a bg that was mostly transparent, so it was shown in changing dark and light colors, depending on the current theme.

However, during a recent re-design, this concept has been dropped; the bg is no longer transparent, it's always blue.

Therefore, the text color now always must be white. However, this bit was missed during implementation, because it looked OK on mainnet.

This PR fixes that: sets the text color to white, independently of the current there.

Fixes #2093

| |Before | After |
| --- |---|---|
| Mainnet | <img width="824" height="841" alt="image" src="https://github.com/user-attachments/assets/06c48961-6938-41d5-9e73-8490387359b4" />  |  <img width="820" height="841" alt="image" src="https://github.com/user-attachments/assets/038a8231-5404-428d-871b-595e9ebd0e03" /> |
| Testnet | <img width="823" height="843" alt="image" src="https://github.com/user-attachments/assets/66ef221d-7e6a-4864-8438-5805d526e074" />  | <img width="824" height="846" alt="image" src="https://github.com/user-attachments/assets/56aa57f2-eae4-4653-87c8-a9079e1d427a" />  |