### PR TITLE
Remove duplicated hash column from blocks list table

### DIFF
--- a/.changelog/2214.bugfix.md
+++ b/.changelog/2214.bugfix.md
@@ -1,0 +1,1 @@
+Remove duplicated hash column from blocks list table

--- a/src/app/components/Blocks/RuntimeBlocks.tsx
+++ b/src/app/components/Blocks/RuntimeBlocks.tsx
@@ -59,7 +59,6 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
           },
         ]
       : []),
-    ...(type === BlocksTableType.Desktop ? [{ key: 'hash', content: t('common.hash') }] : []),
     { key: 'size', content: t('common.size'), align: TableCellAlign.Right },
     ...(type === BlocksTableType.Desktop
       ? [{ key: 'gasUsed', content: t('common.gasUsed'), align: TableCellAlign.Right }]


### PR DESCRIPTION
Broken since https://github.com/oasisprotocol/explorer/pull/2131


https://pr-2214.oasis-explorer.pages.dev/mainnet/sapphire/block
vs prod
https://explorer.oasis.io/mainnet/sapphire/block