### PR TITLE
Simplify hover highlight v3 (keep the border and -1px horizontal margin)

### DIFF
--- a/.changelog/2178.internal.md
+++ b/.changelog/2178.internal.md
@@ -1,0 +1,1 @@
+Simplify hover highlighting

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -26,11 +26,11 @@ const WithTypographyAndLink: FC<{
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
     <WithHoverHighlighting address={address}>
-      <Typography variant="mono" component="span">
+      <Typography variant="mono" component="span" className={'inline-flex'}>
         {labelOnly ? (
           children
         ) : (
-          <Link component={RouterLink} to={to}>
+          <Link component={RouterLink} to={to} className={'inline-flex'}>
             {children}
           </Link>
         )}

--- a/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
+++ b/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
@@ -25,6 +25,7 @@ export const WithHoverHighlighting: FC<{ children: ReactNode; address: string }>
       component={'span'}
       sx={{
         display: 'inline-flex',
+        margin: '0 -1px',
         ...(isHighlighted
           ? {
               background: COLORS.warningLight,

--- a/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
+++ b/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
@@ -25,7 +25,15 @@ export const WithHoverHighlighting: FC<{ children: ReactNode; address: string }>
       component={'span'}
       sx={{
         display: 'inline-flex',
-        ...(isHighlighted ? { background: COLORS.warningLight } : {}),
+        ...(isHighlighted
+          ? {
+              background: COLORS.warningLight,
+              border: `1px dashed ${COLORS.warningColor}`,
+              borderRadius: '6px',
+            }
+          : {
+              border: `1px dashed transparent`,
+            }),
       }}
     >
       {children}

--- a/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
+++ b/src/app/components/HoverHighlightingContext/WithHoverHighlighting.tsx
@@ -22,28 +22,10 @@ export const WithHoverHighlighting: FC<{ children: ReactNode; address: string }>
     <Box
       onMouseEnter={() => selectAddress(address)}
       onMouseLeave={() => releaseAddress(address)}
+      component={'span'}
       sx={{
         display: 'inline-flex',
-        alignItems: 'center',
-        verticalAlign: 'middle',
-        // We want to have a bit of space inside the highlight bubble.
-        // No need for vertical padding, there is already enough space
-        padding: '0 4px',
-        // We don't want the children to move when we add highlighting around them,
-        // so we are compensating the padding+border with negative margins.
-        // Q: Why do we asymmetrical top and bottom?
-        // Q: Nobody really knows, but this way text is aligned properly,
-        // when placed on a line with other (non-highlighted) text in a flex div.
-        margin: '-3px -5px -1px -5px',
-        ...(isHighlighted
-          ? {
-              background: COLORS.warningLight,
-              border: `1px dashed ${COLORS.warningColor}`,
-              borderRadius: '6px',
-            }
-          : {
-              border: `1px dashed transparent`,
-            }),
+        ...(isHighlighted ? { background: COLORS.warningLight } : {}),
       }}
     >
       {children}

--- a/src/app/components/Tooltip/MaybeWithTooltip.tsx
+++ b/src/app/components/Tooltip/MaybeWithTooltip.tsx
@@ -49,14 +49,7 @@ export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({ title, children, s
       disableHoverListener={!title}
       disableTouchListener={!title}
     >
-      <Box
-        component="span"
-        sx={{
-          ...spanSx,
-          display: 'inline-flex',
-          verticalAlign: 'middle',
-        }}
-      >
+      <Box component="span" className={'inline-flex'} sx={spanSx}>
         {children}
       </Box>
     </Tooltip>

--- a/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Endorsement.tsx
@@ -21,8 +21,6 @@ const StyledBox: FC<PropsWithChildren> = ({ children }) => {
         flex: 1,
         overflowX: 'hidden',
         overflowY: 'hidden',
-        // Fix WithHighlighting clipping
-        padding: '3px 0 1px 5px',
       }}
     >
       {children}

--- a/src/app/pages/RuntimeTransactionDetailPage/index.tsx
+++ b/src/app/pages/RuntimeTransactionDetailPage/index.tsx
@@ -258,13 +258,7 @@ export const RuntimeTransactionDetailView: FC<{
             <>
               <dt>{t('transaction.eventsSummary')}</dt>
               <dd>
-                <Box
-                  sx={{
-                    overflowX: 'auto',
-                    // Fix WithHighlighting clipping
-                    paddingTop: '1px',
-                  }}
-                >
+                <Box sx={{ overflowX: 'auto' }}>
                   {transfers.map((transfer, i) => {
                     const params = transfer.evm_log_params
                     if (!params) return null
@@ -285,12 +279,12 @@ export const RuntimeTransactionDetailView: FC<{
                         }}
                       >
                         <TokenTypeTag tokenType={transfer.evm_token?.type} />
-                        <Typography variant="body2">
+                        <Typography variant="body2" className={'inline-flex gap-1 items-center'}>
                           {t('common.from')}{' '}
                           {from ? <AccountLink scope={transaction} address={from} alwaysTrim /> : '?'}
                         </Typography>
 
-                        <Typography variant="body2">
+                        <Typography variant="body2" className={'inline-flex gap-1 items-center'}>
                           {t('common.to')}{' '}
                           {to ? <AccountLink scope={transaction} address={to} alwaysTrim /> : '?'}
                         </Typography>

--- a/src/app/pages/TokenDashboardPage/NFTLinks.tsx
+++ b/src/app/pages/TokenDashboardPage/NFTLinks.tsx
@@ -76,9 +76,6 @@ export const NFTOwnerLink: FC<NFTOwnerLinkProps> = ({ scope, owner }) => {
       sx={{
         display: 'flex',
         whiteSpace: 'initial',
-        // Fix WithHighlighting clipping
-        pt: '4px',
-        pb: '1px',
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>{t('nft.owner')}:</Box>


### PR DESCRIPTION
This is an alternate implementation of #2178 and #2182, which keeps the border around the hover highlight, but adds 1px of negative horizontal margin. This means that we will have proper vertical alignment, but use one pixel above and below every address. We might see some clipping at the left and right sides, if the address is squeezed somewhere really tightly. (I haven't seen this manifest anywhere yet.)

See screenshots at #2178.