### PR TITLE
Fix regression in displaying Endorsements

### DIFF
--- a/.changelog/2097.bugfix.md
+++ b/.changelog/2097.bugfix.md
@@ -1,0 +1,1 @@
+Fix regression in displaying Endorsements

--- a/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
@@ -113,7 +113,13 @@ export const Endorsement: FC<EndorsementProps> = ({ endorsements, groupOp }) => 
               t={t}
               i18nKey="rofl.endorsementLabels.node"
               components={{
-                Address: <AccountLink scope={scope} address={value} alwaysAdapt />,
+                Address: (
+                  <AccountLink
+                    scope={scope}
+                    address={getOasisAddressFromBase64PublicKey(value)}
+                    alwaysAdapt
+                  />
+                ),
               }}
             />
           </StyledBox>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -732,7 +732,7 @@
     "endorsementLabels": {
       "any": "Any node can endorse the enclave",
       "entity": "Node from entity <Address />",
-      "node": "Node <address />",
+      "node": "Node <Address />",
       "role_compute": "Node has the <i>compute</i> role for the current runtime",
       "role_observer": "Node has the <i>observer</i> role for the current runtime",
       "provider": "Node from provider <Address />",


### PR DESCRIPTION
The "node" policy was not tested, and therefore broken. 

This PR fixes that.

Fixes #2095

|Before|After|
|---|---|
| <img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/f332b534-4a55-42bd-a9ea-474607e1545f" />  | <img width="591" height="385" alt="image" src="https://github.com/user-attachments/assets/748d1579-abb9-47ae-8fe3-375a81ca549d" /> |