### PR TITLE
Kaja/uil mono remaining

### DIFF
--- a/.changelog/2212.trivial.md
+++ b/.changelog/2212.trivial.md
@@ -1,0 +1,1 @@
+Update remaining mono fonts across the site.

--- a/src/app/components/LongDataDisplay/index.tsx
+++ b/src/app/components/LongDataDisplay/index.tsx
@@ -56,23 +56,23 @@ export const LongDataDisplay: FC<{ data: string; fontWeight?: number; collapsedL
 
   return (
     <div>
-      <Typography
-        variant="mono"
+      <span
         ref={textRef}
-        sx={{
-          fontWeight,
-          maxHeight: isExpanded ? 'none' : collapsedContainerMaxHeight,
-          overflow: 'hidden',
-          lineHeight: `${lineHeight}px`,
-          overflowWrap: 'anywhere',
-          display: '-webkit-box',
+        className="
+    font-medium
+    overflow-hidden
+    overflow-wrap-anywhere
+    whitespace-pre-wrap
+    [display:-webkit-box]
+    [WebkitBoxOrient:vertical]
+  "
+        style={{
+          maxHeight: isExpanded ? 'none' : `${collapsedContainerMaxHeight}px`,
           WebkitLineClamp: isExpanded ? 'none' : collapsedLinesNumber,
-          WebkitBoxOrient: 'vertical',
-          whiteSpace: 'pre-wrap',
         }}
       >
         {data}
-      </Typography>
+      </span>
       {(isOverflowing || isExpanded) && (
         <StyledButton onClick={() => setIsExpanded(!isExpanded)}>
           {isExpanded ? t('common.hide') : t('common.show')}

--- a/src/app/components/LongDataDisplay/index.tsx
+++ b/src/app/components/LongDataDisplay/index.tsx
@@ -1,7 +1,6 @@
 import { FC, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@mui/material/Button'
-import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import { COLORS } from '../../../styles/theme/colors'
 
@@ -58,16 +57,10 @@ export const LongDataDisplay: FC<{ data: string; fontWeight?: number; collapsedL
     <div>
       <span
         ref={textRef}
-        className="
-    font-medium
-    overflow-hidden
-    overflow-wrap-anywhere
-    whitespace-pre-wrap
-    [display:-webkit-box]
-    [WebkitBoxOrient:vertical]
-  "
+        className="font-medium overflow-hidden overflow-wrap-anywhere whitespace-pre-wrap [display:-webkit-box][WebkitBoxOrient:vertical]"
         style={{
-          maxHeight: isExpanded ? 'none' : `${collapsedContainerMaxHeight}px`,
+          lineHeight: `${lineHeight}px`,
+          maxHeight: isExpanded ? 'none' : collapsedContainerMaxHeight,
           WebkitLineClamp: isExpanded ? 'none' : collapsedLinesNumber,
         }}
       >

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -291,22 +291,14 @@ const RuntimeEventDetailsInner: FC<{
             <b>{eventName}</b>
             <br />
             {t('runtimeEvent.fields.topics')}:
-            <Typography
-              variant="mono"
-              fontWeight={400}
-              sx={{
-                display: 'block',
-                whiteSpace: 'pre-wrap',
-                overflowWrap: 'break-word',
-              }}
-            >
+            <span className="font-medium block whitespace-pre-wrap [overflow-wrap:break-word]">
               {event.body.topics
                 /* @ts-expect-error -- Event body is missing types */
                 .map((base64Topic, index) => {
                   return `${index}: 0x${Buffer.from(base64Topic, 'base64').toString('hex')}`
                 })
                 .join('\n')}
-            </Typography>
+            </span>
             <br />
             {t('runtimeEvent.fields.data')}:
             <LongDataDisplay

--- a/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
+++ b/src/app/components/RuntimeEvents/RuntimeEventDetails.tsx
@@ -17,7 +17,6 @@ import { LongDataDisplay } from '../LongDataDisplay'
 import { parseEvmEvent } from '../../utils/parseEvmEvent'
 import { TokenTransferIcon } from '../Tokens/TokenTransferIcon'
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import StreamIcon from '@mui/icons-material/Stream'
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import { getPreciseNumberFormat } from '../../../locales/getPreciseNumberFormat'
@@ -291,7 +290,7 @@ const RuntimeEventDetailsInner: FC<{
             <b>{eventName}</b>
             <br />
             {t('runtimeEvent.fields.topics')}:
-            <span className="font-medium block whitespace-pre-wrap [overflow-wrap:break-word]">
+            <span className="font-medium block whitespace-pre-wrap wrap-break-word">
               {event.body.topics
                 /* @ts-expect-error -- Event body is missing types */
                 .map((base64Topic, index) => {

--- a/src/app/components/Transactions/TransactionDetailsElements.tsx
+++ b/src/app/components/Transactions/TransactionDetailsElements.tsx
@@ -104,10 +104,10 @@ export const LabelValue: FC<LabelValueProps> = ({ label, trimMobile, value }) =>
       <Label>{label || t('common.amount')}</Label>
       {trimEnabled ? (
         <Tooltip arrow placement="top" title={value} enterDelay={tooltipDelay} enterNextDelay={tooltipDelay}>
-          <Typography variant="mono">{trimLongString(value, 2, 18)}</Typography>
+          <span>{trimLongString(value, 2, 18)}</span>
         </Tooltip>
       ) : (
-        <Typography variant="mono">{value}</Typography>
+        <span>{value}</span>
       )}
     </Box>
   )

--- a/src/app/pages/ConsensusBlockDetailPage/index.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/index.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHref, useOutletContext, useParams } from 'react-router-dom'
-import Typography from '@mui/material/Typography'
 import { AppErrors } from '../../../types/errors'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { Block, EntityMetadata, useGetConsensusBlockByHeight } from '../../../oasis-nexus/api'
@@ -119,11 +118,11 @@ export const ConsensusBlockDetailView: FC<{
           <dt>{t('common.stateRoot')}</dt>
           <dd>
             {isTablet ? (
-              <Typography variant="mono" sx={{ maxWidth: '100%', overflowX: 'hidden' }}>
+              <span className="max-w-full overflow-x-hidden">
                 <AdaptiveTrimmer text={block.state_root} strategy="middle" minLength={13} />
-              </Typography>
+              </span>
             ) : (
-              <Typography variant="mono">{block.state_root}</Typography>
+              <span>{block.state_root}</span>
             )}
             <CopyToClipboard value={block.state_root} />
           </dd>

--- a/src/app/pages/ParatimeDashboardPage/DashboardLink.tsx
+++ b/src/app/pages/ParatimeDashboardPage/DashboardLink.tsx
@@ -1,18 +1,15 @@
 import { FC } from 'react'
 import { getNameForScope, SearchScope } from '../../../types/searchScope'
-import Typography from '@mui/material/Typography'
 import { RouteUtils } from '../../utils/route-utils'
-import Link from '@mui/material/Link'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
 import { Link as RouterLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 export const DashboardLink: FC<{ scope: SearchScope }> = ({ scope }) => {
   const { t } = useTranslation()
   return (
-    <Typography variant="mono">
-      <Link component={RouterLink} to={RouteUtils.getDashboardRoute(scope)}>
-        {getNameForScope(t, scope)}
-      </Link>
-    </Typography>
+    <Link asChild className="font-medium">
+      <RouterLink to={RouteUtils.getDashboardRoute(scope)}>{getNameForScope(t, scope)}</RouterLink>
+    </Link>
   )
 }

--- a/src/app/pages/RoflAppDetailsPage/Secrets.tsx
+++ b/src/app/pages/RoflAppDetailsPage/Secrets.tsx
@@ -1,9 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import { RoflAppSecrets } from '../../../oasis-nexus/api'
-import { COLORS } from '../../../styles/theme/colors'
 
 type SecretsProps = {
   secrets: RoflAppSecrets
@@ -17,24 +14,15 @@ export const Secrets: FC<SecretsProps> = ({ secrets }) => {
   }
 
   return (
-    <Box>
+    <div>
       {Object.keys(secrets).map(key => (
-        <Box key={key}>
-          <Typography
-            variant="mono"
-            component="span"
-            sx={{
-              wordWrap: 'break-word',
-              pr: 3,
-            }}
-          >
-            {key}:
-          </Typography>
-          <Typography variant="mono" sx={{ color: COLORS.grayMedium }}>
+        <div key={key} className="flex flex-wrap gap-x-1">
+          <span className="font-medium break-words">{key}:</span>
+          <span className="text-muted-foreground">
             {t('rofl.secretLength', { value: secrets[key].length })}
-          </Typography>
-        </Box>
+          </span>
+        </div>
       ))}
-    </Box>
+    </div>
   )
 }

--- a/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppInstanceDetailsPage/index.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react'
 import { useHref, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import Typography from '@mui/material/Typography'
 import { RoflInstance, useGetRuntimeRoflAppsIdInstancesRak } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { AppErrors } from '../../../types/errors'
@@ -62,15 +61,15 @@ export const RoflAppInstanceDetailsView: FC<{
     <StyledDescriptionList titleWidth={isMobile ? '100px' : '200px'}>
       <dt>{t('rofl.rakAbbreviation')}</dt>
       <dd>
-        <Typography variant="mono">
+        <span>
           {instance.rak} <CopyToClipboard value={instance.rak} />
-        </Typography>
+        </span>
       </dd>
       <dt>{t('rofl.rekAbbreviation')}</dt>
       <dd>
-        <Typography variant="mono">
+        <span>
           {instance.rek} <CopyToClipboard value={instance.rek} />
-        </Typography>
+        </span>
       </dd>
       <dt>{t('rofl.expirationEpoch')}</dt>
       <dd>{instance.expiration_epoch.toLocaleString()}</dd>
@@ -81,16 +80,16 @@ export const RoflAppInstanceDetailsView: FC<{
       </dd>
       <dt>{t('rofl.endorsingNodeId')}</dt>
       <dd>
-        <Typography variant="mono">
+        <span>
           {instance.endorsing_node_id} <CopyToClipboard value={instance.endorsing_node_id} />
-        </Typography>
+        </span>
       </dd>
       <dt>{t('rofl.endorsingNodeAddress')}</dt>
       <dd>
-        <Typography variant="mono">
+        <span>
           <AccountLink alwaysTrimOnTablet scope={scope} address={nodeAddress} />
           <CopyToClipboard value={nodeAddress} />
-        </Typography>
+        </span>
       </dd>
       <dt>{t('rofl.extraKeys')}</dt>
       <dd>
@@ -104,10 +103,10 @@ export const RoflAppInstanceDetailsView: FC<{
                 return (
                   <tr key={index}>
                     <td>
-                      <Typography variant="mono">{keyType}:</Typography>
+                      <span>{keyType}:</span>
                     </td>
                     <td>
-                      <Typography variant="mono">{String(keyValue)}</Typography>
+                      <span>{String(keyValue)}</span>
                     </td>
                   </tr>
                 )


### PR DESCRIPTION
Update remaining mono fonts across the site (excluding code snippets).

Issue: [#2197](https://github.com/oasisprotocol/explorer/issues/2197)

Example screenshots -

Before:
<img width="686" height="293" alt="Screenshot 2025-09-25 at 11 54 41" src="https://github.com/user-attachments/assets/c174e8b4-f83a-4fa0-8c6a-2c305fc28e6e" />

After:
<img width="766" height="287" alt="Screenshot 2025-09-25 at 11 49 54" src="https://github.com/user-attachments/assets/e4454ce1-a092-44e0-8698-08050ddfeb0d" />
