### PR TITLE
Avoid query param conflict in tx details view

### DIFF
--- a/.changelog/2150.bugfix.md
+++ b/.changelog/2150.bugfix.md
@@ -1,0 +1,1 @@
+Avoid query param conflict in tx details view

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -146,6 +146,7 @@ export const RuntimeTransactionDetailView: FC<{
           offset: 0,
         }
       : undefined,
+    'workaroundQueryParamOverwrittenByOffset',
   )
   const transfers = transferEventsQuery?.results?.data
   const totalTransfers = transferEventsQuery?.results?.tablePaginationProps?.totalCount

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -51,6 +51,7 @@ export const useNFTInstanceTransfers = (
 export const useTokenTransfers = (
   scope: undefined | RuntimeScope,
   params: undefined | GetRuntimeEventsParams,
+  querySearchParamName?: string,
 ) => {
   if (params && Object.values(params).some(value => value === undefined || value === null)) {
     throw new Error('Must set params=undefined while some values are unavailable')
@@ -61,7 +62,7 @@ export const useTokenTransfers = (
   const mockScopeForDisabledQuery = { network: 'mainnet', layer: 'sapphire' } as const
 
   const pagination = useComprehensiveSearchParamsPagination<RuntimeEvent, RuntimeEventList>({
-    paramName: 'page',
+    paramName: querySearchParamName ?? 'page',
     pageSize: NUMBER_OF_ITEMS_ON_SEPARATE_PAGE,
   })
   const query = useGetRuntimeEvents(


### PR DESCRIPTION
View is broken when user uses pagination at the bottom

https://pr-2150.oasis-explorer.pages.dev/mainnet/sapphire/tx/0x3e0ff0ca7e52205392b81643896dd0bf3b494149f0b14ce94cd20382133976bd?page=2
vs
https://explorer.oasis.io/mainnet/sapphire/tx/0x3e0ff0ca7e52205392b81643896dd0bf3b494149f0b14ce94cd20382133976bd?page=2
