### PR TITLE
Parse raw tx error signatures and link to heuristic 4bytes decoding

### DIFF
--- a/.changelog/2409.bugfix.md
+++ b/.changelog/2409.bugfix.md
@@ -1,0 +1,1 @@
+Parse raw tx error signatures and link to heuristic 4bytes decoding

--- a/src/app/components/StatusIcon/index.tsx
+++ b/src/app/components/StatusIcon/index.tsx
@@ -7,6 +7,8 @@ import { useTxErrorMessage } from '../../hooks/useTxErrorMessage'
 import { TFunction } from 'i18next'
 import { cn } from '@oasisprotocol/ui-library/src/lib/utils'
 import { CircleCheck, CircleX, CircleHelp, Clock } from 'lucide-react'
+import { Link } from '@oasisprotocol/ui-library/src/components/link'
+import { AdvancedField } from '../AdvancedField/AdvancedField'
 
 type TxStatus = 'unknown' | 'success' | 'failure' | 'pending'
 
@@ -122,7 +124,7 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText, meth
     failure: t('common.failed'),
     pending: getPendingLabel(t, method, withText),
   }
-  const errorMessage = useTxErrorMessage(error)
+  const { errorMessage, decode4BytesErrorLink } = useTxErrorMessage(error)
   const iconSize = withText ? 16 : 20
 
   if (withText) {
@@ -138,7 +140,18 @@ export const StatusIcon: FC<StatusIconProps> = ({ success, error, withText, meth
           {statusLabel[status]}
           {statusIcon(status, iconSize, withText)}
         </div>
-        {errorMessage && <StatusDetails error>{errorMessage}</StatusDetails>}
+        {errorMessage && (
+          <>
+            <StatusDetails error>{errorMessage} </StatusDetails>
+            {decode4BytesErrorLink && (
+              <AdvancedField>
+                <Link href={decode4BytesErrorLink} rel="noopener noreferrer" target="_blank">
+                  {t('errors.attemptToDecode4Bytes')}
+                </Link>
+              </AdvancedField>
+            )}
+          </>
+        )}
         {!errorMessage && status === 'pending' && <StatusDetails>{getPendingLabel(t, method)}</StatusDetails>}
         {status === 'unknown' && <StatusDetails>{getUnknownLabel(t)}</StatusDetails>}
       </>

--- a/src/app/hooks/useTxErrorMessage.ts
+++ b/src/app/hooks/useTxErrorMessage.ts
@@ -1,8 +1,25 @@
 import { useTranslation } from 'react-i18next'
 import { TxError } from '../../oasis-nexus/api'
+import * as oasis from '@oasisprotocol/client'
+import * as oasisRT from '@oasisprotocol/client-rt'
+import * as externalLinks from '../utils/externalLinks'
 
-export const useTxErrorMessage = (error: TxError | undefined): string | undefined => {
+export const useTxErrorMessage = (error: TxError | undefined) => {
   const { t } = useTranslation()
-  if (!error) return undefined
-  return `${error.message || error.raw_message} (${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module})`
+  if (!error) return {}
+  if (
+    !error.message &&
+    error.module === 'evm' &&
+    error.code === oasisRT.evm.ERROR_REVERTED_CODE &&
+    error.raw_message?.startsWith('reverted: ')
+  ) {
+    const hexSignature = oasis.misc.toHex(oasis.misc.fromBase64(error.raw_message.replace('reverted: ', '')))
+    return {
+      errorMessage: `reverted: 0x${hexSignature} (${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module})`,
+      decode4BytesErrorLink: externalLinks.dapps.decode4bytes.replace('0xf92ee8a9', hexSignature),
+    }
+  }
+  return {
+    errorMessage: `${error.message || error.raw_message} (${t('errors.code')} ${error.code}, ${t('errors.module')}: ${error.module})`,
+  }
 }

--- a/src/app/utils/externalLinks.ts
+++ b/src/app/utils/externalLinks.ts
@@ -59,6 +59,7 @@ export const dapps = {
   stake: 'https://rose.oasis.io/stake',
   sourcifyRoot: 'https://sourcify.dev/',
   abiPlayground: 'https://abi-playground.oasis.io/',
+  decode4bytes: 'https://calldata.swiss-knife.xyz/decoder?calldata=0xf92ee8a9',
 }
 
 export const api = {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -263,6 +263,7 @@
     "value": "{{value, number}}"
   },
   "errors": {
+    "attemptToDecode4Bytes": "Attempt to decode",
     "code": "error code",
     "module": "module",
     "error": "Error",


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/explorer/issues/2300

https://pr-2409.oasis-explorer.pages.dev/testnet/sapphire/tx/0x412f1c59a6b93a137dfe901b7c5eb8c69a3a59797da14cf45e54053a5493a27f

<img width="1001" height="584" alt="Screenshot from 2026-01-06 23-21-54" src="https://github.com/user-attachments/assets/d3694c42-e474-4778-9a6c-b11105f89809" />
