### PR TITLE
Limit usage of MUI icons

### DIFF
--- a/.changelog/2376.trivial.md
+++ b/.changelog/2376.trivial.md
@@ -1,0 +1,1 @@
+Limit usage of MUI icons

--- a/src/app/components/CurrentFiatValue/index.tsx
+++ b/src/app/components/CurrentFiatValue/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { FiatMoneyWarning } from '../Balance/FiatMoneyAmount'
 import { Tooltip } from '@oasisprotocol/ui-library/src/components/tooltip'
 import { CoinGeckoReferral } from '../CoinGeckoReferral'
-import HelpIcon from '@mui/icons-material/Help'
+import { CircleHelp } from 'lucide-react'
 import { TokenPriceInfo } from '../../../coin-gecko/api'
 import BigNumber from 'bignumber.js'
 
@@ -37,7 +37,7 @@ export const CurrentFiatValue: FC<CurrentFiatValueProps> = ({
             })}
             &nbsp;
             <Tooltip title={t('currentFiatValue.explanation')}>
-              <HelpIcon />
+              <CircleHelp size={20} />
             </Tooltip>
           </>
         )}

--- a/src/app/components/EmptyState/index.tsx
+++ b/src/app/components/EmptyState/index.tsx
@@ -1,8 +1,8 @@
 import { FC, ReactNode } from 'react'
 import lightBackgroundEmptyState from './images/background-empty-state.svg'
 import darkBackgroundEmptyState from './images/background-empty-state-dark.svg'
-import CancelIcon from '@mui/icons-material/Cancel'
 import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
