### PR TITLE
Simplify hover highlighting v1 (no border)

### DIFF
--- a/.changelog/2178.internal.md
+++ b/.changelog/2178.internal.md
@@ -1,0 +1,1 @@
+Simplify hover highlighting

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -26,11 +26,11 @@ const WithTypographyAndLink: FC<{
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
     <WithHoverHighlighting address={address}>
-      <Typography variant="mono" component="span">
+      <Typography variant="mono" component="span" className={'inline-flex'}>
         {labelOnly ? (
           children
         ) : (
-          <Link component={RouterLink} to={to}>
+          <Link component={RouterLink} to={to} className={'inline-flex'}>
             {children}
           </Link>
         )}

--- a/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
+++ b/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
@@ -22,28 +22,10 @@ export const WithHoverHighlighting: FC<{ children: ReactNode; address: string }>
     <Box
       onMouseEnter={() => selectAddress(address)}
       onMouseLeave={() => releaseAddress(address)}
+      component={'span'}
       sx={{
         display: 'inline-flex',
-        alignItems: 'center',
-        verticalAlign: 'middle',
-        // We want to have a bit of space inside the highlight bubble.
-        // No need for vertical padding, there is already enough space
-        padding: '0 4px',
-        // We don't want the children to move when we add highlighting around them,
-        // so we are compensating the padding+border with negative margins.
-        // Q: Why do we asymmetrical top and bottom?
-        // Q: Nobody really knows, but this way text is aligned properly,
-        // when placed on a line with other (non-highlighted) text in a flex div.
-        margin: '-3px -5px -1px -5px',
-        ...(isHighlighted
-          ? {
-              background: COLORS.warningLight,
-              border: `1px dashed ${COLORS.warningColor}`,
-              borderRadius: '6px',
-            }
-          : {
-              border: `1px dashed transparent`,
-            }),
+        ...(isHighlighted ? { background: COLORS.warningLight } : {}),
       }}
     >
       {children}

--- a/src/app/components/Tooltip/MaybeWithTooltip.tsx
+++ b/src/app/components/Tooltip/MaybeWithTooltip.tsx
@@ -49,14 +49,7 @@ export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({ title, children, s
       disableHoverListener={!title}
       disableTouchListener={!title}
     >
-      <Box
-        component="span"
-        sx={{
-          ...spanSx,
-          display: 'inline-flex',
-          verticalAlign: 'middle',
-        }}
-      >
+      <Box component="span" className={'inline-flex'} sx={spanSx}>
         {children}
       </Box>
     </Tooltip>

--- a/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
@@ -21,8 +21,6 @@ const StyledBox: FC<PropsWithChildren> = ({ children }) => {
         flex: 1,
         overflowX: 'hidden',
         overflowY: 'hidden',
-        // Fix WithHighlighting clipping
-        padding: '3px 0 1px 5px',
       }}
     >
       {children}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -258,13 +258,7 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('transaction.eventsSummary')}</dt>
               <dd>
-                <Box
-                  sx={{
-                    overflowX: 'auto',
-                    // Fix WithHighlighting clipping
-                    paddingTop: '1px',
-                  }}
-                >
+                <Box sx={{ overflowX: 'auto' }}>
                   {transfers.map((transfer, i) => {
                     const params = transfer.evm_log_params
                     if (!params) return null
@@ -285,12 +279,12 @@ export const RuntimeTransactionDetailView: FC<{
                         }}
                       >
                         <TokenTypeTag tokenType={transfer.evm_token?.type} />
-                        <Typography variant="body2">
+                        <Typography variant="body2" className={'inline-flex gap-1 items-center'}>
                           {t('common.from')}{' '}
                           {from ? <AccountLink scope={transaction} address={from} alwaysTrim /> : '?'}
                         </Typography>
 
-                        <Typography variant="body2">
+                        <Typography variant="body2" className={'inline-flex gap-1 items-center'}>
                           {t('common.to')}{' '}
                           {to ? <AccountLink scope={transaction} address={to} alwaysTrim /> : '?'}
                         </Typography>

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -76,9 +76,6 @@ export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner }) => {
       sx={{
         display: 'flex',
         whiteSpace: 'initial',
-        // Fix WithHighlighting clipping
-        pt: '4px',
-        pb: '1px',
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>{t('nft.owner')}:</Box>


### PR DESCRIPTION
Earlier we had some difficulty about padding/margin about addresses that we might want to highlight on hover, because we wanted a bubble around the highlighted part. Unfortunately this makes correct spacing next to impossible, so now we are giving it up.

From now, hover highlight will simply change the background, and nothing else.

This makes all workaround unnecessary.

Also, fix some more vertical alignment issues around links, so that everything lines up nicely.

|  | Before | After: v1 (this PR) | After: v2, (#2182) | After: v3 (#2183) |
| --- | --- | --- |--- | --- |
| TX detail summery with unnamed account at 120% zoom | <img width="730" height="64" alt="image" src="https://github.com/user-attachments/assets/f9680f1e-4b51-4b11-8a34-741f9356b756" />  | <img width="731" height="68" alt="image" src="https://github.com/user-attachments/assets/5e75cfb9-d72b-4d16-94e5-db9c5d3fe0f4" /> | <img width="735" height="56" alt="image" src="https://github.com/user-attachments/assets/260c1bb6-99ca-4aaa-9237-7b1c896431ea" /> | <img width="727" height="48" alt="image" src="https://github.com/user-attachments/assets/b824303f-207d-4b6b-a96e-71e96c268c3a" />  |
| TX detail summary with multiple named accounts |  <img width="655" height="196" alt="image" src="https://github.com/user-attachments/assets/e46796b6-9395-4bab-885a-06499764796d" />  | <img width="658" height="198" alt="image" src="https://github.com/user-attachments/assets/021f5d42-3578-433c-aa7c-b5944b18dd0c" />  | <img width="679" height="206" alt="image" src="https://github.com/user-attachments/assets/6780c35c-c236-407b-99b6-f9615da86b01" />  | <img width="664" height="205" alt="image" src="https://github.com/user-attachments/assets/a1165f8e-f056-4509-93a4-e3ff092f097f" />  |
| Endorsements | <img width="728" height="166" alt="image" src="https://github.com/user-attachments/assets/9e05915d-ea52-4878-9098-977621f5badb" />  | <img width="713" height="151" alt="image" src="https://github.com/user-attachments/assets/113eeec9-0159-4b78-a8fb-fa75d084c760" />  | <img width="713" height="153" alt="image" src="https://github.com/user-attachments/assets/fe586ccc-d9ed-4aa9-9cbe-7e9080724cd2" />  | <img width="862" height="185" alt="image" src="https://github.com/user-attachments/assets/2ce09b76-107a-4eae-884a-cd343087e972" />  |
| NFT owner link | <img width="234" height="287" alt="image" src="https://github.com/user-attachments/assets/e01cc854-045c-4839-997e-fef5e6f136a8" />  |  <img width="241" height="285" alt="image" src="https://github.com/user-attachments/assets/2f43aacc-bcc6-465c-849b-0ed96fc7f2c9" /> | <img width="243" height="278" alt="image" src="https://github.com/user-attachments/assets/3ecb6fec-efda-4fe1-81a7-42ec547c3bc6" />   | <img width="237" height="278" alt="image" src="https://github.com/user-attachments/assets/acb4b36d-5796-42ce-ad5d-76951e0ae422" />  |