### PR TITLE
Prevent infinite loops in truncated method icons labels

### DIFF
--- a/.changelog/2249.bugfix.md
+++ b/.changelog/2249.bugfix.md
@@ -1,0 +1,1 @@
+Prevent infinite loops in truncated method icons labels

--- a/src/app/components/ConsensusTransactionMethod/index.tsx
+++ b/src/app/components/ConsensusTransactionMethod/index.tsx
@@ -115,18 +115,19 @@ const MethodIconContent: FC<MethodIconContentProps> = ({
 const MethodIconWithTruncatedLabel: FC<MethodIconProps> = props => {
   const elementRef = useRef<HTMLDivElement>(null)
   const [truncate, setTruncate] = useState(false)
-  const [baseLabelWidth, setBaseLabelWidth] = useState(0)
+  const baseLabelWidthRef = useRef(0)
+
   const applyTruncate = useCallback(() => {
     if (elementRef.current) {
       const elementWidth = elementRef.current.offsetWidth
       const parentWidth = (elementRef.current.parentNode as HTMLElement)?.offsetWidth
-      setTruncate(elementWidth === parentWidth || baseLabelWidth > parentWidth)
+      setTruncate(elementWidth === parentWidth || baseLabelWidthRef.current > parentWidth)
     }
-  }, [elementRef, baseLabelWidth])
+  }, [])
 
   useLayoutEffect(() => {
     if (elementRef.current) {
-      setBaseLabelWidth(elementRef.current.offsetWidth)
+      baseLabelWidthRef.current = elementRef.current.offsetWidth
       applyTruncate()
     }
 
@@ -139,7 +140,7 @@ const MethodIconWithTruncatedLabel: FC<MethodIconProps> = props => {
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [applyTruncate, elementRef, props.label, props.size])
+  }, [applyTruncate, props.label, props.size])
 
   return (
     <Tooltip


### PR DESCRIPTION
nav to https://explorer.oasis.io/mainnet/sapphire/tx. Not sure if viewport affects this, but I had devtools open / app viewport <= 850px. switch browser tab. wait unknown number of seconds/minutes to see 

<img width="951" height="707" alt="Screenshot from 2025-10-09 17-59-00" src="https://github.com/user-attachments/assets/953379e6-bb4a-4472-b033-315e5977f34b" />

Using ref instead of state seems Ok. Easier to repro locally 
