### PR TITLE
Align Recharts tooltip with design guide

### DIFF
--- a/.changelog/2340.trivial.md
+++ b/.changelog/2340.trivial.md
@@ -1,0 +1,1 @@
+Align Recharts tooltip with design guide

--- a/src/app/components/charts/Tooltip.tsx
+++ b/src/app/components/charts/Tooltip.tsx
@@ -1,5 +1,4 @@
 import { TooltipProps } from 'recharts'
-import { COLORS } from 'styles/theme/colors'
 
 export type Formatters = {
   formatters?: {
@@ -26,14 +25,11 @@ export const TooltipContent = ({
   const labelKey = dataLabelKey || Object.keys(rest)[0]
 
   return (
-    <div
-      className="inline-flex flex-col px-5 py-3 shadow-lg rounded-lg text-white text-center"
-      style={{ backgroundColor: COLORS.spaceCadet }}
-    >
-      <span className="text-xs">
+    <div className="inline-flex flex-col rounded-md px-3 py-1.5 text-pretty bg-popover border text-popover-foreground text-sm shadow-md">
+      <span>
         {formatters?.label ? formatters.label(payload[0].payload[labelKey]) : payload[0].payload[labelKey]}
       </span>
-      <span className="text-xs font-semibold">
+      <span className="font-semibold">
         {formatters?.data ? formatters.data(payload[0].value!, payload[0].payload.payload) : payload[0].value}
       </span>
     </div>

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -27,7 +27,6 @@ export const COLORS = {
   linen: '#fae8e8',
   platinum: '#e2e2e2',
   white: '#ffffff',
-  spaceCadet: '#0f0f5f',
   disabledPrimaryBackground: '#acadb0',
   disabledPrimaryText: '#d5d6d7',
   errorIndicatorBackground: '#d44c4c',


### PR DESCRIPTION
note: styles follows design guide and UI Lib. New Explorer designs use diff colors and font sizes for chart tooltips, but imo it's better to keep tooltip consistent across app. 

any chart
https://pr-2340.oasis-explorer.pages.dev/mainnet/consensus
vs https://explorer.dev.oasis.io/mainnet/consensus