### PR TITLE
Replace MUI Progress with Oasis UI Library component

### DIFF
--- a/.changelog/2235.internal.md
+++ b/.changelog/2235.internal.md
@@ -1,0 +1,1 @@
+Replace MUI Progress with Oasis UI Library component

--- a/src/app/components/Blocks/RuntimeBlocks.tsx
+++ b/src/app/components/Blocks/RuntimeBlocks.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next'
 import { RuntimeBlock } from '../../../oasis-nexus/api'
-import { VerticalProgressBar } from '../../components/ProgressBar'
 import { Table, TableCellAlign, TableColProps } from '../../components/Table'
 import { paraTimesConfig } from '../../../config'
 import { TablePaginationProps } from '../Table/TablePagination'
@@ -10,6 +9,7 @@ import { FC } from 'react'
 import { BlocksTableType } from './index'
 import { TableHeaderAge } from '../TableHeaderAge'
 import { TableCellAge } from '../TableCellAge'
+import { Progress } from '@oasisprotocol/ui-library/src/components/progress'
 
 export type TableRuntimeBlock = RuntimeBlock & {
   markAsNew?: boolean
@@ -77,7 +77,7 @@ export const RuntimeBlocks: FC<RuntimeBlocksProps> = ({
         ...(type === BlocksTableType.Desktop
           ? [
               {
-                content: <VerticalProgressBar value={(100 * block.gas_used) / blockGasLimit} />,
+                content: <Progress className="w-6" value={(100 * block.gas_used) / blockGasLimit} />,
                 key: 'fill',
               },
             ]

--- a/src/app/components/LabeledProgress/index.tsx
+++ b/src/app/components/LabeledProgress/index.tsx
@@ -1,13 +1,13 @@
 import { FC, ReactNode } from 'react'
 import { Progress } from '@oasisprotocol/ui-library/src/components/progress'
 
-type CustomProgressProps = {
+type LabeledProgresssProps = {
   value?: number
   max?: number
   label: ReactNode
 }
 
-export const CustomProgress: FC<CustomProgressProps> = ({ value, max, label }) => {
+export const LabeledProgress: FC<LabeledProgresssProps> = ({ value, max, label }) => {
   if (!value || !max) {
     return null
   }

--- a/src/app/components/ProgressBar/index.tsx
+++ b/src/app/components/ProgressBar/index.tsx
@@ -1,48 +1,5 @@
 import { FC, ReactNode } from 'react'
-import Box from '@mui/material/Box'
-import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress'
-import { styled } from '@mui/material/styles'
-import { COLORS } from 'styles/theme/colors'
 import { Progress } from '@oasisprotocol/ui-library/src/components/progress'
-
-type VerticalProgressBarProps = {
-  value: number
-  height?: number
-  width?: number
-  barWithBorder?: boolean
-  barBackgroundColor?: string
-}
-
-const barSize = 36
-
-export const VerticalProgressBar: FC<VerticalProgressBarProps> = ({
-  value,
-  height = barSize,
-  width = barSize,
-  barWithBorder = true,
-  barBackgroundColor,
-}) => {
-  return (
-    <Box sx={{ height: width, width: height, transform: 'rotate(-90deg)' }}>
-      <StyledLinearProgress
-        sx={{ height: width, width: height }}
-        barWithBorder={barWithBorder}
-        barBackgroundColor={barBackgroundColor}
-        variant="determinate"
-        value={value}
-      />
-    </Box>
-  )
-}
-const StyledLinearProgress = styled(LinearProgress, {
-  shouldForwardProp: prop => prop !== 'barWithBorder' && prop !== 'barBackgroundColor',
-})<{ barWithBorder?: boolean; barBackgroundColor?: string }>(({ barWithBorder, barBackgroundColor }) => ({
-  [`&.${linearProgressClasses.determinate} > .${linearProgressClasses.bar1Determinate}`]: {
-    backgroundColor: COLORS.brandDark,
-  },
-  ...(!barWithBorder && { border: '0' }),
-  ...(barBackgroundColor && { backgroundColor: barBackgroundColor }),
-}))
 
 type CustomProgressProps = {
   value?: number

--- a/src/app/components/ProgressBar/index.tsx
+++ b/src/app/components/ProgressBar/index.tsx
@@ -1,8 +1,9 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress'
 import { styled } from '@mui/material/styles'
 import { COLORS } from 'styles/theme/colors'
+import { Progress } from '@oasisprotocol/ui-library/src/components/progress'
 
 type VerticalProgressBarProps = {
   value: number
@@ -43,11 +44,23 @@ const StyledLinearProgress = styled(LinearProgress, {
   ...(barBackgroundColor && { backgroundColor: barBackgroundColor }),
 }))
 
-export const BrandProgressBar = styled(LinearProgress)(() => ({
-  [`&.${linearProgressClasses.determinate} > .${linearProgressClasses.bar1Determinate}`]: {
-    backgroundColor: COLORS.brandDark,
-  },
-  borderColor: COLORS.grayLight,
-  backgroundColor: COLORS.grayLight,
-  height: '12px',
-}))
+type CustomProgressProps = {
+  value?: number
+  max?: number
+  label: ReactNode
+}
+
+export const CustomProgress: FC<CustomProgressProps> = ({ value, max, label }) => {
+  if (!value || !max) {
+    return null
+  }
+
+  return (
+    <div className="w-full relative">
+      <Progress value={(value / max) * 100} className="h-8 bg-muted-foreground rounded-[8px]" />
+      <span className="absolute inset-y-0 left-3 flex items-center text-white text-xs font-normal">
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
@@ -5,7 +5,8 @@ import { useGetConsensusEpochs } from '../../../oasis-nexus/api'
 import { useGetStatus } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
-import { BrandProgressBar } from '../../components/ProgressBar'
+import { PercentageValue } from '../../components/PercentageValue'
+import { CustomProgress } from '../../components/ProgressBar'
 
 // We need to get the previous epoch to compute end_height for the current one
 // This may not be precise during abnormal network conditions, but such conditions never happened so far
@@ -18,17 +19,17 @@ export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
   const epochsQuery = useGetConsensusEpochs(scope.network, { limit: epochsLimit })
   const epochs = epochsQuery.data?.data.epochs
   const epoch = epochs?.length && epochs[0].id
-  let percentageValue = undefined
+  let epochDiffHeight = undefined
+  let completedBlocksInCurrentEpoch = undefined
 
   if (epochs && epochs[1]?.end_height && blockHeight) {
-    const epochDiffHeight = epochs[1]?.end_height - epochs[1]?.start_height
-    const completedBlocksInCurrentEpoch = blockHeight - epochs[0]?.start_height
-    percentageValue = completedBlocksInCurrentEpoch / epochDiffHeight
+    epochDiffHeight = epochs[1]?.end_height - epochs[1]?.start_height + 1
+    completedBlocksInCurrentEpoch = blockHeight - epochs[0]?.start_height
   }
 
   return (
     <SnapshotTextCard
-      title={t('currentEpoch')}
+      title={t('snapshotEpochTitle')}
       label={
         blockHeight !== undefined && (
           <Typography className="font-normal flex gap-2 items-center">
@@ -46,30 +47,21 @@ export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
       }
     >
       {epoch !== undefined && (
-        <>
-          {percentageValue !== undefined && (
-            <div className="-mt-2 mb-2">
-              <BrandProgressBar value={percentageValue * 100} variant="determinate" />
-            </div>
-          )}
-          <div className="flex items-baseline gap-2">
-            {epoch.toLocaleString()}
-            {percentageValue !== undefined && (
-              <Typography variant="xsmall" textColor="muted">
-                (
-                {t('common.valuePair', {
-                  value: percentageValue,
-                  formatParams: {
-                    value: {
-                      style: 'percent',
-                    } satisfies Intl.NumberFormatOptions,
-                  },
-                })}
-                )
-              </Typography>
-            )}
-          </div>
-        </>
+        <CustomProgress
+          value={completedBlocksInCurrentEpoch}
+          max={epochDiffHeight}
+          label={
+            <>
+              <span className="font-bold">{completedBlocksInCurrentEpoch}</span>/{epochDiffHeight} (
+              <PercentageValue
+                value={completedBlocksInCurrentEpoch}
+                total={epochDiffHeight}
+                maximumFractionDigits={1}
+              />
+              )
+            </>
+          }
+        />
       )}
     </SnapshotTextCard>
   )

--- a/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
+++ b/src/app/pages/ConsensusDashboardPage/SnapshotEpoch.tsx
@@ -6,7 +6,7 @@ import { useGetStatus } from '../../../oasis-nexus/api'
 import { SearchScope } from '../../../types/searchScope'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
 import { PercentageValue } from '../../components/PercentageValue'
-import { CustomProgress } from '../../components/ProgressBar'
+import { LabeledProgress } from '../../components/LabeledProgress'
 
 // We need to get the previous epoch to compute end_height for the current one
 // This may not be precise during abnormal network conditions, but such conditions never happened so far
@@ -47,7 +47,7 @@ export const SnapshotEpoch: FC<{ scope: SearchScope }> = ({ scope }) => {
       }
     >
       {epoch !== undefined && (
-        <CustomProgress
+        <LabeledProgress
           value={completedBlocksInCurrentEpoch}
           max={epochDiffHeight}
           label={

--- a/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
-import { CustomProgress } from 'app/components/ProgressBar'
+import { LabeledProgress } from 'app/components/LabeledProgress'
 import { PercentageValue } from '../../components/PercentageValue'
 
 type VotingPowerCardProps = {
@@ -30,7 +30,7 @@ export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator, stats }) 
             {t('validator.votingPowerOverall')}
           </Typography>
           <div className="pt-4">
-            <CustomProgress
+            <LabeledProgress
               value={validator.voting_power}
               max={stats.total_voting_power}
               label={

--- a/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
+++ b/src/app/pages/ValidatorDetailsPage/VotingPowerCard.tsx
@@ -1,10 +1,9 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import Typography from '@mui/material/Typography'
+import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { Validator, ValidatorAggStats } from '../../../oasis-nexus/api'
 import { SnapshotTextCard } from '../../components/Snapshots/SnapshotCard'
-import { COLORS } from 'styles/theme/colors'
-import { VerticalProgressBar } from 'app/components/ProgressBar'
+import { CustomProgress } from 'app/components/ProgressBar'
 import { PercentageValue } from '../../components/PercentageValue'
 
 type VotingPowerCardProps = {
@@ -20,31 +19,33 @@ export const VotingPowerCard: FC<VotingPowerCardProps> = ({ validator, stats }) 
       title={t('validator.votingPower')}
       label={
         typeof validator?.voting_power === 'number' && (
-          <Typography sx={{ fontSize: 18, color: COLORS.grayMedium }}>
-            ({validator?.voting_power.toLocaleString()})
-          </Typography>
+          <Typography>({validator?.voting_power.toLocaleString()})</Typography>
         )
       }
       withContentPadding={false}
     >
       {typeof validator?.voting_power === 'number' && stats?.total_voting_power && (
-        <div className="flex justify-between">
-          <div className="flex flex-col">
-            <Typography sx={{ fontSize: 12, color: COLORS.grayMedium, textAlign: 'left', paddingBottom: 3 }}>
-              {t('validator.votingPowerOverall')}
-            </Typography>
-            <PercentageValue value={validator.voting_power} total={stats.total_voting_power} />
-          </div>
+        <>
+          <Typography className="font-normal text-xs text-muted-foreground text-left pb-2">
+            {t('validator.votingPowerOverall')}
+          </Typography>
           <div className="pt-4">
-            <VerticalProgressBar
-              height={80}
-              width={50}
-              value={(100 * validator.voting_power) / stats.total_voting_power}
-              barWithBorder={false}
-              barBackgroundColor={COLORS.grayMediumLight}
+            <CustomProgress
+              value={validator.voting_power}
+              max={stats.total_voting_power}
+              label={
+                <span className="font-bold">
+                  <PercentageValue
+                    adaptMaximumFractionDigits
+                    value={validator.voting_power}
+                    total={stats.total_voting_power}
+                    maximumFractionDigits={2}
+                  />
+                </span>
+              }
             />
           </div>
-        </div>
+        </>
       )}
     </SnapshotTextCard>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -200,11 +200,11 @@
     }
   },
   "consensusSnapshot": {
-    "blockHeight": "Block Height <BlockHeight />",
+    "blockHeight": "Current block height <BlockHeight />",
     "title": "Consensus Snapshot",
     "totalCirculation": "This is <StakedPercentage /> of the total circulation"
   },
-  "currentEpoch": "Current Epoch",
+  "snapshotEpochTitle": "Current epoch & block height",
   "networkProposal": {
     "close": "Closed",
     "closeTooltip": "Voting ended on epoch shown.",

--- a/src/styles/theme/defaultTheme.ts
+++ b/src/styles/theme/defaultTheme.ts
@@ -376,20 +376,6 @@ export const defaultTheme = createTheme({
         },
       },
     },
-    MuiLinearProgress: {
-      styleOverrides: {
-        root: {
-          backgroundColor: COLORS.grayLight,
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: COLORS.vistaBlue,
-          borderRadius: 5,
-        },
-        bar: {
-          borderRadius: 5,
-        },
-      },
-    },
     MuiTableContainer: {
       styleOverrides: {
         root: ({ theme }) => ({


### PR DESCRIPTION
Used in:
- Consensus snapshot
https://pr-2235.oasis-explorer.pages.dev/mainnet/consensus
vs https://explorer.dev.oasis.io/mainnet/consensus

- valdiator snapshot
https://pr-2235.oasis-explorer.pages.dev/mainnet/consensus/validators/oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57
vs https://explorer.dev.oasis.io/mainnet/consensus/validators/oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57

- runtime blocks list
https://pr-2235.oasis-explorer.pages.dev/mainnet/sapphire/block
vs https://explorer.dev.oasis.io/mainnet/sapphire/block
