### PR TITLE
Replace MUI ButtonBase with Oasis UI Library component

### DIFF
--- a/.changelog/2236.internal.md
+++ b/.changelog/2236.internal.md
@@ -1,0 +1,1 @@
+Replace MUI ButtonBase with Oasis UI Library component

--- a/src/app/components/CodeDisplay/SimpleJsonCode.tsx
+++ b/src/app/components/CodeDisplay/SimpleJsonCode.tsx
@@ -1,18 +1,25 @@
+import { useState } from 'react'
 import { COLORS } from '../../../styles/theme/colors'
+import { FloatingCopyToClipboard } from '../CopyToClipboard'
 
 export function SimpleJsonCode(props: { data: Record<string, any> }) {
+  const [isHovering, setIsHovering] = useState(false)
+
   return (
-    <textarea
-      readOnly
-      value={JSON.stringify(props.data, null, 2)}
-      style={{
-        width: '100%',
-        height: '350px',
-        color: COLORS.brandExtraDark,
-        background: COLORS.grayLight,
-        borderRadius: '5px',
-        padding: '10px',
-      }}
-    />
+    <div
+      className="flex-1 relative"
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      <FloatingCopyToClipboard isVisible={isHovering} value={JSON.stringify(props.data, null, 2)} />
+      <textarea
+        className="w-full h-[350px] rounded-sm p-3 bg-border"
+        readOnly
+        value={JSON.stringify(props.data, null, 2)}
+        style={{
+          color: COLORS.brandExtraDark,
+        }}
+      />
+    </div>
   )
 }

--- a/src/app/components/CodeDisplay/SimpleJsonCode.tsx
+++ b/src/app/components/CodeDisplay/SimpleJsonCode.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { COLORS } from '../../../styles/theme/colors'
-import { FloatingCopyToClipboard } from '../CopyToClipboard'
+import { CopyToClipboard } from '../CopyToClipboard'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 export function SimpleJsonCode(props: { data: Record<string, any> }) {
   const [isHovering, setIsHovering] = useState(false)
+  const value = JSON.stringify(props.data, null, 2)
 
   return (
     <div
@@ -11,11 +13,17 @@ export function SimpleJsonCode(props: { data: Record<string, any> }) {
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
-      <FloatingCopyToClipboard isVisible={isHovering} value={JSON.stringify(props.data, null, 2)} />
+      <CopyToClipboard
+        className={cn(
+          'absolute right-8 top-4 transition-opacity duration-200 ease-in-out z-10 shadow-md bg-white rounded-full w-10 h-10 flex justify-center ml-0',
+          isHovering ? 'opacity-100' : 'opacity-0',
+        )}
+        value={value}
+      />
       <textarea
         className="w-full h-[350px] rounded-sm p-3 bg-border"
         readOnly
-        value={JSON.stringify(props.data, null, 2)}
+        value={value}
         style={{
           color: COLORS.brandExtraDark,
         }}

--- a/src/app/components/CodeDisplay/index.tsx
+++ b/src/app/components/CodeDisplay/index.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useState, Suspense } from 'react'
+import React, { FC, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
-import { CopyToClipboard, FloatingCopyToClipboard } from '../../components/CopyToClipboard'
+import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useScreenSize } from '../../hooks/useScreensize'
 import { base64ToHex } from '../../utils/helpers'
 import { MonacoLanguages } from './MonacoLanguages'
@@ -43,48 +43,33 @@ type CodeDisplayProps = {
   language: MonacoLanguages
   label?: string
   extraTopPadding?: boolean
-  floatingCopyButton?: boolean
 }
 
-const CodeDisplay: FC<CodeDisplayProps> = ({
-  code,
-  language,
-  label = undefined,
-  extraTopPadding = false,
-  floatingCopyButton = false,
-}) => {
+const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
-  const [isHovering, setIsHovering] = useState(false)
 
   if (!code) {
     return null
   }
 
   return (
-    <Box
-      sx={{ flex: 1, position: 'relative' }}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-    >
+    <Box sx={{ flex: 1, position: 'relative' }}>
       <Box
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          my: floatingCopyButton ? 0 : 3,
-          pt: extraTopPadding ? 4 : 0,
+          my: 3,
+          pt: 0,
         }}
       >
         {label && <Typography variant="h4">{label}</Typography>}
-        {floatingCopyButton ? (
-          <FloatingCopyToClipboard isVisible={isHovering} value={code} />
-        ) : (
-          <CopyToClipboard
-            value={code}
-            label={isMobile ? t('common.copy') : t('contract.copyButton', { subject: label })}
-          />
-        )}
+
+        <CopyToClipboard
+          value={code}
+          label={isMobile ? t('common.copy') : t('contract.copyButton', { subject: label })}
+        />
       </Box>
       <Box sx={{ height: '350px', overflow: 'auto', resize: 'vertical' }}>
         {/* While loading wrapper show <textarea> instead */}
@@ -133,13 +118,10 @@ export const FileDisplay: FC<FileDisplayProps> = ({ code, filename }) => {
 type JsonCodeDisplayProps = {
   data: Record<string, any>
   label?: string
-  floatingCopyButton?: boolean
 }
 
-export const JsonCodeDisplay: FC<JsonCodeDisplayProps> = ({ data, label, floatingCopyButton }) => {
+export const JsonCodeDisplay: FC<JsonCodeDisplayProps> = ({ data, label }) => {
   const formattedJson = JSON.stringify(data, null, 2)
 
-  return (
-    <CodeDisplay code={formattedJson} label={label} floatingCopyButton={floatingCopyButton} language="json" />
-  )
+  return <CodeDisplay code={formattedJson} label={label} language="json" />
 }

--- a/src/app/components/CodeDisplay/index.tsx
+++ b/src/app/components/CodeDisplay/index.tsx
@@ -4,7 +4,6 @@ import Box from '@mui/material/Box'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useScreenSize } from '../../hooks/useScreensize'
-import { base64ToHex } from '../../utils/helpers'
 import { MonacoLanguages } from './MonacoLanguages'
 
 const TextAreaFallback = ({ value }: { value?: string }) => (
@@ -45,7 +44,7 @@ type CodeDisplayProps = {
   extraTopPadding?: boolean
 }
 
-const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }) => {
+export const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }) => {
   const { t } = useTranslation()
   const { isMobile } = useScreenSize()
 
@@ -90,38 +89,4 @@ const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }
       </Box>
     </Box>
   )