+import { CircleX } from 'lucide-react'
 
 type EmptyStateProps = {
   description: ReactNode
@@ -23,7 +23,7 @@ export const EmptyState: FC<EmptyStateProps> = ({ description, title, light, min
       className="flex flex-col items-center justify-center bg-no-repeat bg-cover bg-center h-full"
       style={{ backgroundImage: `url(${lightBackgroundEmptyState})`, minHeight }}
     >
-      <CancelIcon color="error" fontSize="large" />
+      <CircleX size={32} className="text-destructive" />
       {content}
     </div>
   ) : (

--- a/src/app/components/NoPreview/index.tsx
+++ b/src/app/components/NoPreview/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import NotInterestedIcon from '@mui/icons-material/NotInterested'
+import { Ban } from 'lucide-react'
 
 type NoPreviewProps = {
   placeholderSize: string
@@ -17,7 +17,7 @@ export const NoPreview: FC<NoPreviewProps> = ({ placeholderSize }) => {
         width: placeholderSize,
       }}
     >
-      <NotInterestedIcon sx={{ fontSize: '60px', color: '#A7A7A7' }} />
+      <Ban size={50} color="#A7A7A7" />
       {t('nft.noPreview')}
     </div>
   )

--- a/src/app/components/RuntimeEvents/EventError.tsx
+++ b/src/app/components/RuntimeEvents/EventError.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import CancelIcon from '@mui/icons-material/Cancel'
 import { RuntimeEvent } from '../../../oasis-nexus/api'
 import { StatusDetails, StatusBadge } from '../StatusIcon'
+import { CircleX } from 'lucide-react'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { RuntimeEventType } from '../../../oasis-nexus/api'
@@ -36,7 +36,7 @@ export const EventError: FC<EventErrorProps> = ({ event }) => {
       <StatusBadge status="failure" withText>
         {t('common.failed')}
         &nbsp;
-        <CancelIcon color="error" fontSize="inherit" />
+        <CircleX size={14} className="fill-destructive" />
       </StatusBadge>
       <StatusDetails error>{errorMessage}</StatusDetails>
     </>

--- a/src/app/components/Validators/ValidatorImage.tsx
+++ b/src/app/components/Validators/ValidatorImage.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import ImageNotSupportedIcon from '@mui/icons-material/ImageNotSupported'
+import { ImageOff } from 'lucide-react'
 import { isUrlSafe } from '../../utils/url'
 import { COLORS } from 'styles/theme/colors'
 
@@ -16,7 +16,7 @@ export const ValidatorImage: FC<ValidatorImageProps> = ({ address, name, logotyp
         <img alt={name || address} src={logotype} className="w-7 h-7 rounded-md" />
       ) : (
         <div className="w-8 h-8 flex justify-center items-center text-inherit rounded-full bg-gray-200">
-          <ImageNotSupportedIcon sx={{ color: COLORS.grayMedium, fontSize: 18 }} />
+          <ImageOff color={COLORS.grayMedium} size={18} />
         </div>
       )}
     </>

--- a/src/app/components/charts/PieChart.tsx
+++ b/src/app/components/charts/PieChart.tsx
@@ -1,7 +1,6 @@
 import { FC, memo, ReactNode, useState } from 'react'
 import { Legend, ResponsiveContainer, Tooltip, PieChart as RechartsPieChart, Pie, Cell } from 'recharts'
 import { useTranslation } from 'react-i18next'
-import CircleIcon from '@mui/icons-material/Circle'
 import { TooltipContent, type Formatters } from './Tooltip'
 import { COLORS } from '../../../styles/theme/colors'
 import { Props } from 'recharts/types/component/DefaultLegendContent'
@@ -35,7 +34,10 @@ const LegendListItem: FC<LegendListItemProps> = ({ children, compact, isActive, 
         )}
         style={isActive && color ? { backgroundColor: `${color}40` } : undefined}
       >
-        <CircleIcon sx={{ color: color || COLORS.grayMedium, fontSize: compact ? 12 : 18 }} />
+        <div
+          className={cn('rounded-full', compact ? 'w-[10px] h-[10px]' : 'w-[15px] h-[15px]')}
+          style={{ backgroundColor: color || COLORS.grayMedium }}
+        />
       </div>
       <span
         className={cn(

--- a/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountCardEmptyState.tsx
+++ b/src/app/pages/ConsensusAccountDetailsPage/ConsensusAccountCardEmptyState.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
-import StackedBarChartIcon from '@mui/icons-material/StackedBarChart'
+import { ChartColumnDecreasing } from 'lucide-react'
 import { COLORS } from '../../../styles/theme/colors'
 
 type ConsensusAccountCardEmptyStateProps = {
@@ -14,7 +14,7 @@ export const ConsensusAccountCardEmptyState: FC<ConsensusAccountCardEmptyStatePr
 }) => {
   return (
     <div className="flex flex-col justify-center items-center gap-2 text-center min-h-36 pt-2 sm:pt-16 sm:min-h-48">
-      <StackedBarChartIcon sx={{ color: COLORS.grayMedium, fontSize: 40, opacity: 0.5 }} />
+      <ChartColumnDecreasing size={36} color={COLORS.grayMedium} className="opacity-50" />
       <Typography textColor="muted" className="font-semibold text-center">
         {label}
       </Typography>

--- a/src/app/pages/ConsensusDashboardPage/RuntimePreview.tsx
+++ b/src/app/pages/ConsensusDashboardPage/RuntimePreview.tsx
@@ -6,7 +6,6 @@ import { Link } from '@oasisprotocol/ui-library/src/components/link'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
 import FilterNoneIcon from '@mui/icons-material/FilterNone'
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked'
-import CircleIcon from '@mui/icons-material/Circle'
 import { Runtime, useGetRuntimeStatus } from 'oasis-nexus/api'
 import { COLORS } from '../../../styles/theme/colors'
 import { useRuntimeFreshness } from '../../components/OfflineBanner/hook'
@@ -242,7 +241,7 @@ const PanelButton: FC<PanelButtonProps> = ({ activePanel, ariaLabel, panel, setP
       className="hover:bg-black/[0.04] rounded-full w-[26px] h-[26px]"
     >
       {panel === activePanel ? (
-        <CircleIcon sx={{ color: COLORS.brandDark, fontSize: '10px' }} />
+        <div className="rounded-full w-[10px] h-[10px] bg-chart-5" />
       ) : (
         <RadioButtonUncheckedIcon sx={{ color: COLORS.brandDark, fontSize: '10px' }} />
       )}

--- a/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
+++ b/src/app/pages/NFTInstanceDashboardPage/InstanceImageCard.tsx
@@ -2,17 +2,16 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@oasisprotocol/ui-library/src/components/ui/button'
 import { Card, CardContent } from '@oasisprotocol/ui-library/src/components/cards'
-import ContrastIcon from '@mui/icons-material/Contrast'
 import { Link } from '@oasisprotocol/ui-library/src/components/link'
 import { Skeleton } from '@oasisprotocol/ui-library/src/components/ui/skeleton'
 import { Tooltip } from '@oasisprotocol/ui-library/src/components/tooltip'
-import OpenInFullIcon from '@mui/icons-material/OpenInFull'
 import { EvmNft } from 'oasis-nexus/api'
 import { processNftImageUrl } from '../../utils/nft-images'
 import { isUrlSafe } from '../../utils/url'
 import { ImagePreview } from '../../components/ImagePreview'
 import { NoPreview } from '../../components/NoPreview'
 import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
+import { Contrast, Maximize2 } from 'lucide-react'
 
 const imageSize = '350px'
 
@@ -35,7 +34,7 @@ const DarkModeSwitch: FC<{ darkMode: boolean; onSetDarkMode: (darkMode: boolean)
             : 'bg-muted text-foreground hover:bg-muted/70',
         )}
       >
-        <ContrastIcon />
+        <Contrast />
       </Button>
     </Tooltip>
   )
@@ -56,7 +55,7 @@ const FullScreenButton: FC<{ darkMode: boolean; onClick: () => void }> = ({ dark
             : 'bg-muted text-foreground hover:bg-muted/70',
         )}
       >
-        <OpenInFullIcon />
+        <Maximize2 />
       </Button>
     </Tooltip>
   )

--- a/src/app/pages/ProposalDetailsPage/index.tsx
+++ b/src/app/pages/ProposalDetailsPage/index.tsx
@@ -1,8 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tooltip } from '@oasisprotocol/ui-library/src/components/tooltip'
-import { Info } from 'lucide-react'
-import CancelIcon from '@mui/icons-material/Cancel'
+import { Info, CircleX } from 'lucide-react'
 import { useConsensusScope } from '../../hooks/useScopeParam'
 import { Proposal, useGetConsensusProposalsProposalId } from '../../../oasis-nexus/api'
 import { AppErrors } from '../../../types/errors'
@@ -56,7 +55,7 @@ const VoteLoadingProblemIndicator: FC = () => {
   const { t } = useTranslation()
   return (
     <Tooltip title={t('networkProposal.failedToLoadAllVotes')}>
-      <CancelIcon color="error" fontSize="inherit" sx={{ ml: 2 }} />
+      <CircleX size={14} className="ml-4 text-destructive" />
     </Tooltip>
   )
 }

--- a/src/app/pages/RuntimeAccountDetailsPage/AccountCardEmptyState.tsx
+++ b/src/app/pages/RuntimeAccountDetailsPage/AccountCardEmptyState.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react'
 import { Typography } from '@oasisprotocol/ui-library/src/components/typography'
-import StackedBarChartIcon from '@mui/icons-material/StackedBarChart'
+import { ChartColumnDecreasing } from 'lucide-react'
+
 import { COLORS } from '../../../styles/theme/colors'
 
 type AccountCardEmptyStateProps = {
@@ -11,7 +12,7 @@ type AccountCardEmptyStateProps = {
 export const AccountCardEmptyState: FC<AccountCardEmptyStateProps> = ({ children, label }) => {
   return (
     <div className="flex flex-col justify-center items-center gap-2 text-center pt-1 pb-2">
-      <StackedBarChartIcon sx={{ color: COLORS.grayMedium, fontSize: 40, opacity: 0.5 }} />
+      <ChartColumnDecreasing size={36} color={COLORS.grayMedium} className="opacity-50" />
       <Typography textColor="muted" className="font-semibold text-center">
         {label}
       </Typography>

--- a/src/app/pages/SearchResultsPage/ShowMoreResults.tsx
+++ b/src/app/pages/SearchResultsPage/ShowMoreResults.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react'
-import ZoomOut from '@mui/icons-material/ZoomOut'
 import { Trans, useTranslation } from 'react-i18next'
-import ZoomIn from '@mui/icons-material/ZoomIn'
+import { ZoomIn, ZoomOut } from 'lucide-react'
 
 export const HideMoreResults: FC<{ onHide: () => void }> = ({ onHide }) => {
   return (
@@ -9,7 +8,7 @@ export const HideMoreResults: FC<{ onHide: () => void }> = ({ onHide }) => {
       className="w-[90%] mx-auto md:w-full flex justify-center items-center gap-1 p-4 leading-tight my-8 rounded-md box-border bg-[#F4F4F5] hover:bg-[#DDDDDE] cursor-pointer"
       onClick={onHide}
     >
-      <ZoomOut />
+      <ZoomOut size={18} />
       <span>
         <Trans i18nKey="search.otherResults.clickToHide" />
       </span>
@@ -28,7 +27,7 @@ export const ShowMoreResults: FC<{
       className="w-[90%] mx-auto md:w-full flex justify-center items-center gap-1 p-4 leading-tight my-8 rounded-md box-border bg-[#F4F4F5] hover:bg-[#DDDDDE] cursor-pointer"
       onClick={onShow}
     >
-      <ZoomIn />
+      <ZoomIn size={18} />
       <span>
         <Trans
           t={t}

--- a/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
+++ b/src/app/pages/TokenDashboardPage/ImageListItemImage.tsx
@@ -2,13 +2,13 @@ import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import { Link } from '@oasisprotocol/ui-library/src/components/link'
-import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
 import { processNftImageUrl } from 'app/utils/nft-images'
 import { isUrlSafe } from 'app/utils/url'
 import { NoPreview } from '../../components/NoPreview'
 import { getNftInstanceLabel } from '../../utils/nft'
 import { EvmNft } from '../../../oasis-nexus/api'
 import { useScreenSize } from 'app/hooks/useScreensize'
+import { MonitorUp } from 'lucide-react'
 
 const minMobileSize = '150px'
 const minSize = '210px'
@@ -43,7 +43,7 @@ export const ImageListItemImage: FC<ImageListItemImageProps> = ({ instance, to }
           <NoPreview placeholderSize={isMobile ? minMobileSize : minSize} />
         )}
         <div className="absolute inset-0 flex flex-col justify-center items-center gap-2 text-sm font-medium text-white opacity-0 hover:opacity-100 focus-visible:opacity-100 transition-opacity transition-colors duration-300 hover:bg-black/80 focus-visible:bg-black/80">
-          <OpenInBrowserIcon sx={{ fontSize: '40px' }} />
+          <MonitorUp size={40} />
           {t('common.view')}
         </div>
       </RouterLink>

--- a/src/app/utils/content.tsx
+++ b/src/app/utils/content.tsx
@@ -4,7 +4,7 @@ import { Layer } from '../../oasis-nexus/api'
 import { Network } from '../../types/network'
 import { MainnetIcon } from '../components/CustomIcons/Mainnet'
 import { TestnetIcon } from '../components/CustomIcons/Testnet'
-import ConstructionIcon from '@mui/icons-material/Construction'
+import { Hammer } from 'lucide-react'
 
 export const getLayerLabels = (t: TFunction): Record<Layer, string> => ({
   emerald: t('common.emerald'),
@@ -18,5 +18,5 @@ export const getLayerLabels = (t: TFunction): Record<Layer, string> => ({
 export const getNetworkIcons = ({ className }: { className?: string } = {}): Record<Network, ReactNode> => ({
   mainnet: <MainnetIcon className={className} />,
   testnet: <TestnetIcon className={className} />,
-  localnet: <ConstructionIcon className={className} />,
+  localnet: <Hammer size={18} className={className} />,
 })


### PR DESCRIPTION
Small batch of icons for https://github.com/oasisprotocol/explorer/issues/2317


validator active/waiting/inactive chart circles
https://pr-2376.oasis-explorer.pages.dev/mainnet/consensus
vs https://explorer.dev.oasis.io/mainnet/consensus

secondary runtime chart button switcher (emerald/pontusX)
https://pr-2376.oasis-explorer.pages.dev/testnet/consensus
vs https://explorer.dev.oasis.io/testnet/consensus

consensus acc balance chart
https://pr-2376.oasis-explorer.pages.dev/mainnet/consensus/address/oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn
vs https://explorer.dev.oasis.io/mainnet/consensus/address/oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn

search icons at the bottom 
https://pr-2376.oasis-explorer.pages.dev/search?q=oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn
vs https://explorer.dev.oasis.io/search?q=oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn

missing validator icon
https://pr-2376.oasis-explorer.pages.dev/mainnet/consensus/validators/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm
vs https://explorer.dev.oasis.io/mainnet/consensus/validators/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm

nft instance details image (contrast/full screen)
https://pr-2376.oasis-explorer.pages.dev/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2
vs https://explorer.dev.oasis.io/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/instance/2

nft gallery thumbnails 
https://pr-2376.oasis-explorer.pages.dev/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/inventory#inventory
vs https://explorer.dev.oasis.io/mainnet/emerald/token/0x903d32d7307b4b3FC4bc9a510CA658C91A346A67/inventory#inventory

cancel icon - cannot provide all no live examples
advance view - events empty state icon
https://pr-2376.oasis-explorer.pages.dev/mainnet/consensus/tx/978e5a21e7727f99104c5ee06a3586da7a54a6f817163a7c9637f2f2368fa5cd
vs https://explorer.dev.oasis.io/mainnet/consensus/tx/978e5a21e7727f99104c5ee06a3586da7a54a6f817163a7c9637f2f2368fa5cd

empty staked card
https://pr-2376.oasis-explorer.pages.dev/mainnet/consensus/address/oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn
vs https://explorer.dev.oasis.io/mainnet/consensus/address/oasis1qzca4c3gch3ymy3w7e5ffzf9l6alpazpf5ffyytn

https://pr-2376.oasis-explorer.pages.dev/mainnet/sapphire/address/0xFBe030f83EC3646cdAEAaA476c02f4b370611a8c
vs https://explorer.dev.oasis.io/mainnet/sapphire/address/0xFBe030f83EC3646cdAEAaA476c02f4b370611a8c

no preview avail
https://pr-2376.oasis-explorer.pages.dev/mainnet/sapphire/token/0x998633BDF6eE32A9CcA6c9A247F428596e8e65d8/inventory#inventory
vs https://explorer.dev.oasis.io/mainnet/sapphire/token/0x998633BDF6eE32A9CcA6c9A247F428596e8e65d8/inventory#inventory

help icon 
https://pr-2376.oasis-explorer.pages.dev/mainnet/sapphire/tx/0xa9dd53e1d01b0b089aed72350825ff80a57a4b16a3c3a28cdeba2c0823f0e6b4
vs https://explorer.dev.oasis.io/mainnet/sapphire/tx/0xa9dd53e1d01b0b089aed72350825ff80a57a4b16a3c3a28cdeba2c0823f0e6b4

