### PR TITLE
Replace MUI LinearProgress with Oasis UI Library component

### DIFF
--- a/.changelog/2131.internal.md
+++ b/.changelog/2131.internal.md
@@ -1,0 +1,1 @@
+Replace MUI LinearProgress with Oasis UI Library component

--- a/src/app/components/Blocks/ConsensusBlocks.tsx
+++ b/src/app/components/Blocks/ConsensusBlocks.tsx
@@ -44,13 +44,13 @@ export const ConsensusBlocks: FC<ConsensusBlocksProps> = ({
     { key: 'height', content: t('common.height'), align: TableCellAlign.Left },
     ...(showHash ? [{ key: 'hash', content: t('common.hash') }] : []),
     ...(showEpoch ? [{ key: 'epoch', content: t('common.epoch') }] : []),
+    { key: 'age', content: <TableHeaderAge />, align: TableCellAlign.Right },
     {
       key: 'transaction',
       content: isLaptop ? t('common.transactionAbbreviation') : t('common.transactions'),
       align: TableCellAlign.Right,
     },
     ...(showProposer ? [{ key: 'proposer', content: t('common.proposer') }] : []),
-    { key: 'age', content: <TableHeaderAge />, align: TableCellAlign.Right },
   ]
 
   const tableRows = blocks?.map(block => {
@@ -80,6 +80,11 @@ export const ConsensusBlocks: FC<ConsensusBlocksProps> = ({
           : []),
         {
           align: TableCellAlign.Right,
+          content: <TableCellAge sinceTimestamp={block.timestamp} />,
+          key: 'timestamp',
+        },
+        {
+          align: TableCellAlign.Right,
           content: block.num_transactions.toLocaleString(),
           key: 'txs',
         },
@@ -104,11 +109,6 @@ export const ConsensusBlocks: FC<ConsensusBlocksProps> = ({
               },
             ]
           : []),
-        {
-          align: TableCellAlign.Right,
-          content: <TableCellAge sinceTimestamp={block.timestamp} />,
-          key: 'timestamp',
-        },
       ],
       highlight: block.markAsNew,
     }

--- a/src/app/components/Blocks/RuntimeBlocks.tsx
+++ b/src/app/components/Blocks/RuntimeBlocks.tsx
@@ -39,7 +39,7 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
   const { t } = useTranslation()
   const { isLaptop } = useScreenSize()
   const tableColumns: TableColProps[] = [
-    { key: 'fill', content: t('common.fill') },
+    ...(type === BlocksTableType.Desktop ? [{ key: 'fill', content: t('common.fill') }] : []),
     { key: 'height', content: t('common.height'), align: TableCellAlign.Right },
     { key: 'age', content: <TableHeaderAge />, align: TableCellAlign.Right },
     ...(type === BlocksTableType.Desktop || type === BlocksTableType.DesktopLite
@@ -67,10 +67,14 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
     return {
       key: block.hash,
       data: [
-        {
-          content: <VerticalProgressBar value={(100 * block.gas_used) / blockGasLimit} />,
-          key: 'fill',
-        },
+        ...(type === BlocksTableType.Desktop
+          ? [
+              {
+                content: <VerticalProgressBar value={(100 * block.gas_used) / blockGasLimit} />,
+                key: 'fill',
+              },
+            ]
+          : []),
         {
           align: TableCellAlign.Right,
           content: <BlockLink scope={block} height={block.round} />,

--- a/src/app/components/Blocks/RuntimeBlocks.tsx
+++ b/src/app/components/Blocks/RuntimeBlocks.tsx
@@ -40,7 +40,15 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
   const { isLaptop } = useScreenSize()
   const tableColumns: TableColProps[] = [
     ...(type === BlocksTableType.Desktop ? [{ key: 'fill', content: t('common.fill') }] : []),
-    { key: 'height', content: t('common.height'), align: TableCellAlign.Right },
+    { key: 'height', content: t('common.height') },
+    ...(type === BlocksTableType.Desktop || type === BlocksTableType.DesktopLite
+      ? [
+          {
+            key: 'hash',
+            content: t('common.hash'),
+          },
+        ]
+      : []),
     { key: 'age', content: <TableHeaderAge />, align: TableCellAlign.Right },
     ...(type === BlocksTableType.Desktop || type === BlocksTableType.DesktopLite
       ? [
@@ -76,10 +84,17 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
             ]
           : []),
         {
-          align: TableCellAlign.Right,
           content: <BlockLink scope={block} height={block.round} />,
           key: 'block',
         },
+        ...(type === BlocksTableType.Desktop || type === BlocksTableType.DesktopLite
+          ? [
+              {
+                content: <BlockHashLink scope={block} hash={block.hash} height={block.round} alwaysTrim />,
+                key: 'hash',
+              },
+            ]
+          : []),
         {
           align: TableCellAlign.Right,
           content: <TableCellAge sinceTimestamp={block.timestamp} />,
@@ -91,14 +106,6 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
                 align: TableCellAlign.Right,
                 content: block.num_transactions.toLocaleString(),
                 key: 'txs',
-              },
-            ]
-          : []),
-        ...(type === BlocksTableType.Desktop
-          ? [
-              {
-                content: <BlockHashLink scope={block} hash={block.hash} height={block.round} alwaysTrim />,
-                key: 'hash',
               },
             ]
           : []),

--- a/src/app/components/ProgressBar/index.tsx
+++ b/src/app/components/ProgressBar/index.tsx
@@ -43,16 +43,6 @@ const StyledLinearProgress = styled(LinearProgress, {
   ...(barBackgroundColor && { backgroundColor: barBackgroundColor }),
 }))
 
-export const ProgressBar = styled(LinearProgress)(() => ({
-  [`&.${linearProgressClasses.determinate} > .${linearProgressClasses.bar1Determinate}`]: {
-    backgroundColor: COLORS.eucalyptus,
-  },
-  borderColor: COLORS.eucalyptus,
-  backgroundColor: COLORS.honeydew,
-  height: '12px',
-  width: '85px',
-}))
-
 export const BrandProgressBar = styled(LinearProgress)(() => ({
   [`&.${linearProgressClasses.determinate} > .${linearProgressClasses.bar1Determinate}`]: {
     backgroundColor: COLORS.brandDark,

--- a/src/app/components/Tokens/TokenHolders.tsx
+++ b/src/app/components/Tokens/TokenHolders.tsx
@@ -1,12 +1,11 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
 import { Table, TableCellAlign, TableColProps } from '../Table'
 import { BareTokenHolder } from '../../../oasis-nexus/api'
 import { TablePaginationProps } from '../Table/TablePagination'
 import { AccountLink } from '../Account/AccountLink'
 import { RoundedBalance } from '../RoundedBalance'
-import { ProgressBar } from '../ProgressBar'
+import { Progress } from '@oasisprotocol/ui-library/src/components/progress'
 import { fromBaseUnits } from '../../utils/number-utils'
 
 type TableTokenHolder = BareTokenHolder & {
@@ -70,15 +69,15 @@ export const TokenHolders: FC<TokenHoldersProps> = ({
           content: (
             <>
               {totalSupply ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }} gap={4}>
+                <div className="flex items-center justify-end gap-4">
                   {`${calculateRatio(holder.balance, totalSupply, decimals).toFixed(4)}%`}
-                  <ProgressBar
+                  <Progress
                     value={calculateRatio(holder.balance, totalSupply, decimals)}
-                    variant="determinate"
+                    className="w-[85px]"
                   />
-                </Box>
+                </div>
               ) : (
-                <Box>{t('common.missing')}</Box>
+                <div>{t('common.missing')}</div>
               )}
             </>
           ),


### PR DESCRIPTION
Used in:

-  Token holders 
https://pr-2131.oasis-explorer.pages.dev/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520/holders#holders 
vs 
https://explorer.dev.oasis.io/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520/holders#holders

- Dashboard Latest Blocks (Fill column removed, order of columns Height/Hash/Age/Transactions)
https://pr-2131.oasis-explorer.pages.dev/mainnet/sapphire
vs
https://explorer.dev.oasis.io/mainnet/sapphire/


Notes:
- MUI Progress is still being used in two places, but it has to be replaced by Charts component (not ready in Oasis UI Lib yet) 
- VerticalProgressBar is still used in runtime blocks list page. For now it is not sure if we are removing it or replacing with custom component