-}
-
-type RawDataDisplayProps = {
-  data: string | undefined
-  label: string
-}
-
-export const RawDataDisplay: FC<RawDataDisplayProps> = ({ data, label }) => {
-  const code = data === undefined ? undefined : base64ToHex(data)
-  if (!code) return null
-
-  return <CodeDisplay code={code} label={label} extraTopPadding language="plaintext" />
-}
-
-type FileDisplayProps = {
-  code: string | undefined
-  filename: string
-}
-
-export const FileDisplay: FC<FileDisplayProps> = ({ code, filename }) => {
-  if (!code) return null
-
-  return <CodeDisplay code={code} label={filename} extraTopPadding language="sol" />
-}
-
-type JsonCodeDisplayProps = {
-  data: Record<string, any>
-  label?: string
-}
-
-export const JsonCodeDisplay: FC<JsonCodeDisplayProps> = ({ data, label }) => {
-  const formattedJson = JSON.stringify(data, null, 2)
-
-  return <CodeDisplay code={formattedJson} label={label} language="json" />
 }

--- a/src/app/components/CodeDisplay/index.tsx
+++ b/src/app/components/CodeDisplay/index.tsx
@@ -1,6 +1,5 @@
 import React, { FC, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
-import Box from '@mui/material/Box'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
 import { useScreenSize } from '../../hooks/useScreensize'
@@ -41,7 +40,6 @@ type CodeDisplayProps = {
   code: string
   language: MonacoLanguages
   label?: string
-  extraTopPadding?: boolean
 }
 
 export const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }) => {
@@ -53,24 +51,16 @@ export const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = unde
   }
 
   return (
-    <Box sx={{ flex: 1, position: 'relative' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          my: 3,
-          pt: 0,
-        }}
-      >
+    <div className="flex-1">
+      <div className="flex justify-between items-center my-2 pt-4">
         {label && <Typography variant="h4">{label}</Typography>}
 
         <CopyToClipboard
           value={code}
           label={isMobile ? t('common.copy') : t('contract.copyButton', { subject: label })}
         />
-      </Box>
-      <Box sx={{ height: '350px', overflow: 'auto', resize: 'vertical' }}>
+      </div>
+      <div className="h-[350px] overflow-auto resize-y">
         {/* While loading wrapper show <textarea> instead */}
         <Suspense fallback={<TextAreaFallback value={code} />}>
           <MonacoEditor
@@ -86,7 +76,7 @@ export const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = unde
             }}
           />
         </Suspense>
-      </Box>
-    </Box>
+      </div>
+    </div>
   )
 }

