### PR TITLE
Solve warning about missing dialog title

### DIFF
--- a/.changelog/2168.internal.md
+++ b/.changelog/2168.internal.md
@@ -1,0 +1,1 @@
+Solve warning about missing dialog title

--- a/src/app/components/LayerPicker/index.tsx
+++ b/src/app/components/LayerPicker/index.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import { Drawer, DrawerContent } from '@oasisprotocol/ui-library/src/components/ui/drawer'
+import { Drawer, DrawerContent, DrawerTitle } from '@oasisprotocol/ui-library/src'
 import { Separator } from '@oasisprotocol/ui-library/src/components/ui/separator'
 import Grid from '@mui/material/Unstable_Grid2'
 import { HomePageLink } from '../PageLayout/Logotype'
@@ -106,9 +106,11 @@ const LayerPickerContent: FC<LayerPickerContentProps> = ({ isOutOfDate, onClose,
 
   return (
     <StyledLayerPickerContent>
-      <Box sx={{ mb: isTablet ? 0 : 5, position: 'relative' }}>
-        <HomePageLink color="#0500e2" showText={!isMobile} />
-      </Box>
+      <DrawerTitle>
+        <Box sx={{ mb: isTablet ? 0 : 5, position: 'relative' }}>
+          <HomePageLink color="#0500e2" showText={!isMobile} />
+        </Box>
+      </DrawerTitle>
       {isTablet && (
         <TabletActionBar>
           <div>


### PR DESCRIPTION
In the layout picker, we are using a [Drawer](https://www.npmjs.com/package/vaul) component, which is using Radix's Dialog under the hood.

On the browser console, there was a message:

> `DialogContent` requires a `DialogTitle`
> for the component to be accessible for screen reader users.

etc.

This change fixes that, by wrapping the already existing app logo with the required `DrawerTitle` tag.