### PR TITLE
Revert workaround adding empty revert message to transactions without it

### DIFF
--- a/.changelog/2407.trivial.md
+++ b/.changelog/2407.trivial.md
@@ -1,0 +1,1 @@
+Revert workaround adding empty revert message to transactions without it

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -3,13 +3,6 @@ import { TxError } from '../../oasis-nexus/api'
 
 export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
   const { t } = useTranslation()
-  if (!error) {
-    return undefined
-  }
-  if (error.module === 'evm' && error.code === 8 && !error.message && !error.raw_message) {
-    // EVM reverted, without any message
-    return `${t('errors.revertedWithoutMessage')} (${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module})`
-  }
-
+  if (!error) return undefined
   return `${error.message || error.raw_message} (${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module})`
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -287,7 +287,6 @@
     "invalidUrl": "This URL doesn't exist",
     "invalidVote": "Invalid vote",
     "alternativelyGoExplore": "Alternatively, discover our ecosystem by exploring Oasis.",
-    "revertedWithoutMessage": "reverted without a message",
     "storage": "Access to browser storage denied"
   },
   "footer": {


### PR DESCRIPTION
Reverts dd6fc7ad0116d7c7359c813c8db77efe5c4b7921

Fixes https://github.com/oasisprotocol/explorer/issues/1511