--- a/src/app/components/CopyToClipboard/index.tsx
+++ b/src/app/components/CopyToClipboard/index.tsx
@@ -3,59 +3,18 @@ import { useTranslation } from 'react-i18next'
 import Tooltip from '@mui/material/Tooltip'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import { COLORS } from '../../../styles/theme/colors'
-import ButtonBase from '@mui/material/ButtonBase'
-import { styled } from '@mui/material/styles'
-import Button from '@mui/material/Button'
+import { Button } from '@oasisprotocol/ui-library/src/components/ui/button'
+import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 const clipboardTooltipDuration = 2000
 
 type CopyToClipboardProps = {
-  floating?: boolean
-  isFloatingVisible?: boolean
+  className?: string
   value: string
   label?: string
 }
 
-const StyledIconButton = styled(ButtonBase, {
-  shouldForwardProp: prop => prop !== 'floating' && prop !== 'isFloatingVisible',
-})<{ floating?: boolean; isFloatingVisible?: boolean }>(({ theme, floating, isFloatingVisible }) => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-  border: 0,
-  background: 'none',
-  cursor: 'pointer',
-  fontSize: '14px',
-  fontFamily: 'inherit',
-  padding: 0,
-  marginLeft: theme.spacing(3),
-  ...(floating && {
-    position: 'absolute',
-    right: theme.spacing(5),
-    top: theme.spacing(4),
-    opacity: isFloatingVisible ? 1 : 0,
-    transition: 'opacity 0.2s ease-in-out',
-    zIndex: theme.zIndex.fab,
-    boxShadow: theme.shadows[1],
-    background: COLORS.white,
-    borderRadius: '50%',
-    width: 40,
-    height: 40,
-    display: 'flex',
-    justifyContent: 'center',
-    marginLeft: 0,
-  }),
-}))
-
-type FloatingCopyToClipboardProps = {
-  isVisible: boolean
-  value: string
-}
-
-export const FloatingCopyToClipboard: FC<FloatingCopyToClipboardProps> = ({ isVisible, value }) => {
-  return <CopyToClipboard floating isFloatingVisible={isVisible} value={value} />
-}
-
-export const CopyToClipboard: FC<CopyToClipboardProps> = ({ label, floating, isFloatingVisible, value }) => {
+export const CopyToClipboard: FC<CopyToClipboardProps> = ({ className, label, value }) => {
   const { t } = useTranslation()
   const timeout = useRef<number | undefined>(undefined)
   const ariaLabel = t('clipboard.label')
@@ -84,19 +43,17 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({ label, floating, isF
   return (
     <Tooltip arrow onOpen={hideTooltip} open={isCopied} placement="right" title={t('clipboard.success')}>
       {label ? (
-        <Button variant="outlined" color="secondary" onClick={handleCopyToClipboard} aria-label={ariaLabel}>
+        <Button variant="outline" size="lg" onClick={handleCopyToClipboard} aria-label={ariaLabel}>
           {label}
         </Button>
       ) : (
-        <StyledIconButton
-          floating={floating}
-          isFloatingVisible={isFloatingVisible}
-          color="inherit"
+        <button
           onClick={handleCopyToClipboard}
           aria-label={ariaLabel}
+          className={cn('inline-flex items-center ml-3', className)}
         >
           <ContentCopyIcon sx={{ fontSize: '14px', color: COLORS.brandDark }} />
-        </StyledIconButton>
+        </button>
       )}
     </Tooltip>
   )

--- a/src/app/components/Select/index.tsx
+++ b/src/app/components/Select/index.tsx
@@ -24,8 +24,6 @@ import { useTranslation } from 'react-i18next'
 import { WithOptionalOwnerState } from '@mui/base/utils'
 import { SelectPopupSlotProps, SelectSlots } from '@mui/base/Select/Select.types'
 import { PopupProps } from '@mui/base/Unstable_Popup'
-import { ButtonTypeMap } from '@mui/material/Button/Button'
-import { ExtendButtonBase } from '@mui/material/ButtonBase'
 import { Theme } from '@mui/material/styles/createTheme'
 
 // Props that are not supposed to be passed to the DOM
@@ -36,10 +34,10 @@ const swallowReactProps = {
   shouldForwardProp: (prop: string) => !forbiddenProps.includes(prop),
 }
 
-export const StyledSelectButton = styled<ExtendButtonBase<ButtonTypeMap<{ light?: boolean }>>>(
+export const StyledSelectButton = styled(
   Button,
   swallowReactProps,
-)(({ theme, light }) => ({
+)<{ light?: boolean }>(({ theme, light }) => ({
   height: '36px',
   minWidth: '135px',
   padding: `0 ${theme.spacing(4)}`,

--- a/src/app/pages/NFTInstanceDashboardPage/NFTMetadataCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/NFTMetadataCard.tsx
@@ -5,7 +5,7 @@ import CardContent from '@mui/material/CardContent'
 import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { CardEmptyState } from '../../components/CardEmptyState'
 import { NftDashboardContext } from '../NFTInstanceDashboardPage'
-import { JsonCodeDisplay } from '../../components/CodeDisplay'
+import { CodeDisplay } from '../../components/CodeDisplay'
 import { useNFTInstance } from '../TokenDashboardPage/hook'
 import { metadataContainerId } from '../../utils/tabAnchors'
 
@@ -21,7 +21,11 @@ export const NFTMetadataCard: FC<NftDashboardContext> = ({ scope, address, insta
         {metadata && (
           <CardContent>
             <LinkableDiv id={metadataContainerId}>
-              <JsonCodeDisplay data={metadata} label={t('nft.metadata')} />
+              <CodeDisplay
+                code={JSON.stringify(metadata, null, 2)}
+                label={t('nft.metadata')}
+                language="json"
+              />
             </LinkableDiv>
           </CardContent>
         )}

--- a/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
@@ -6,11 +6,13 @@ import { LinkableDiv } from '../../components/PageLayout/LinkableDiv'
 import { useAccount } from './hook'
 import { CardEmptyState } from '../../components/CardEmptyState'
 import { TokenDashboardContext } from '../TokenDashboardPage'
-import { FileDisplay, RawDataDisplay } from '../../components/CodeDisplay'
+import { CodeDisplay } from '../../components/CodeDisplay'
 import { codeContainerId } from '../../utils/tabAnchors'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { VerificationIcon } from 'app/components/ContractVerificationIcon'
 import { useTokenInfo } from '../TokenDashboardPage/hook'
+import { base64ToHex } from '../../utils/helpers'
+
 export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
 
@@ -90,19 +92,32 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
             )}
 
             {filesSorted?.map((file, index) => (
-              <FileDisplay key={file.path} code={file.content} filename={file.name} />
+              <CodeDisplay key={file.path} code={file.content} label={file.name} language="sol" />
             ))}
 
             {contract.verification?.compilation_metadata && (
-              <FileDisplay
+              <CodeDisplay
                 code={JSON.stringify(contract.verification.compilation_metadata, null, 2)}
-                filename={t('contract.contractMetadata')}
+                label={t('contract.contractMetadata')}
+                language="sol"
               />
             )}
 
-            <RawDataDisplay data={contract.creation_bytecode} label={t('contract.creationByteCode')} />
+            {contract.creation_bytecode && (
+              <CodeDisplay
+                code={base64ToHex(contract.creation_bytecode)}
+                label={t('contract.creationByteCode')}
+                language="plaintext"
+              />
+            )}
 
-            <RawDataDisplay data={contract.runtime_bytecode} label={t('contract.runtimeByteCode')} />
+            {contract.runtime_bytecode && (
+              <CodeDisplay
+                code={base64ToHex(contract.runtime_bytecode)}
+                label={t('contract.runtimeByteCode')}
+                language="plaintext"
+              />
+            )}
           </LinkableDiv>
         </CardContent>
       )}


### PR DESCRIPTION
- remove MUI ButtonBase
- bring back missing CopyToClipboard in SimpleCode component. https://github.com/oasisprotocol/explorer/pull/1979 PR removed usage of "floating" copy to clipboard button. At the same time floating logic was updated in the same PR.
- remove CodeDisplay wrappers 

Affected views
- Bring back copy to clipboard for simpel json previews
https://pr-2236.oasis-explorer.pages.dev/mainnet/sapphire/tx/69a9ad3a7ed55523d636d25852c2f733919c9e8e65ef2035a7f2a9b1e2736313 
vs https://explorer.dev.oasis.io/mainnet/sapphire/tx/69a9ad3a7ed55523d636d25852c2f733919c9e8e65ef2035a7f2a9b1e2736313 
- CodeDisplay buttons
https://pr-2236.oasis-explorer.pages.dev/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520/code#code
vs https://explorer.dev.oasis.io/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520/code#code

https://pr-2236.oasis-explorer.pages.dev/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2/metadata#metadata
vs https://explorer.dev.oasis.io/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2/metadata#metadata

- CopyToClipboard button in various places 
http://localhost:1234/mainnet/consensus/block/26735911
vs https://explorer.dev.oasis.io/mainnet/consensus/block/26735911
