### PR TITLE
Tweaks around ROFL apps search results

### DIFF
--- a/.changelog/2358.trivial.md
+++ b/.changelog/2358.trivial.md
@@ -1,0 +1,1 @@
+Tweaks around ROFL apps search results

--- a/src/app/pages/RoflAppDetailsPage/index.tsx
+++ b/src/app/pages/RoflAppDetailsPage/index.tsx
@@ -200,12 +200,20 @@ export const RoflAppDetailsViewSearchResult: FC<{
 
   return (
     <StyledDescriptionList>
+      <dt>{t('common.name')}</dt>
+      <dd>
+        <RoflAppLink
+          id={app.id}
+          name={app.metadata['net.oasis.rofl.name']}
+          network={app.network}
+          withSourceIndicator={false}
+        />
+        <CopyToClipboard value={app.metadata['net.oasis.rofl.name']} />
+      </dd>
       <DetailsRow title={t('common.paratime')}>
         <DashboardLink scope={{ network: app.network, layer: app.layer }} />
       </DetailsRow>
-      <NameRow name={app.metadata['net.oasis.rofl.name']} />
       <VersionRow version={app.metadata['net.oasis.rofl.version']} />
-      <TeeRow policy={app.policy} />
       <DetailsRow title={t('rofl.appId')}>
         <RoflAppLink id={app.id} name={app.id} network={app.network} withSourceIndicator={false} />
         <CopyToClipboard value={app.id} />
@@ -216,7 +224,6 @@ export const RoflAppDetailsViewSearchResult: FC<{
       />
       <StakedAmountRow stake={app.stake} ticker={app.ticker} />
       <StatusBadgeRow hasActiveInstances={!!app.num_active_instances} removed={app.removed} />
-      <ActiveInstancesNumberRow number={app.num_active_instances} />
       <LastActivityRow
         scope={{ network: app.network, layer: app.layer }}
         transaction={app.last_activity_tx}

--- a/src/app/pages/SearchResultsPage/ResultsGroupByType.tsx
+++ b/src/app/pages/SearchResultsPage/ResultsGroupByType.tsx
@@ -32,7 +32,7 @@ export function ResultsGroupByType<T>({ title, results, resultComponent, link, l
       {results.map((item, i) => (
         <div key={i}>
           {resultComponent(item)}
-          <div className="flex justify-center mt-7">
+          <div className="flex justify-center mt-2">
             <Button asChild size="lg">
               <RouterLink to={link(item)}>{linkLabel}</RouterLink>
             </Button>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -838,8 +838,8 @@
         "viewLink": "View Transaction"
       },
       "roflApps": {
-        "title": "ROFL",
-        "viewLink": "View ROFL App"
+        "title": "ROFL-Powered Apps",
+        "viewLink": "View App"
       },
       "proposals": {
         "title": "Proposals",


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/explorer/issues/2357

- we need to keep "View App" button to keep search consistent. I am not sure removing it everywhere is expected.
- keeping "ParaTime" line below app name. Scoped search return all networks for a given layer + global search return all networks for all layers. It is easy for users to get lost without this row.
- name copy to clipboard copies app id, right?

global search
https://pr-2358.oasis-explorer.pages.dev/search?q=demo-rofl

testnet scoped search (mainnet still avail at the bottom/collapsible section)
https://pr-2358.oasis-explorer.pages.dev/testnet/sapphire/search?q=demo-rofl