### PR TITLE
Remove usage of MUI GlobalStyles

### DIFF
--- a/.changelog/2324.internal.md
+++ b/.changelog/2324.internal.md
@@ -1,0 +1,1 @@
+Remove usage of MUI GlobalStyles

--- a/src/app/components/PageLayout/LinkableDiv.tsx
+++ b/src/app/components/PageLayout/LinkableDiv.tsx
@@ -1,4 +1,3 @@
-import GlobalStyles from '@mui/material/GlobalStyles'
 import { FC, useEffect, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
@@ -26,11 +25,5 @@ export const LinkableDiv: FC<JSX.IntrinsicElements['div'] & { id: string }> = pr
     }
   }, [id, hash, element])
 
-  return (
-    <>
-      {/* Don't scroll the target underneath sticky Header */}
-      <GlobalStyles styles="html { scroll-padding-top: 180px; }" />
-      <div {...props} ref={divRef} />
-    </>
-  )
+  return <div {...props} ref={divRef} />
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,6 +4,8 @@
 
 html {
   scroll-behavior: smooth;
+  /* Don't scroll the target underneath sticky Header */
+  scroll-padding-top: 180px;
 }
 
 /** Use Inter for "…" instead of Roboto Mono. */
@@ -12,7 +14,8 @@ html {
   font-style: normal;
   font-display: swap;
   font-weight: 100 700;
-  src: url('../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2') format('woff2');  
+  src: url('../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2')
+    format('woff2');
   unicode-range: U+2026;
 }
 


### PR DESCRIPTION
click transfers in details section to trigget scroll (table header and tabs should he visible)
https://pr-2324.oasis-explorer.pages.dev/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520
vs
https://explorer.dev.oasis.io/mainnet/sapphire/token/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520