### PR TITLE
Swallow any errors when opportunistically looking up token names

### DIFF
--- a/.changelog/2163.internal.md
+++ b/.changelog/2163.internal.md
@@ -1,0 +1,1 @@
+Swallow any errors when opportunistically looking up token names

--- a/src/app/hooks/useAccountMetadata.ts
+++ b/src/app/hooks/useAccountMetadata.ts
@@ -36,6 +36,7 @@ export const useAccountMetadata = (scope: SearchScope, address: string): Account
     // The type cast is OK because whenever we are on consensus, we will set enabled to false
     enabled: !registryData?.metadata && scope.layer !== 'consensus',
     useCaching: true,
+    swallowError: true,
   })
   const tokenData: AccountMetadataInfo = {
     metadata: token ? { address: token.contract_addr, name: token.name, source: 'SelfProfessed' } : undefined,

--- a/src/app/pages/TokenDashboardPage/hook.ts
+++ b/src/app/pages/TokenDashboardPage/hook.ts
@@ -20,16 +20,18 @@ interface UseTokenInfoParams {
   /** Defaults to true */
   enabled?: boolean
   useCaching?: boolean
+  swallowError?: boolean
 }
 
 export const useTokenInfo = (scope: RuntimeScope, address: string, params: UseTokenInfoParams = {}) => {
   const { network, layer } = scope
-  const { enabled, useCaching } = params
+  const { enabled, useCaching, swallowError = false } = params
   const query = useGetRuntimeEvmTokensAddress(network, layer, address, {
     query: {
       enabled,
       staleTime: useCaching ? 3600000 : undefined,
     },
+    request: swallowError ? ({ swallowError } as any) : undefined,
   })
   const token = query.data?.data
   const { isLoading, isError, isFetched } = query

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,21 @@ import './locales/i18n'
 import { LocalSettingsContextProvider } from './app/providers/LocalSettingsProvider'
 import { AdaptiveTrimmerContextProvider } from './app/components/AdaptiveTrimmerContext/AdaptiveTrimmerProvider'
 
+const customLogger = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: (error: any) => {
+    // Suppress error messages when swallowError is set
+    if (typeof error === 'object' && error?.config.swallowError) return
+    // We don't need the warning about custom logger feature being deprecated.
+    // When we migrate to the next major version of react-query, we can simply drop this
+    if (typeof error === 'string' && error.startsWith('Passing a custom logger has been deprecated')) return
+    console.error(error) // Log any other errors
+  },
+}
+
 const queryClient = new QueryClient({
+  logger: customLogger, // This can be dropped when support is removed
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,


### PR DESCRIPTION
Any time we display an address, we want to check out if it has a token name. However, if no such token exists, we get a 404 error, and hence, a big ugly exception on the console, for each lookup attepmts. It looks like this:

<img width="1885" height="1221" alt="image" src="https://github.com/user-attachments/assets/7cf7a1ab-d9cd-458d-a61d-c524271bc178" />

This change makes it so that these errors are swallowed. (Not all token lookup errors, just the opportunistic ones, for finding out if they have a name.)

After this change, even in development mode, all we see on the console, after 5 look up attempts, is this:

<img width="1905" height="389" alt="image" src="https://github.com/user-attachments/assets/f863c1f6-566c-45b4-80d5-dc46829a6091" />
