### PR TITLE
Make sure there is always enough space for the highlighting border

### DIFF
--- a/.changelog/2108.trivial.md
+++ b/.changelog/2108.trivial.md
@@ -1,0 +1,1 @@
+Make sure there is always enough space for the highlighting border

--- a/src/app/components/HighlightingContext/WithHighlighting.tsx
+++ b/src/app/components/HighlightingContext/WithHighlighting.tsx
@@ -24,8 +24,15 @@ export const WithHighlighting: FC<{ children: ReactNode; address: string }> = ({
         display: 'inline-flex',
         alignItems: 'center',
         verticalAlign: 'middle',
-        padding: '2px 4px',
-        margin: '-5px -5px -3px -5px',
+        // We want to have a bit of space inside the highlight bubble.
+        // No need for vertical padding, there is already enough space
+        padding: '0 4px',
+        // We don't want the children to move when we add highlighting around them,
+        // so we are compensating the padding+border with negative margins.
+        // Q: Why do we asymmetrical top and bottom?
+        // Q: Nobody really knows, but this way text is aligned properly,
+        // when placed on a line with other (non-highlighted) text in a flex div.
+        margin: '-3px -5px -1px -5px',
         ...(isHighlighted
           ? {
               background: COLORS.warningLight,

--- a/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
@@ -21,6 +21,8 @@ const StyledBox: FC<PropsWithChildren> = ({ children }) => {
         flex: 1,
         overflowX: 'hidden',
         overflowY: 'hidden',
+        // Fix WithHighlighting clipping
+        padding: '3px 0 1px 5px',
       }}
     >
       {children}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -257,7 +257,13 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('transaction.eventsSummary')}</dt>
               <dd>
-                <Box sx={{ overflowX: 'auto', paddingTop: '1px' }}>
+                <Box
+                  sx={{
+                    overflowX: 'auto',
+                    // Fix WithHighlighting clipping
+                    paddingTop: '1px',
+                  }}
+                >
                   {transfers.map((transfer, i) => {
                     const params = transfer.evm_log_params
                     if (!params) return null

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -72,7 +72,15 @@ export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner }) => {
   const { t } = useTranslation()
 
   return (
-    <Typography sx={{ display: 'flex', whiteSpace: 'initial' }}>
+    <Typography
+      sx={{
+        display: 'flex',
+        whiteSpace: 'initial',
+        // Fix WithHighlighting clipping
+        pt: '4px',
+        pb: '1px',
+      }}
+    >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>{t('nft.owner')}:</Box>
       &nbsp;
       <AccountLink scope={scope} address={owner} alwaysTrim />


### PR DESCRIPTION
Add padding around:
 - endorsements,
 -  NFT owner link

| | Before | After |
| --- | --- | --- | 
| Endorsements | <img width="1234" height="187" alt="image" src="https://github.com/user-attachments/assets/0f71b48d-d41a-443e-99c8-97e7b6708fc6" />  |<img width="1228" height="222" alt="image" src="https://github.com/user-attachments/assets/ed9290b4-b9ce-4058-8899-7ad7d01ebc28" />|  
| NFT instance owner link |  <img width="337" height="164" alt="image" src="https://github.com/user-attachments/assets/a39aaf05-9f55-47f4-8e41-d7d4e3f20559" /> | <img width="368" height="196" alt="image" src="https://github.com/user-attachments/assets/92fe945d-4fd9-4f2d-9f84-65c9ba455593" />  | 

Improves #2096
