### PR TITLE
Replace MUI Modal with Oasis UI Library component

### DIFF
--- a/.changelog/2111.internal.md
+++ b/.changelog/2111.internal.md
@@ -1,0 +1,1 @@
+Replace MUI Modal with Oasis UI Library component

--- a/src/app/components/ImagePreview/index.tsx
+++ b/src/app/components/ImagePreview/index.tsx
@@ -1,15 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
-import Backdrop from '@mui/material/Backdrop'
-import Modal from '@mui/material/Modal'
-import Fade from '@mui/material/Fade'
-import Typography from '@mui/material/Typography'
-import CancelIcon from '@mui/icons-material/Cancel'
-import IconButton from '@mui/material/IconButton'
 import { Button } from '@mui/base/Button'
 import { styled } from '@mui/material/styles'
-import { COLORS } from '../../../styles/theme/colors'
+import { ImagePreviewDialog } from '@oasisprotocol/ui-library/src/components/dialog'
 
 const StyledThumbnail = styled('img', {
   shouldForwardProp: prop => prop !== 'maxThumbnailSize',
@@ -22,11 +16,6 @@ const StyledButton = styled(Button)({
   cursor: 'pointer',
   border: 'none',
   background: 'none',
-})
-
-const StyledImage = styled('img')({
-  maxWidth: '80dvw',
-  maxHeight: ' 80dvh',
 })
 
 type ImagePreviewProps = {
@@ -58,46 +47,7 @@ export const ImagePreview: FC<ImagePreviewProps> = ({
           <StyledThumbnail onError={onError} src={src} alt={label} maxThumbnailSize={maxThumbnailSize} />
         </StyledButton>
       </Box>
-      <Modal
-        aria-labelledby={label}
-        open={previewOpen}
-        onClose={handlePreviewClose}
-        closeAfterTransition
-        slots={{ backdrop: Backdrop }}
-        slotProps={{
-          backdrop: {
-            timeout: 500,
-          },
-        }}
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Fade in={previewOpen}>
-          <Box sx={{ position: 'absolute' }}>
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: title ? 'space-between' : 'flex-end',
-                alignItems: 'center',
-                mb: 3,
-              }}
-            >
-              {title && (
-                <Typography fontSize="24px" fontWeight={700} color={COLORS.white}>
-                  {title}
-                </Typography>
-              )}
-              <IconButton aria-label="Close" onClick={handlePreviewClose}>
-                <CancelIcon sx={{ fontSize: '40px', color: COLORS.white }} />
-              </IconButton>
-            </Box>
-            <StyledImage src={src} alt={label} />
-          </Box>
-        </Fade>
-      </Modal>
+      <ImagePreviewDialog open={previewOpen} onClose={handlePreviewClose} src={src} title={title} />
     </>
   )
 }


### PR DESCRIPTION
Relies on https://github.com/oasisprotocol/explorer/pull/1993
Needs https://github.com/oasisprotocol/ui-library/pull/47

https://explorer.oasis.io/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2
vs
https://pr-2111.oasis-explorer.pages.dev/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2
