### PR TITLE
Update mono fonts on dashboards

### DIFF
--- a/.changelog/2208.trivial.md
+++ b/.changelog/2208.trivial.md
@@ -1,0 +1,1 @@
+Update mono fonts on dashboards.

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -1,10 +1,8 @@
 import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
-import Link from '@mui/material/Link'
 import { RouteUtils } from '../../utils/route-utils'
 import InfoIcon from '@mui/icons-material/Info'
-import Typography from '@mui/material/Typography'
 import { SearchScope } from '../../../types/searchScope'
 import { useAccountMetadata } from '../../hooks/useAccountMetadata'
 import { trimLongString } from '../../utils/trimLongString'
@@ -15,6 +13,7 @@ import { AdaptiveHighlightedText } from '../HighlightedText/AdaptiveHighlightedT
 import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { AccountMetadataSourceIndicator } from './AccountMetadataSourceIndicator'
 import { WithHoverHighlighting } from '../HoverHighlightingContext/WithHoverHighlighting'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 
 const WithTypographyAndLink: FC<{
   scope: SearchScope
@@ -26,15 +25,13 @@ const WithTypographyAndLink: FC<{
   const to = RouteUtils.getAccountRoute(scope, address)
   return (
     <WithHoverHighlighting address={address}>
-      <Typography variant="mono" component="span" sx={{ display: 'inline-flex' }}>
-        {labelOnly ? (
-          children
-        ) : (
-          <Link component={RouterLink} to={to} sx={{ display: 'inline-flex' }}>
-            {children}
-          </Link>
-        )}
-      </Typography>
+      {labelOnly ? (
+        <span className="text-foreground font-medium">{children}</span>
+      ) : (
+        <Link asChild className="font-medium">
+          <RouterLink to={to}>{children}</RouterLink>
+        </Link>
+      )}
     </WithHoverHighlighting>
   )
 }

--- a/src/app/components/Blocks/BlockLink.tsx
+++ b/src/app/components/Blocks/BlockLink.tsx
@@ -1,20 +1,17 @@
 import { FC } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
-import Typography from '@mui/material/Typography'
-import Link from '@mui/material/Link'
 import { RouteUtils } from '../../utils/route-utils'
 import { trimLongString } from '../../utils/trimLongString'
 import { SearchScope } from '../../../types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 
 export const BlockLink: FC<{ scope: SearchScope; height: number }> = ({ scope, height }) => (
-  <Typography variant="mono">
-    <Link component={RouterLink} to={RouteUtils.getBlockRoute(scope, height)}>
-      {height?.toLocaleString()}
-    </Link>
-  </Typography>
+  <Link asChild className="font-medium">
+    <RouterLink to={RouteUtils.getBlockRoute(scope, height)}>{height?.toLocaleString()}</RouterLink>
+  </Link>
 )
 
 export const BlockHashLink: FC<{
@@ -29,33 +26,35 @@ export const BlockHashLink: FC<{
   if (alwaysTrim) {
     // Table view
     return (
-      <Typography variant="mono">
-        <MaybeWithTooltip title={hash}>
-          <Link component={RouterLink} to={to}>
+      <MaybeWithTooltip title={hash}>
+        <Link asChild>
+          <RouterLink to={to} className="text-primary font-medium">
             {trimLongString(hash)}
-          </Link>
-        </MaybeWithTooltip>
-      </Typography>
+          </RouterLink>
+        </Link>
+      </MaybeWithTooltip>
     )
   }
 
   if (!isTablet) {
     // Desktop view
     return (
-      <Typography variant="mono">
-        <Link component={RouterLink} to={to}>
+      <Link asChild>
+        <RouterLink to={to} className="text-primary font-medium">
           {hash}
-        </Link>
-      </Typography>
+        </RouterLink>
+      </Link>
     )
   }
 
   // Mobile view
   return (
-    <Typography variant="mono" sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
-      <Link component={RouterLink} to={to}>
-        <AdaptiveTrimmer text={hash} strategy="middle" minLength={13} />
+    <span className="max-w-full overflow-x-hidden">
+      <Link asChild>
+        <RouterLink to={to} className="text-primary font-medium">
+          <AdaptiveTrimmer text={hash} strategy="middle" minLength={13} />
+        </RouterLink>
       </Link>
-    </Typography>
+    </span>
   )
 }

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -1,9 +1,7 @@
 import { FC, PropsWithChildren } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
-import MuiLink from '@mui/material/Link'
-import Typography from '@mui/material/Typography'
-import { COLORS } from '../../../styles/theme/colors'
+import { Link as UilLink } from '@oasisprotocol/ui-library/src/components/link'
 import { trimLongString } from '../../utils/trimLongString'
 import { HighlightedText } from '../HighlightedText'
 import Box from '@mui/material/Box'
@@ -13,6 +11,7 @@ import { WithHoverHighlighting } from '../HoverHighlightingContext/WithHoverHigh
 import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { AdaptiveHighlightedText } from '../HighlightedText/AdaptiveHighlightedText'
 import { HighlightedTrimmedText } from '../HighlightedText/HighlightedTrimmedText'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 export type TrimMode = 'fixes' | 'adaptive'
 
@@ -62,11 +61,7 @@ export const Link: FC<LinkProps> = ({
     <MaybeWithTooltip title={tooltipTitle}>
       <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
         {hasName && withSourceIndicator && <AccountMetadataSourceIndicator source={'SelfProfessed'} />}
-        <Typography
-          variant="mono"
-          component="span"
-          sx={{ color: labelOnly ? COLORS.brandExtraDark : COLORS.brandDark, fontWeight: 700 }}
-        >
+        <span className={cn('font-medium', !labelOnly && 'text-primary')}>
           {isTablet ? (
             <TabletLink address={address} name={name} to={to} labelOnly={labelOnly} trimMode={trimMode} />
           ) : (
@@ -79,7 +74,7 @@ export const Link: FC<LinkProps> = ({
               trimMode={trimMode}
             />
           )}
-        </Typography>
+        </span>
       </Box>
     </MaybeWithTooltip>
   )
@@ -93,9 +88,7 @@ type CustomTrimEndLinkLabelProps = {
 }
 
 const LinkLabel: FC<PropsWithChildren> = ({ children }) => (
-  <Typography component="span" fontSize={'inherit'} fontWeight={'inherit'} lineHeight={'inherit'}>
-    <span>{children}</span>
-  </Typography>
+  <span className="text-inherit font-inherit leading-inherit">{children}</span>
 )
 
 const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({ name, to, labelOnly, trimMode }) => {
@@ -108,9 +101,9 @@ const CustomTrimEndLinkLabel: FC<CustomTrimEndLinkLabelProps> = ({ name, to, lab
   return labelOnly ? (
     <LinkLabel>{label}</LinkLabel>
   ) : (
-    <MuiLink component={RouterLink} to={to}>
-      {label}
-    </MuiLink>
+    <UilLink asChild>
+      <RouterLink to={to}>{label}</RouterLink>
+    </UilLink>
   )
 }
 
@@ -136,9 +129,9 @@ const TabletLink: FC<TabletLinkProps> = ({ address, name, to, labelOnly, trimMod
   return labelOnly ? (
     <LinkLabel>{label}</LinkLabel>
   ) : (
-    <MuiLink component={RouterLink} to={to}>
-      {label}
-    </MuiLink>
+    <UilLink asChild>
+      <RouterLink to={to}>{label}</RouterLink>
+    </UilLink>
   )
 }
 
@@ -156,9 +149,9 @@ const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, trim
         ) : labelOnly ? (
           <LinkLabel>{trimLongString(address)}</LinkLabel>
         ) : (
-          <MuiLink component={RouterLink} to={to}>
-            {trimLongString(address)}
-          </MuiLink>
+          <UilLink asChild>
+            <RouterLink to={to}>{trimLongString(address)}</RouterLink>
+          </UilLink>
         )}
       </WithHoverHighlighting>
     )
@@ -169,9 +162,9 @@ const DesktopLink: FC<DesktopLinkProps> = ({ address, name, to, alwaysTrim, trim
       {labelOnly ? (
         <LinkLabel>{label}</LinkLabel>
       ) : (
-        <MuiLink component={RouterLink} to={to}>
-          {label}
-        </MuiLink>
+        <UilLink asChild>
+          <RouterLink to={to}>{label}</RouterLink>
+        </UilLink>
       )}
     </WithHoverHighlighting>
   )

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -1,7 +1,5 @@
 import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
-import Link from '@mui/material/Link'
-import Typography from '@mui/material/Typography'
 import InfoIcon from '@mui/icons-material/Info'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { RouteUtils } from '../../utils/route-utils'
@@ -10,23 +8,17 @@ import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import { trimLongString } from '../../utils/trimLongString'
 import Box from '@mui/material/Box'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 
 const WithTypographyAndLink: FC<{ children: ReactNode; mobile?: boolean; to: string }> = ({
   children,
   mobile,
   to,
 }) => (
-  <Typography
-    variant="mono"
-    component="span"
-    sx={{
-      ...(mobile ? { maxWidth: '85%' } : {}),
-    }}
-  >
-    <Link component={RouterLink} to={to}>
-      {children}
-    </Link>
-  </Typography>
+  <Link asChild className={cn('font-medium', mobile && 'max-w-[85%]')}>
+    <RouterLink to={to}>{children}</RouterLink>
+  </Link>
 )
 
 export const TransactionLink: FC<{

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -4,7 +4,7 @@
 
 /* Override MUI styles that are applied globally */
 [class*=' text-'] {
-  font-family: var(--default-font-family);
+  font-family: 'Inter Variable', sans-serif;
 }
 
 /* Override Tailwind's vertical-align reset for MUI SVG components */


### PR DESCRIPTION
Replace mono fonts in tables on dashboard pages.
Partial implementation of issue [#2197](https://github.com/oasisprotocol/explorer/issues/2197)

Before:
<img width="2972" height="4073" alt="screenshot_explorer_before" src="https://github.com/user-attachments/assets/2a18c347-e5de-4ed4-913a-6373170de33f" />

After:
<img width="2972" height="3918" alt="screenshot_explorer_after" src="https://github.com/user-attachments/assets/535751aa-76ec-4b45-aed4-b6789398be5c" />
