### PR TITLE
Replace MUI Fade with tailwind classes

### DIFF
--- a/.changelog/2125.internal.md
+++ b/.changelog/2125.internal.md
@@ -1,0 +1,1 @@
+Replace MUI Fade with tailwind classes

--- a/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
+++ b/src/app/pages/HomePage/Graph/GraphTooltipMobile/index.tsx
@@ -14,7 +14,6 @@ import { useConsensusFreshness, useRuntimeFreshness } from '../../../../componen
 import { getNetworkIcons } from '../../../../utils/content'
 import { useNavigate } from 'react-router-dom'
 import { RouteUtils } from '../../../../utils/route-utils'
-import Fade from '@mui/material/Fade'
 import { Button } from '@oasisprotocol/ui-library/src/components/ui/button'
 import CloseIcon from '@mui/icons-material/Close'
 import { zIndexHomePage } from '../../index'
@@ -98,20 +97,6 @@ const MobileBackdrop = styled(Box)(() => ({
   backgroundColor: COLORS.black,
   opacity: 0.3,
   zIndex: zIndexHomePage.mobileTooltip,
-}))
-
-const MobileGraphTooltip = styled(Box)(({ theme }) => ({
-  position: 'fixed',
-  bottom: 0,
-  left: 0,
-  right: 0,
-  height: 120,
-  zIndex: zIndexHomePage.mobileTooltip,
-  '> button': {
-    position: 'fixed',
-    right: theme.spacing(2),
-    bottom: 125,
-  },
 }))
 
 interface GraphTooltipMobileProps {
@@ -285,17 +270,23 @@ export const GraphTooltipMobile: FC<GraphTooltipMobileProps> = ({ network, area,
   return (
     <>
       <MobileBackdrop onClick={onClose} />
-      <Fade in>
-        <MobileGraphTooltip>
-          <Button variant="ghost" size="icon" onClick={onClose} className="hover:bg-black/[0.04]">
-            <CloseIcon fontSize="medium" sx={{ color: COLORS.white }} aria-label={t('home.tooltip.close')} />
-          </Button>
-          <GraphTooltipStyled disabled={disabled} isMobile={isMobile} onClick={navigateTo}>
-            <GraphTooltipHeader disabled={disabled} network={network} area={area} />
-            <GraphTooltipBody {...body} disabled={disabled} failing={failing} />
-          </GraphTooltipStyled>
-        </MobileGraphTooltip>
-      </Fade>
+      <div
+        className="fixed bottom-0 left-0 right-0 h-[120px] animate-in fade-in duration-300"
+        style={{ zIndex: zIndexHomePage.mobileTooltip }}
+      >
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="hover:bg-black/[0.04] fixed right-1 bottom-[125px]"
+        >
+          <CloseIcon fontSize="medium" sx={{ color: COLORS.white }} aria-label={t('home.tooltip.close')} />
+        </Button>
+        <GraphTooltipStyled disabled={disabled} isMobile={isMobile} onClick={navigateTo}>
+          <GraphTooltipHeader disabled={disabled} network={network} area={area} />
+          <GraphTooltipBody {...body} disabled={disabled} failing={failing} />
+        </GraphTooltipStyled>
+      </div>
     </>
   )
 }

--- a/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
+++ b/src/app/pages/HomePage/Graph/ParaTimeSelector/index.tsx
@@ -10,7 +10,6 @@ import Button from '@mui/material/Button'
 import { useTranslation } from 'react-i18next'
 import { ParaTimeSelectorStep } from '../types'
 import { ParaTimeSelectorUtils } from '../para-time-selector-utils'
-import Fade from '@mui/material/Fade'
 import { useScreenSize } from '../../../../hooks/useScreensize'
 import QuickPinchZoom, { make3dTransformValue, UpdateAction } from 'react-quick-pinch-zoom'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
@@ -24,6 +23,7 @@ import { storage } from '../../../../utils/storage'
 import { StorageKeys } from '../../../../../types/storage'
 import { GraphTooltipMobile } from '../GraphTooltipMobile'
 import { fixedNetwork } from '../../../../utils/route-utils'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 interface ParaTimeSelectorBaseProps {
   disabled: boolean
@@ -110,10 +110,6 @@ export const ZoomOutBtn = styled(Button)(({ theme }) => ({
   '&&': {
     backgroundColor: 'transparent',
   },
-}))
-
-const ZoomOutBtnFade = styled(Fade)(() => ({
-  transitionDelay: '500ms !important',
 }))
 
 // border affecting scale (quick-pinch-zoom)
@@ -261,7 +257,12 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
             </QuickPinchZoom>
           </QuickPinchZoomOuter>
           {!isMobile && (
-            <ZoomOutBtnFade in={graphZoomedIn}>
+            <div
+              className={cn('transition-opacity duration-300 delay-300', {
+                'opacity-100': graphZoomedIn,
+                'opacity-0 pointer-events-none': !graphZoomedIn,
+              })}
+            >
               <ZoomOutBtn
                 color="primary"
                 variant="text"
@@ -271,7 +272,7 @@ const ParaTimeSelectorCmp: FC<ParaTimeSelectorProps> = ({
               >
                 {t('home.zoomOutBtnText')}
               </ZoomOutBtn>
-            </ZoomOutBtnFade>
+            </div>
           )}
           {isMobile && ParaTimeSelectorUtils.showExploreBtn(step) && (
             <ExploreBtn


### PR DESCRIPTION
Used in:

- mobile homepage (layer details popup, zoom out button - only visible on desktop when zoom in was set in mobile?)
https://pr-2125.oasis-explorer.pages.dev/
vs
https://explorer.dev.oasis.io/