### PR TITLE
Fix warnings div cannot appear as a descendant of paragraph

### DIFF
--- a/.changelog/2189.trivial.md
+++ b/.changelog/2189.trivial.md
@@ -1,0 +1,1 @@
+Fix warnings div cannot appear as a descendant of paragraph

--- a/src/app/components/PageLayout/Footer.tsx
+++ b/src/app/components/PageLayout/Footer.tsx
@@ -34,12 +34,12 @@ export const Footer: FC<FooterProps> = ({ scope, mobileSearchAction, enableMobil
             enableMobileSearch={enableMobileSearch}
           >
             <Typography variant="xsmall" textColor="muted" className="flex items-center gap-0.5 flex-wrap">
-              <div className="whitespace-nowrap">{t('footer.mobileTitle')} |</div>
-              <div className={cn(hasMobileAction && 'order-1 basis-full sm:order-none sm:basis-auto')}>
+              <span className="whitespace-nowrap">{t('footer.mobileTitle')} |</span>
+              <span className={cn(hasMobileAction && 'order-1 basis-full sm:order-none sm:basis-auto')}>
                 <ReopenAnalyticsConsentButton />
                 {!hasMobileAction && ' | '}
-              </div>
-              <div>{currentYear}</div>
+              </span>
+              <span>{currentYear}</span>
             </Typography>
           </AppendMobileSearch>
         ) : (


### PR DESCRIPTION
Introduced in https://github.com/oasisprotocol/explorer/pull/2155

dev/mobile view throws 
```
chunk-KPD4VVXB.js?v=629ceb01:521 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>....
```