### PR TITLE
Code snippet wrapping on mobile

### DIFF
--- a/.changelog/2216.bugfix.md
+++ b/.changelog/2216.bugfix.md
@@ -1,0 +1,1 @@
+Add word wrapping for events code snippets on mobile

--- a/src/app/components/ConsensusEvents/ConsensusEventDetails.tsx
+++ b/src/app/components/ConsensusEvents/ConsensusEventDetails.tsx
@@ -67,7 +67,7 @@ const ConsensusEventDetailsContent: FC<{
     <div>
       <b>{getConsensusEventTypeLabel(t, event.type)}</b>
       <br />
-      <pre>{JSON.stringify(event, null, ' ')}</pre>
+      <pre className="whitespace-pre-wrap break-words">{JSON.stringify(event, null, ' ')}</pre>
     </div>
   )
 }


### PR DESCRIPTION
Added word wrapping for events code snippets on mobile.

Fixes: [#2181](https://github.com/oasisprotocol/explorer/issues/2181)

Before:
<img width="443" height="862" alt="Screenshot 2025-09-29 at 13 56 27" src="https://github.com/user-attachments/assets/ae06f83f-fc9c-45e5-ae44-2b76ecd22f47" />

After:
<img width="375" height="667" alt="pr-2216 oasis-explorer pages dev_mainnet_consensus_block_26621356_events(iPhone SE)" src="https://github.com/user-attachments/assets/ece9ffc8-c3f7-43dd-ba18-5eaab7687615" />
