### PR TITLE
Avoid query param conflict with useTokenTransfers

### DIFF
--- a/.changelog/2148.bugfix.md
+++ b/.changelog/2148.bugfix.md
@@ -1,0 +1,1 @@
+Avoid query param conflict with useTokenTransfers

--- a/src/app/components/Transactions/RuntimeTransactionEvents.tsx
+++ b/src/app/components/Transactions/RuntimeTransactionEvents.tsx
@@ -10,7 +10,7 @@ export const RuntimeTransactionEvents: FC<{
   eventType: RuntimeEventFilteringType
 }> = ({ transaction, eventType }) => {
   const { network, layer } = transaction
-  const pagination = useSearchParamsPagination('page')
+  const pagination = useSearchParamsPagination('event-page')
   const offset = (pagination.selectedPage - 1) * limit
   const eventsQuery = useGetRuntimeEvents(network, layer, {
     tx_hash: transaction.hash,


### PR DESCRIPTION
PR opened In a case we will want this route of fix

Use pagination at the bottom

https://pr-2148.oasis-explorer.pages.dev/mainnet/sapphire/tx/0x3e0ff0ca7e52205392b81643896dd0bf3b494149f0b14ce94cd20382133976bd
vs
https://explorer.oasis.io/mainnet/sapphire/tx/0x3e0ff0ca7e52205392b81643896dd0bf3b494149f0b14ce94cd20382133976bd

10 ERC-20 transfers test:
https://pr-2148.oasis-explorer.pages.dev/mainnet/sapphire/tx/0x9ce91f01d822bb4144de04ad4fce4711eb005c7d2824bfe38f670bf2916727ca