### PR TITLE
Place validator voting power percentage on the same line

### DIFF
--- a/.changelog/2105.trivial.md
+++ b/.changelog/2105.trivial.md
@@ -1,0 +1,1 @@
+Place validator voting power percentage on the same line

--- a/src/app/pages/ValidatorDetailsPage/index.tsx
+++ b/src/app/pages/ValidatorDetailsPage/index.tsx
@@ -255,14 +255,15 @@ export const ValidatorDetailsView: FC<{
           {typeof validator.voting_power === 'number' && (
             <>
               <dt>{t('validator.votingPower')}</dt>
-              <dd>{validator.voting_power.toLocaleString()}</dd>
-            </>
-          )}
-          {typeof validator.voting_power === 'number' && stats?.total_voting_power && (
-            <>
-              <dt>{t('validator.totalShare')}</dt>
               <dd>
-                <PercentageValue value={validator.voting_power} total={stats.total_voting_power} />
+                {stats?.total_voting_power ? (
+                  <>
+                    <PercentageValue value={validator.voting_power} total={stats.total_voting_power} />
+                    &nbsp; ({validator.voting_power.toLocaleString()})
+                  </>
+                ) : (
+                  validator.voting_power.toLocaleString()
+                )}
               </dd>
             </>
           )}


### PR DESCRIPTION
In validator details, we are showing the voting power (as a number) in one row, and the percentage in the next.
Sometimes this is not easy to find.

We can put them in one row.

| Before | After |
| --- | --- |
|  <img width="710" height="762" alt="image" src="https://github.com/user-attachments/assets/744c6238-cb34-43bb-9389-0d81dd5a570e" />  |  <img width="722" height="727" alt="image" src="https://github.com/user-attachments/assets/806ed469-15fd-4afb-a874-885c71fe49f9" />  |

Thanks for the top to @amela 

Also, @juresobocan has approved the new design.