### PR TITLE
Remove usage of MUI CssBaseline

### DIFF
--- a/.changelog/2333.internal.md
+++ b/.changelog/2333.internal.md
@@ -1,0 +1,1 @@
+Remove usage of MUI CssBaseline

--- a/src/app/components/AnalyticsConsent/index.tsx
+++ b/src/app/components/AnalyticsConsent/index.tsx
@@ -64,7 +64,7 @@ export const AnalyticsConsentProvider = (props: { children: React.ReactNode }) =
     >
       {props.children}
       {/* Theme is needed because AnalyticsConsentProvider is outside network-themed routes */}
-      <ThemeByScope isRootTheme={false} network={'mainnet'}>
+      <ThemeByScope network={'mainnet'}>
         <AnalyticsConsentView
           isOpen={hasAccepted === 'not-chosen'}
           onAccept={async () => {

--- a/src/app/components/ThemeByScope/index.tsx
+++ b/src/app/components/ThemeByScope/index.tsx
@@ -2,24 +2,19 @@ import { FC, ReactNode } from 'react'
 import { Network } from '../../../types/network'
 import { ThemeProvider } from '@mui/material/styles'
 import { getThemeForScope } from '../../../styles/theme'
-import CssBaseline from '@mui/material/CssBaseline'
 import { fixedNetwork } from '../../utils/route-utils'
 import { Layer } from '../../../oasis-nexus/api'
 
 export const ThemeByScope: FC<{
   network: Network
   layer?: Layer
-  isRootTheme: boolean
   children: React.ReactNode
-}> = ({ network, layer, isRootTheme, children }) => (
+}> = ({ network, layer, children }) => (
   <ThemeProvider theme={getThemeForScope(network, layer)}>
-    {isRootTheme && <CssBaseline />}
     <div className={network}>{children}</div>
   </ThemeProvider>
 )
 
 export const withDefaultTheme = (node: ReactNode, alwaysMainnet = false) => (
-  <ThemeByScope isRootTheme={true} network={alwaysMainnet ? 'mainnet' : (fixedNetwork ?? 'mainnet')}>
-    {node}
-  </ThemeByScope>
+  <ThemeByScope network={alwaysMainnet ? 'mainnet' : (fixedNetwork ?? 'mainnet')}>{node}</ThemeByScope>
 )

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -88,7 +88,7 @@ export const HomePage: FC = () => {
               </Button>
             )}
           </div>
-          <ThemeByScope isRootTheme={false} network={network}>
+          <ThemeByScope network={network}>
             <div className="z-0">
               <ParaTimeSelector
                 step={step}

--- a/src/app/pages/RoutingErrorPage/index.tsx
+++ b/src/app/pages/RoutingErrorPage/index.tsx
@@ -9,7 +9,7 @@ import { LayoutDivider } from '../../components/Divider'
 export const RoutingErrorPage: FC = () => {
   const scope = useScopeParam()
   return (
-    <ThemeByScope isRootTheme={true} network={scope?.network ?? 'mainnet'} layer={scope?.layer}>
+    <ThemeByScope network={scope?.network ?? 'mainnet'} layer={scope?.layer}>
       <PageLayout>
         <LayoutDivider />
         <ErrorDisplay error={useRouteError()} />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -80,7 +80,7 @@ import { RoflAppInstanceRakTransactionsCard } from 'app/pages/RoflAppInstanceDet
 const ScopeSpecificPart = () => {
   const { network, layer } = useRequiredScopeParam()
   return (
-    <ThemeByScope isRootTheme={true} network={network} layer={layer}>
+    <ThemeByScope network={network} layer={layer}>
       <Outlet />
     </ThemeByScope>
   )

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,6 +6,10 @@ html {
   scroll-behavior: smooth;
   /* Don't scroll the target underneath sticky Header */
   scroll-padding-top: 180px;
+  /* TODO: Remove when Oasis UI library use variable fonts */
+  font-family: 'Inter Variable', Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
 }
 
 /** Use Inter for "…" instead of Roboto Mono. */


### PR DESCRIPTION
I did not found any issues except base fonts set by MUI (in other cases tailwind already took control over styling). In our case Oasis UI Lib system Inter is slightly diff than variable font rendering. 
I guess we want to use variable fonts in UIL at some point, right?