### PR TITLE
Fix mobile contract badge in tokens list

### DIFF
--- a/.changelog/2259.bugfix.md
+++ b/.changelog/2259.bugfix.md
@@ -1,0 +1,1 @@
+Fix mobile contract badge in tokens list

--- a/src/app/components/ContractVerificationIcon/index.tsx
+++ b/src/app/components/ContractVerificationIcon/index.tsx
@@ -7,7 +7,6 @@ import { SearchScope } from '../../../types/searchScope'
 import * as externalLinks from '../../utils/externalLinks'
 import { isLocalnet } from '../../utils/route-utils'
 import { AbiPlaygroundLink } from './AbiPlaygroundLink'
-import Tooltip from '@mui/material/Tooltip'
 import { Badge } from '@oasisprotocol/ui-library/src/components/badge'
 
 export const verificationIconBoxHeight = 28
@@ -17,8 +16,7 @@ export const VerificationIcon: FC<{
   scope: SearchScope
   verificationLevel?: 'full' | 'partial'
   hideLink?: boolean
-  hideLabel?: boolean
-}> = ({ address_eth, scope, verificationLevel, hideLink, hideLabel }) => {
+}> = ({ address_eth, scope, verificationLevel, hideLink }) => {
   const { t } = useTranslation()
   const [explainDelay, setExplainDelay] = useState(false)
   if (isLocalnet(scope.network)) {
@@ -42,11 +40,9 @@ export const VerificationIcon: FC<{
   }
   return (
     <>
-      <Tooltip placement="top" arrow title={hideLabel ? label : undefined}>
-        <Link {...sourcifyLinkProps}>
-          <Badge variant={statusVariant}>{hideLabel ? '' : label}</Badge>
-        </Link>
-      </Tooltip>
+      <Link {...sourcifyLinkProps}>
+        <Badge variant={statusVariant}>{label}</Badge>
+      </Link>
       {!hideLink &&
         (verificationLevel ? (
           <Typography component="span" sx={{ fontSize: '12px', color: COLORS.brandExtraDark }}>

--- a/src/app/components/Tokens/TokenList.tsx
+++ b/src/app/components/Tokens/TokenList.tsx
@@ -8,7 +8,6 @@ import { CopyToClipboard } from '../CopyToClipboard'
 import { VerificationIcon } from '../ContractVerificationIcon'
 import { FC } from 'react'
 import { RoundedBalance } from '../RoundedBalance'
-import { useScreenSize } from 'app/hooks/useScreensize'
 import { Badge } from '@oasisprotocol/ui-library/src/components/badge'
 
 type TokensProps = {
@@ -41,7 +40,6 @@ export const TokenTypeTag: FC<{ tokenType: EvmTokenType | undefined }> = ({ toke
 export const TokenList = (props: TokensProps) => {
   const { isLoading, tokens, pagination, limit } = props
   const { t } = useTranslation()
-  const { isMobile } = useScreenSize()
   const tableColumns: TableColProps[] = [
     { key: 'index', content: '' },
     { key: 'name', content: t('common.name') },
@@ -50,7 +48,7 @@ export const TokenList = (props: TokensProps) => {
     { key: 'contract', content: t('common.smartContract') },
     {
       key: 'verification',
-      content: isMobile ? t('contract.verification.sourceShort') : t('contract.verification.source'),
+      content: t('contract.verification.source'),
     },
     {
       key: 'holders',
@@ -115,7 +113,6 @@ export const TokenList = (props: TokensProps) => {
               scope={token}
               verificationLevel={token.verification_level}
               hideLink
-              hideLabel={isMobile}
             />
           ),
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -191,7 +191,6 @@
       "openInAbiPlayground": "Interact in <AbiPlaygroundLink>ABI Playground</AbiPlaygroundLink>",
       "openInSourcify": "Open in <SourcifyLink>Sourcify</SourcifyLink>",
       "source": "Source",
-      "sourceShort": "Src",
       "verifyInSourcify": "Verify through <SourcifyLink>Sourcify</SourcifyLink>",
       "explainVerificationDelay": "If you have just verified a contract, it should take a few minutes to update here.",
       "proxyERC1167": "ERC-1167 proxy to"


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/explorer/pull/2121 
Reverts https://github.com/oasisprotocol/explorer/pull/2003 ~or waits for new contract status icons designs~

~Waits for Don's feedback~

Design feedback: `removing the labels doesn’t reduce the table width that much so unless we do a bigger exercise to optimise mobile we can keep labels.`
- https://pr-2259.oasis-explorer.pages.dev/mainnet/sapphire/token (mobile)
vs https://explorer.oasis.io/mainnet/sapphire/token (mobile)