### PR TITLE
Kaja/uil rofl mono typography

### DIFF
--- a/.changelog/2210.trivial.md
+++ b/.changelog/2210.trivial.md
@@ -1,0 +1,1 @@
+Update mono fonts on ROFL app details page.

--- a/src/app/components/Account/AccountLink.tsx
+++ b/src/app/components/Account/AccountLink.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useScreenSize } from '../../hooks/useScreensize'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 import { RouteUtils } from '../../utils/route-utils'
 import InfoIcon from '@mui/icons-material/Info'
 import { SearchScope } from '../../../types/searchScope'
@@ -13,7 +14,6 @@ import { AdaptiveHighlightedText } from '../HighlightedText/AdaptiveHighlightedT
 import { AdaptiveTrimmer } from '../AdaptiveTrimmer/AdaptiveTrimmer'
 import { AccountMetadataSourceIndicator } from './AccountMetadataSourceIndicator'
 import { WithHoverHighlighting } from '../HoverHighlightingContext/WithHoverHighlighting'
-import { Link } from '@oasisprotocol/ui-library/src/components/link'
 
 const WithTypographyAndLink: FC<{
   scope: SearchScope

--- a/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
+++ b/src/app/components/AdaptiveTrimmer/AdaptiveDynamicTrimmer.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import InfoIcon from '@mui/icons-material/Info'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import { getAdaptiveId, ShorteningResult, useAdaptiveSizing } from './hooks'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 type AdaptiveDynamicTrimmerProps = {
   /**
@@ -92,7 +93,7 @@ export const AdaptiveDynamicTrimmer: FC<AdaptiveDynamicTrimmerProps> = ({
     <Box component="span" ref={textRef} sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
       <MaybeWithTooltip
         title={title}
-        spanSx={{ textWrap: 'nowrap', whiteSpace: 'nowrap', opacity: isFinal ? 1 : 0 }}
+        spanClassName={cn('whitespace-nowrap', isFinal ? 'opacity-100' : 'opacity-0')}
       >
         {currentContent}
       </MaybeWithTooltip>

--- a/src/app/components/Blocks/BlockLink.tsx
+++ b/src/app/components/Blocks/BlockLink.tsx
@@ -39,10 +39,8 @@ export const BlockHashLink: FC<{
   if (!isTablet) {
     // Desktop view
     return (
-      <Link asChild>
-        <RouterLink to={to} className="text-primary font-medium">
-          {hash}
-        </RouterLink>
+      <Link asChild className="font-medium">
+        <RouterLink to={to}>{hash}</RouterLink>
       </Link>
     )
   }

--- a/src/app/components/StyledDescriptionList/index.tsx
+++ b/src/app/components/StyledDescriptionList/index.tsx
@@ -59,7 +59,6 @@ export const StyledDescriptionList = styled(InlineDescriptionList, {
     alignItems: 'start',
   },
   dd: {
-    color: COLORS.brandExtraDark,
     overflowWrap: 'anywhere',
     alignItems: 'center',
     maxWidth: '100%',

--- a/src/app/components/TableCellNode/index.tsx
+++ b/src/app/components/TableCellNode/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react'
-import Typography from '@mui/material/Typography'
 import { NodeDisplayType } from '../../../types/node-display-type'
 import { SearchScope } from '../../../types/searchScope'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -24,5 +23,5 @@ export const TableCellNode: FC<TableCellNodeProps> = ({ id, scope }) => {
     return <AccountLink alwaysTrimOnTablet scope={scope} address={getOasisAddressFromBase64PublicKey(id)} />
   }
 
-  return <Typography variant="mono">{isTablet ? trimLongString(id) : id}</Typography>
+  return <span className="font-medium">{isTablet ? trimLongString(id) : id}</span>
 }

--- a/src/app/components/Tooltip/MaybeWithTooltip.tsx
+++ b/src/app/components/Tooltip/MaybeWithTooltip.tsx
@@ -1,7 +1,6 @@
 import { FC, ReactNode } from 'react'
 import Tooltip from '@mui/material/Tooltip'
 import Box from '@mui/material/Box'
-import { SxProps } from '@mui/material/styles'
 import { useScreenSize } from '../../hooks/useScreensize'
 
 type MaybeWithTooltipProps = {
@@ -15,7 +14,7 @@ type MaybeWithTooltipProps = {
   /**
    * Any extra styles to apply to the span
    */
-  spanSx?: SxProps
+  spanClassName?: string
 
   /**
    * The content to show
@@ -26,8 +25,9 @@ type MaybeWithTooltipProps = {
 /**
  * A component to display some content with or without a tooltip
  */
-export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({ title, children, spanSx }) => {
+export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({ title, children, spanClassName }) => {
   const { isMobile } = useScreenSize()
+
   return (
     <Tooltip
       placement="top"
@@ -49,9 +49,7 @@ export const MaybeWithTooltip: FC<MaybeWithTooltipProps> = ({ title, children, s
       disableHoverListener={!title}
       disableTouchListener={!title}
     >
-      <Box component="span" sx={{ display: 'inline-flex', ...spanSx }}>
-        {children}
-      </Box>
+      <span className={spanClassName}>{children}</span>
     </Tooltip>
   )
 }

--- a/src/app/components/Transactions/TransactionLink.tsx
+++ b/src/app/components/Transactions/TransactionLink.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 import InfoIcon from '@mui/icons-material/Info'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { RouteUtils } from '../../utils/route-utils'
@@ -9,7 +10,6 @@ import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import { trimLongString } from '../../utils/trimLongString'
 import Box from '@mui/material/Box'
 import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
-import { Link } from '@oasisprotocol/ui-library/src/components/link'
 
 const WithTypographyAndLink: FC<{ children: ReactNode; mobile?: boolean; to: string }> = ({
   children,

--- a/src/app/pages/RoflAppDetailsPage/Enclaves.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Enclaves.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Typography from '@mui/material/Typography'
 import { RoflAppPolicy } from '../../../oasis-nexus/api'
 import { CopyToClipboard } from 'app/components/CopyToClipboard'
 
@@ -21,9 +20,7 @@ export const Enclaves: FC<EnclavesProps> = ({ policy }) => {
         {policy.enclaves.map((enclave: string) => (
           <tr key={enclave}>
             <td>
-              <Typography variant="mono" component="span">
-                {enclave}
-              </Typography>
+              <span className="font-medium">{enclave}</span>
             </td>
             <td>
               <CopyToClipboard value={enclave} />

--- a/src/app/pages/RoflAppDetailsPage/GridRow.tsx
+++ b/src/app/pages/RoflAppDetailsPage/GridRow.tsx
@@ -25,7 +25,7 @@ export const GridRow: FC<GridRowProps> = ({ label, children, tooltip }) => {
       </div>
 
       <div className="col-span-2 border-b border-gray-100 p-2 md:p-4">
-        {children ? <strong>{children}</strong> : t('common.missing')}
+        {children ? <span className="font-medium">{children}</span> : t('common.missing')}
       </div>
     </>
   )

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -3,7 +3,6 @@ import { useHref, useLoaderData } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@oasisprotocol/ui-library/src/components/ui/skeleton'
 import Tooltip from '@mui/material/Tooltip'
-import Typography from '@mui/material/Typography'
 import InfoIcon from '@mui/icons-material/Info'
 import { RoflApp, RoflAppPolicy, RuntimeTransaction, useGetRuntimeRoflAppsId } from '../../../oasis-nexus/api'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
@@ -125,9 +124,7 @@ export const RoflAppDetailsView: FC<{
       <TeeRow policy={app.policy} />
       <DetailsRow title={t('rofl.appId')}>
         <WithHoverHighlighting address={app.id}>
-          <Typography variant="mono" component="span">
-            {app.id}
-          </Typography>
+          <span className="font-medium">{app.id}</span>
         </WithHoverHighlighting>
         <CopyToClipboard value={app.id} />
       </DetailsRow>
@@ -135,7 +132,7 @@ export const RoflAppDetailsView: FC<{
         <Enclaves policy={app.policy} />
       </DetailsRow>
       <DetailsRow title={t('rofl.sekPublicKey')}>
-        <Typography variant="mono">{app.sek}</Typography> <CopyToClipboard value={app.sek} />
+        <span className="font-medium">{app.sek}</span> <CopyToClipboard value={app.sek} />
       </DetailsRow>
       <AdminAccountRow
         address={app.admin_eth ?? app.admin}


### PR DESCRIPTION
Update mono fonts on ROFL app details page.

Before:
<img width="1650" height="875" alt="Screenshot 2025-09-24 at 20 53 20" src="https://github.com/user-attachments/assets/7b77a5a8-0b75-43c6-9b5d-e17827a7ba4a" />

After:
<img width="1650" height="866" alt="Screenshot 2025-09-24 at 20 52 27" src="https://github.com/user-attachments/assets/0fa84adb-8bc2-4d50-b474-0c67f9b0740f" />
