### PR TITLE
Make BuildBanner non-sticky to fix on mobile

### DIFF
--- a/.changelog/2228.trivial.md
+++ b/.changelog/2228.trivial.md
@@ -1,0 +1,1 @@
+Make BuildBanner non-sticky to fix on mobile

--- a/src/app/components/BuildBanner/index.tsx
+++ b/src/app/components/BuildBanner/index.tsx
@@ -20,7 +20,11 @@ export const BuildBanner: FC = () => {
     : t('banner.buildPreview', { appTitle: getAppTitle() })
 
   return (
-    <Alert variant="warning-filled" sticky>
+    <Alert
+      variant="warning-filled"
+      // classes for [sticky] alert, without being sticky
+      className="rounded-none border-0 flex justify-center items-center [&>svg]:-mt-1"
+    >
       {message}
     </Alert>
   )


### PR DESCRIPTION
Our sticky AppBar is now shorter so BuildBanner became slightly visible behind it. BuildBanner doesn't really need to stay sticky, so that fixes it.

![Recording 2025-10-02 at 21 57 39](https://github.com/user-attachments/assets/b3fc0451-2942-4015-be2f-d120ac96164f)
