### PR TITLE
Fix block details display (remove "0" breaking the table structure)

### DIFF
--- a/.changelog/2265.trivial.md
+++ b/.changelog/2265.trivial.md
@@ -1,0 +1,1 @@
+Fix block details display (remove "0" breaking the table structure)

--- a/src/app/pages/ConsensusBlockDetailPage/index.tsx
+++ b/src/app/pages/ConsensusBlockDetailPage/index.tsx
@@ -161,7 +161,7 @@ export const ConsensusBlockDetailView: FC<{
         </>
       )}
 
-      {block.gas_limit && (
+      {!!block.gas_limit && (
         <>
           <dt>{t('common.gasLimit')}</dt>
           <dd>


### PR DESCRIPTION
Related https://github.com/oasisprotocol/explorer/issues/259

https://explorer.dev.oasis.io/search?q=8586817
Before | After
<img width="999" height="691" alt="image" src="https://github.com/user-attachments/assets/d575862d-618d-47b3-ba8f-44881b44b117" />
