### PR TITLE
Remove usage of MUI Paper component

### DIFF
--- a/.changelog/2109.internal.md
+++ b/.changelog/2109.internal.md
@@ -1,0 +1,1 @@
+Remove usage of MUI Paper component

--- a/src/app/components/LearningMaterialsCard/LearningSection.tsx
+++ b/src/app/components/LearningMaterialsCard/LearningSection.tsx
@@ -1,25 +1,32 @@
-import Paper, { type PaperProps } from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { FC } from 'react'
 import { COLORS } from 'styles/theme/colors'
 import { AnchorCircle } from '../StyledLinks'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
-type LearningSectionProps = PaperProps & {
+type LearningSectionProps = {
+  className?: string
   description: string
   title: string
   url: string
 }
 
-export const LearningSection: FC<LearningSectionProps> = ({ description, title, url, ...props }) => {
+export const LearningSection: FC<LearningSectionProps> = ({ className, description, title, url }) => {
   return (
-    <Paper variant="content" {...props}>
-      <Typography variant="h4" sx={{ mb: 4 }}>
-        {title}
-      </Typography>
-      <Typography variant="body2" sx={{ color: COLORS.grayMedium }}>
-        {description}
-      </Typography>
-      <AnchorCircle url={url} />
-    </Paper>
+    <div
+      className={cn('flex flex-col px-6 py-5 gap-4 rounded-md border border-zinc-200 bg-zinc-50', className)}
+    >
+      <div className="flex-1 flex flex-col gap-1">
+        <Typography variant="h4" sx={{ mb: 4 }}>
+          {title}
+        </Typography>
+        <Typography variant="body2" sx={{ color: COLORS.grayMedium }}>
+          {description}
+        </Typography>
+      </div>
+      <div>
+        <AnchorCircle url={url} />
+      </div>
+    </div>
   )
 }

--- a/src/app/components/charts/Tooltip.tsx
+++ b/src/app/components/charts/Tooltip.tsx
@@ -1,19 +1,6 @@
 import { TooltipProps } from 'recharts'
-import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
-import { styled } from '@mui/material/styles'
-import { COLORS } from '../../../styles/theme/colors'
-
-export const StyledPaper = styled(Paper)(({ theme }) => ({
-  display: 'inline-flex',
-  flexDirection: 'column',
-  padding: theme.spacing(3, 5),
-  background: COLORS.spaceCadet,
-  boxShadow: '0 4px 4px rgba(0, 0, 0, 0.25)',
-  borderRadius: '8px',
-  color: COLORS.white,
-  textAlign: 'center',
-}))
+import { COLORS } from 'styles/theme/colors'
 
 export type Formatters = {
   formatters?: {
@@ -40,13 +27,16 @@ export const TooltipContent = ({
   const labelKey = dataLabelKey || Object.keys(rest)[0]
 
   return (
-    <StyledPaper>
+    <div
+      className="inline-flex flex-col px-5 py-3 shadow-lg rounded-lg text-white text-center"
+      style={{ backgroundColor: COLORS.spaceCadet }}
+    >
       <Typography paragraph={false} sx={{ fontSize: 12 }}>
         {formatters?.label ? formatters.label(payload[0].payload[labelKey]) : payload[0].payload[labelKey]}
       </Typography>
       <Typography paragraph={false} sx={{ fontSize: 12, fontWeight: 600 }}>
         {formatters?.data ? formatters.data(payload[0].value!, payload[0].payload.payload) : payload[0].value}
       </Typography>
-    </StyledPaper>
+    </div>
   )
 }

--- a/src/app/pages/ConsensusDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ConsensusDashboardPage/LearningMaterials.tsx
@@ -16,7 +16,7 @@ export const LearningMaterials: FC = () => {
             description={t('learningMaterials.consensus.description')}
             title={t('learningMaterials.consensus.header')}
             url={docs.consensus}
-            sx={{ height: '100%' }}
+            className="h-full"
           />
         </Grid>
         <Grid xs={12} md={3}>
@@ -40,7 +40,7 @@ export const LearningMaterials: FC = () => {
             description={t('learningMaterials.consensus.delegationDescription')}
             title={t('learningMaterials.consensus.delegation')}
             url={docs.delegation}
-            sx={{ height: '100%' }}
+            className="h-full"
           />
         </Grid>
         <Grid xs={12} md={3}>

--- a/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
+++ b/src/app/pages/ParatimeDashboardPage/LearningMaterials.tsx
@@ -192,7 +192,7 @@ export const LearningMaterials: FC<{ scope: RuntimeScope }> = ({ scope }) => {
             description={content.primary.description}
             title={content.primary.header}
             url={content.primary.url}
-            sx={{ height: '100%' }}
+            className="h-full"
           />
         </Grid>
         <Grid xs={12} md={6} spacing={3}>

--- a/src/app/pages/SearchResultsPage/ResultListFrame.tsx
+++ b/src/app/pages/SearchResultsPage/ResultListFrame.tsx
@@ -3,7 +3,6 @@ import { styled, useTheme } from '@mui/material/styles'
 import { cardClasses } from '@mui/material/Card'
 import { boxClasses } from '../../utils/mui-helpers'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { paperClasses } from '@mui/material/Paper'
 import { COLORS } from '../../../styles/theme/colors'
 
 export const ResultListFrame = styled(Box)(({ theme: wantedTheme }) => {
@@ -11,7 +10,7 @@ export const ResultListFrame = styled(Box)(({ theme: wantedTheme }) => {
   const isMobile = useMediaQuery(wantedTheme.breakpoints.down('sm'))
   return isMobile
     ? {
-        [`&& > div > .${paperClasses.root}`]:
+        [`&& > div > .${cardClasses.root}`]:
           currentTheme.palette.layout.border !== wantedTheme.palette.layout.networkBubbleBorder &&
           wantedTheme.palette.layout.main !== wantedTheme.palette.layout.networkBubbleBorder
             ? {

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -548,13 +548,6 @@ export const defaultTheme = createTheme({
         },
       },
     },
-    MuiPaper: {
-      styleOverrides: {
-        root: () => ({
-          borderRadius: 6,
-        }),
-      },
-    },
     MuiLinearProgress: {
       styleOverrides: {
         root: {

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -54,12 +54,6 @@ declare module '@mui/material/Typography' {
   }
 }
 
-declare module '@mui/material/Paper' {
-  interface PaperPropsVariantOverrides {
-    content: true
-  }
-}
-
 declare module '@mui/material/Chip' {
   export interface ChipPropsColorOverrides {
     tertiary: true
@@ -555,17 +549,6 @@ export const defaultTheme = createTheme({
       },
     },
     MuiPaper: {
-      variants: [
-        {
-          props: { variant: 'content' },
-          style: ({ theme }) => ({
-            backgroundColor: COLORS.brightGray,
-            boxShadow: 'none',
-            color: COLORS.darkBlueGray,
-            padding: theme.spacing(4),
-          }),
-        },
-      ],
       styleOverrides: {
         root: () => ({
           borderRadius: 6,


### PR DESCRIPTION
Used in:

- Learning Materials section
- charts tooltip 
- search results not affected (targets diff class of the same element)

Learning Material follow new layout, but to fully adjust this section we need to update MUI Typography (next PR)

https://explorer.dev.oasis.io/mainnet/consensus
vs
https://pr-2109.oasis-explorer.pages.dev/mainnet/consensus

