### PR TITLE
Clean up snapshot card

### DIFF
--- a/.changelog/2211.trivial.md
+++ b/.changelog/2211.trivial.md
@@ -1,0 +1,1 @@
+Clean up snapshot card

--- a/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
+++ b/src/app/components/Snapshots/SnapshotCardDurationLabel.tsx
@@ -1,7 +1,5 @@
 import { FC } from 'react'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
-import { COLORS } from '../../../styles/theme/colors'
+import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 
 type SnapshotCardLabelProps = {
   label: string
@@ -13,9 +11,10 @@ export const SnapshotCardDurationLabel: FC<SnapshotCardLabelProps> = ({ label, v
   }
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 3 }}>
-      <Typography sx={{ fontSize: 12, color: COLORS.grayMedium }}>{label}</Typography>
-      <Typography sx={{ fontSize: 'inherit' }}>{value.toLocaleString()}</Typography>
-    </Box>
+    <Typography className="flex gap-2 flex justify-end items-center" asChild>
+      <span>
+        {label} <span className="font-semibold text-primary">{value.toLocaleString()}</span>
+      </span>
+    </Typography>
   )
 }


### PR DESCRIPTION
- clean up dev warnings `<p> cannot appear as a descendant of ` 
- align card label with what was introduced in SnapshotEpoch
<img width="571" height="86" alt="Screenshot from 2025-09-25 11-48-48" src="https://github.com/user-attachments/assets/84f73096-84c8-4150-ad43-369622799847" />
vs master
<img width="571" height="86" alt="Screenshot from 2025-09-25 11-49-00" src="https://github.com/user-attachments/assets/67b6328d-a0a1-4a41-af88-b7ba8890c86f" />

