### PR TITLE
Remove usage of MUI Menu components

### DIFF
--- a/.changelog/2194.internal.md
+++ b/.changelog/2194.internal.md
@@ -1,0 +1,1 @@
+Remove usage of MUI Menu components

--- a/src/app/components/LayerPicker/LayerMenu.tsx
+++ b/src/app/components/LayerPicker/LayerMenu.tsx
@@ -2,8 +2,6 @@ import { FC, PropsWithChildren, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Typography from '@mui/material/Typography'
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
-import MenuList from '@mui/material/MenuList'
-import MenuItem from '@mui/material/MenuItem'
 import Tooltip from '@mui/material/Tooltip'
 import { COLORS } from '../../../styles/theme/colors'
 import { Layer } from '../../../oasis-nexus/api'
@@ -14,6 +12,7 @@ import { orderByLayer } from '../../../types/layers'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { useScopeParam } from '../../hooks/useScopeParam'
 import { SearchScope } from '../../../types/searchScope'
+import { MenuItem } from '../LayerPicker/MenuItem'
 
 type BaseLayerMenuItemProps = {
   divider: boolean
@@ -82,7 +81,6 @@ export const LayerMenuItem: FC<LayerMenuItemProps> = ({
         setSelectedScope(targetScope)
       }}
       selected={isSelected}
-      tabIndex={isSelected ? 0 : -1}
     >
       <div className="flex-auto">
         {labels[targetScope.layer]}
@@ -128,7 +126,7 @@ export const LayerMenu: FC<LayerMenuProps> = ({ selectedNetwork, selectedScope, 
     : getOptionsForNetwork(selectedNetwork ?? activeScope.network, activeScope)
 
   return (
-    <MenuList>
+    <ul role="menu">
       {options.map((option, index) => {
         if (!option.enabled) {
           if (selectedNetwork === 'localnet') return null
@@ -154,6 +152,6 @@ export const LayerMenu: FC<LayerMenuProps> = ({ selectedNetwork, selectedScope, 
           )
         }
       })}
-    </MenuList>
+    </ul>
   )
 }

--- a/src/app/components/LayerPicker/MenuItem.tsx
+++ b/src/app/components/LayerPicker/MenuItem.tsx
@@ -1,0 +1,40 @@
+import { FC, ReactNode } from 'react'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
+
+type MenuItemProps = {
+  children: ReactNode
+  selected?: boolean
+  divider?: boolean
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  onClick?: () => void
+  disabled?: boolean
+}
+
+export const MenuItem: FC<MenuItemProps> = ({
+  children,
+  selected,
+  divider,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+  disabled,
+}) => {
+  return (
+    <li
+      className={cn(
+        'flex items-center max-md:min-h-12 px-4 py-1.5 cursor-pointer hover:bg-border/50',
+        selected && 'text-primary bg-border',
+        divider && 'border-b',
+        disabled && 'cursor-default text-muted-foreground hover:bg-transparent',
+      )}
+      role="menuitem"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+      tabIndex={selected ? 0 : -1}
+    >
+      {children}
+    </li>
+  )
+}

--- a/src/app/components/LayerPicker/NetworkMenu.tsx
+++ b/src/app/components/LayerPicker/NetworkMenu.tsx
@@ -2,12 +2,11 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Typography from '@mui/material/Typography'
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
-import MenuList from '@mui/material/MenuList'
-import MenuItem from '@mui/material/MenuItem'
 import { COLORS } from '../../../styles/theme/colors'
 import { Network, getNetworkNames } from '../../../types/network'
 import { RouteUtils } from '../../utils/route-utils'
 import { getNetworkIcons } from '../../utils/content'
+import { MenuItem } from '../LayerPicker/MenuItem'
 
 type NetworkMenuItemProps = Omit<NetworkMenuProps, 'options'> & {
   divider: boolean
@@ -39,11 +38,10 @@ export const NetworkMenuItem: FC<NetworkMenuItemProps> = ({
       onMouseLeave={() => {
         setHoveredNetwork(undefined)
       }}
-      selected={isSelected}
-      tabIndex={isSelected ? 0 : -1}
       onClick={() => {
         setSelectedNetwork(network)
       }}
+      selected={isSelected}
     >
       <div className="min-w-9 shrink-0 inline-flex text-inherit">{icons[network]}</div>
       <div className="flex-auto">
@@ -73,7 +71,7 @@ export const NetworkMenu: FC<NetworkMenuProps> = ({ activeNetwork, selectedNetwo
   const options: Network[] = RouteUtils.getEnabledNetworks()
 
   return (
-    <MenuList>
+    <ul role="menu">
       {options.map((network, index) => (
         <NetworkMenuItem
           activeNetwork={activeNetwork}
@@ -86,6 +84,6 @@ export const NetworkMenu: FC<NetworkMenuProps> = ({ activeNetwork, selectedNetwo
           network={network}
         />
       ))}
-    </MenuList>
+    </ul>
   )
 }

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -5,7 +5,6 @@ import { outlinedInputClasses } from '@mui/material/OutlinedInput'
 import { inputBaseClasses } from '@mui/material/InputBase'
 import { inputAdornmentClasses } from '@mui/material/InputAdornment'
 import { tabClasses } from '@mui/material/Tab'
-import { menuItemClasses } from '@mui/material/MenuItem'
 
 declare module '@mui/material/styles' {
   interface Palette {
@@ -702,29 +701,6 @@ export const defaultTheme = createTheme({
         dotActive: ({ theme }) => ({
           background: theme.palette.layout.main,
         }),
-      },
-    },
-    MuiMenuItem: {
-      styleOverrides: {
-        root: {
-          color: COLORS.grayExtraDark,
-          [`&.${menuItemClasses.selected}`]: {
-            color: COLORS.brandDark,
-            backgroundColor: COLORS.grayLight,
-            '&:hover': {
-              color: COLORS.brandDark,
-              backgroundColor: COLORS.grayMediumLight,
-            },
-          },
-          [`&.${menuItemClasses.disabled}`]: {
-            color: COLORS.grayMedium,
-            opacity: 1,
-          },
-          '&:hover': {
-            color: COLORS.grayExtraDark,
-            backgroundColor: COLORS.grayMediumLight,
-          },
-        },
       },
     },
     MuiList: {


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/explorer/issues/2191

Used in 

- layer picker (network and layer lists) 
https://pr-2194.oasis-explorer.pages.dev/mainnet/consensus
vs https://explorer.dev.oasis.io/mainnet/consensus