### PR TITLE
Fix headers colors after changing Explorer background

### DIFF
--- a/.changelog/2126.bugfix.md
+++ b/.changelog/2126.bugfix.md
@@ -1,0 +1,1 @@
+Fix headers colors after changing Explorer background

--- a/src/app/components/CardHeaderWithCounter/index.tsx
+++ b/src/app/components/CardHeaderWithCounter/index.tsx
@@ -2,40 +2,33 @@ import { FC } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { COLORS } from 'styles/theme/colors'
-import { useScreenSize } from '../../hooks/useScreensize'
+import { useTheme } from '@mui/material/styles'
 
 type CardHeaderWithCounterProps = {
   label: string | undefined
   totalCount: number | undefined
   isTotalCountClipped: boolean | undefined
-  changeMobileColors?: boolean
 }
 
 export const CardHeaderWithCounter: FC<CardHeaderWithCounterProps> = ({
   label,
   totalCount,
   isTotalCountClipped,
-  changeMobileColors,
 }) => {
-  const { isMobile } = useScreenSize()
+  const theme = useTheme()
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'baseline' }} gap={'0.8ex'}>
       <Typography
         fontWeight={700}
         component="span"
-        color={isMobile && changeMobileColors ? COLORS.white : COLORS.brandExtraDark}
+        color={theme.palette.layout.titleOnBackground}
         fontSize="inherit"
       >
         {label}
       </Typography>
       {!!totalCount && (
-        <Typography
-          fontWeight="normal"
-          component="span"
-          color={isMobile && changeMobileColors ? COLORS.white : COLORS.grayMedium}
-          fontSize="inherit"
-        >
+        <Typography fontWeight="normal" component="span" color={COLORS.grayMedium} fontSize="inherit">
           ({`${isTotalCountClipped ? '>' : ''}${totalCount}`})
         </Typography>
       )}

--- a/src/app/pages/ConsensusAccountsPage/index.tsx
+++ b/src/app/pages/ConsensusAccountsPage/index.tsx
@@ -51,7 +51,6 @@ export const ConsensusAccountsPage: FC = () => {
       <SubPageCard
         title={
           <CardHeaderWithCounter
-            changeMobileColors
             label={t('account.listTitle')}
             totalCount={accountsData?.total_count}
             isTotalCountClipped={accountsData?.is_total_count_clipped}

--- a/src/app/pages/ProposalsPage/index.tsx
+++ b/src/app/pages/ProposalsPage/index.tsx
@@ -51,7 +51,6 @@ export const ProposalsPage: FC = () => {
       <SubPageCard
         title={
           <CardHeaderWithCounter
-            changeMobileColors
             label={t('networkProposal.listTitle')}
             totalCount={proposalsData?.total_count}
             isTotalCountClipped={proposalsData?.is_total_count_clipped}

--- a/src/app/pages/ValidatorsPage/index.tsx
+++ b/src/app/pages/ValidatorsPage/index.tsx
@@ -52,7 +52,6 @@ export const ValidatorsPage: FC = () => {
       <SubPageCard
         title={
           <CardHeaderWithCounter
-            changeMobileColors
             label={t('validator.listTitle')}
             totalCount={validatorsData?.total_count}
             isTotalCountClipped={validatorsData?.is_total_count_clipped}


### PR DESCRIPTION
Some custom headers are not visible on mobile

master
<img alt="Screenshot from 2025-08-13 16-45-57" src="https://github.com/user-attachments/assets/f643ef5c-12c6-4fe6-9fa6-af72fd4e971a" />
vs
<img width="412" height="345" alt="Screenshot from 2025-08-13 16-47-53" src="https://github.com/user-attachments/assets/0a11f6b4-0450-43be-abfa-788a6f93dd08" />
