### PR TITLE
Remove deprecated label prop from CopyToClipboard

### DIFF
--- a/.changelog/2256.trivial.md
+++ b/.changelog/2256.trivial.md
@@ -1,0 +1,1 @@
+Remove deprecated label prop from CopyToClipboard

--- a/src/app/components/CodeDisplay/index.tsx
+++ b/src/app/components/CodeDisplay/index.tsx
@@ -1,8 +1,6 @@
 import React, { FC, Suspense } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { CopyToClipboard } from '../../components/CopyToClipboard'
-import { useScreenSize } from '../../hooks/useScreensize'
 import { MonacoLanguages } from './MonacoLanguages'
 
 const TextAreaFallback = ({ value }: { value?: string }) => (
@@ -43,22 +41,16 @@ type CodeDisplayProps = {
 }
 
 export const CodeDisplay: FC<CodeDisplayProps> = ({ code, language, label = undefined }) => {
-  const { t } = useTranslation()
-  const { isMobile } = useScreenSize()
-
   if (!code) {
     return null
   }
 
   return (
     <div className="flex-1">
-      <div className="flex justify-between items-center my-2 pt-4">
-        {label && <Typography variant="h4">{label}</Typography>}
+      <div className="flex justify-between items-center mb-4 pt-4 h-13">
+        {label && <Typography className="font-bold">{label}</Typography>}
 
-        <CopyToClipboard
-          value={code}
-          label={isMobile ? t('common.copy') : t('contract.copyButton', { subject: label })}
-        />
+        <CopyToClipboard value={code} />
       </div>
       <div className="h-[350px] overflow-auto resize-y">
         {/* While loading wrapper show <textarea> instead */}

--- a/src/app/components/CopyToClipboard/index.tsx
+++ b/src/app/components/CopyToClipboard/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import Tooltip from '@mui/material/Tooltip'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import { COLORS } from '../../../styles/theme/colors'
-import { Button } from '@oasisprotocol/ui-library/src/components/ui/button'
 import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 
 const clipboardTooltipDuration = 2000
@@ -11,10 +10,9 @@ const clipboardTooltipDuration = 2000
 type CopyToClipboardProps = {
   className?: string
   value: string
-  label?: string
 }
 
-export const CopyToClipboard: FC<CopyToClipboardProps> = ({ className, label, value }) => {
+export const CopyToClipboard: FC<CopyToClipboardProps> = ({ className, value }) => {
   const { t } = useTranslation()
   const timeout = useRef<number | undefined>(undefined)
   const ariaLabel = t('clipboard.label')
@@ -42,19 +40,13 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({ className, label, va
 
   return (
     <Tooltip arrow onOpen={hideTooltip} open={isCopied} placement="right" title={t('clipboard.success')}>
-      {label ? (
-        <Button variant="outline" size="lg" onClick={handleCopyToClipboard} aria-label={ariaLabel}>
-          {label}
-        </Button>
-      ) : (
-        <button
-          onClick={handleCopyToClipboard}
-          aria-label={ariaLabel}
-          className={cn('inline-flex items-center ml-3', className)}
-        >
-          <ContentCopyIcon sx={{ fontSize: '14px', color: COLORS.brandDark }} />
-        </button>
-      )}
+      <button
+        onClick={handleCopyToClipboard}
+        aria-label={ariaLabel}
+        className={cn('inline-flex items-center ml-3', className)}
+      >
+        <ContentCopyIcon sx={{ fontSize: '14px', color: COLORS.brandDark }} />
+      </button>
     </Tooltip>
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/ContractCodeCard.tsx
@@ -12,6 +12,7 @@ import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import { VerificationIcon } from 'app/components/ContractVerificationIcon'
 import { useTokenInfo } from '../TokenDashboardPage/hook'
 import { base64ToHex } from '../../utils/helpers'
+import { Separator } from '@oasisprotocol/ui-library/src/components/ui/separator'
 
 export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) => {
   const { t } = useTranslation()
@@ -48,7 +49,7 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
                 </Typography>
 
                 <dl className="grid grid-cols-[max-content_1fr] items-baseline gap-y-3">
-                  <dt className="mx-6">
+                  <dt className="mx-6 py-2">
                     <Typography>{t('contract.verification.title')}</Typography>
                   </dt>
                   <dd className="flex items-center">
@@ -62,7 +63,7 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
 
                   {contract.verification?.compilation_metadata?.settings?.compilationTarget && (
                     <>
-                      <dt className="mx-6">
+                      <dt className="mx-6 py-2">
                         <Typography>{t('contract.name')}</Typography>
                       </dt>
                       <dd>
@@ -79,7 +80,7 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
 
                   {token?.name && (
                     <>
-                      <dt className="mx-6">
+                      <dt className="mx-6 py-2">
                         <Typography>{t('common.tokenName')}</Typography>
                       </dt>
                       <dd>
@@ -88,6 +89,7 @@ export const ContractCodeCard: FC<TokenDashboardContext> = ({ scope, address }) 
                     </>
                   )}
                 </dl>
+                <Separator className="my-4" />
               </>
             )}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -73,7 +73,6 @@
     "bytes": "{{value, number}}",
     "cancel": "Cancel",
     "collection": "Collection",
-    "copy": "Copy",
     "data": "Data",
     "debonding": "Debonding",
     "description": "Description",
@@ -176,7 +175,6 @@
   "contract": {
     "code": "Code",
     "contractMetadata": "Contract Metadata",
-    "copyButton": "Copy {{subject}}",
     "creationByteCode": "Creation ByteCode",
     "creator": "Creator",
     "createdAt": "at",


### PR DESCRIPTION
in new designs we don't use "large buttons with custom labels" in CopyToClipboard component