### PR TITLE
Replace MUI Drawer with Oasis UI Library component

### DIFF
--- a/.changelog/2113.internal.md
+++ b/.changelog/2113.internal.md
@@ -1,0 +1,1 @@
+Replace MUI Drawer with Oasis UI Library component

--- a/src/app/components/LayerPicker/index.tsx
+++ b/src/app/components/LayerPicker/index.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Drawer from '@mui/material/Drawer'
+import { Drawer, DrawerContent } from '@oasisprotocol/ui-library/src/components/ui/drawer'
 import { Separator } from '@oasisprotocol/ui-library/src/components/ui/separator'
 import Grid from '@mui/material/Unstable_Grid2'
 import { HomePageLink } from '../PageLayout/Logotype'
@@ -27,9 +27,14 @@ type LayerPickerProps = {
 }
 
 export const LayerPicker: FC<LayerPickerProps> = ({ onClose, onConfirm, open, isOutOfDate }) => (
-  <Drawer anchor="top" open={open} onClose={onClose}>
-    <LayerPickerContent onClose={onClose} onConfirm={onConfirm} isOutOfDate={isOutOfDate} />
-  </Drawer>
+  <>
+    <Drawer direction="top" open={open} onClose={onClose}>
+      {/* Match MUI md breakpoint during migration */}
+      <DrawerContent className="py-4 px-[5%] z-[1200] max-[900px]:h-dvh max-[900px]:!max-h-dvh max-[900px]:mb-0">
+        <LayerPickerContent onClose={onClose} onConfirm={onConfirm} isOutOfDate={isOutOfDate} />
+      </DrawerContent>
+    </Drawer>
+  </>
 )
 
 const StyledLayerPickerContent = styled(Box)(({ theme }) => ({

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -491,19 +491,6 @@ export const defaultTheme = createTheme({
         },
       },
     },
-    MuiDrawer: {
-      styleOverrides: {
-        paperAnchorTop: ({ theme }) => ({
-          borderRadius: '0 0 6px 6px',
-          padding: theme.spacing(4, '5%'),
-        }),
-        paper: ({ theme }) => ({
-          [theme.breakpoints.down('md')]: {
-            height: '100vh',
-          },
-        }),
-      },
-    },
     MuiImageList: {
       styleOverrides: {
         root: ({ theme }) => ({


### PR DESCRIPTION
Used in:

- Layer picker dropdown (desktop and mobile)

https://explorer.dev.oasis.io/mainnet/consensus
vs
https://pr-2113.oasis-explorer.pages.dev/mainnet/consensus

